### PR TITLE
Landing page, backend tests, WASM crypto, Windows CI, deploy config

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -28,8 +28,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
+
+      - name: Checkout submodules
+        env:
+          GLOSSIA_DEPLOY_KEY: ${{ secrets.GLOSSIA_DEPLOY_KEY }}
+        shell: bash
+        run: |
+          mkdir -p ~/.ssh
+          echo "$GLOSSIA_DEPLOY_KEY" > ~/.ssh/glossia_key
+          chmod 600 ~/.ssh/glossia_key
+          printf "Host github.com\n  IdentityFile ~/.ssh/glossia_key\n  StrictHostKeyChecking no\n" > ~/.ssh/config
+          git submodule update --init --recursive
+          rm -f ~/.ssh/glossia_key
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -12,6 +12,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Checkout submodules
+      env:
+        GLOSSIA_DEPLOY_KEY: ${{ secrets.GLOSSIA_DEPLOY_KEY }}
+      run: |
+        mkdir -p ~/.ssh
+        echo "$GLOSSIA_DEPLOY_KEY" > ~/.ssh/glossia_key
+        chmod 600 ~/.ssh/glossia_key
+        printf "Host github.com\n  IdentityFile ~/.ssh/glossia_key\n  StrictHostKeyChecking no\n" > ~/.ssh/config
+        git submodule update --init --recursive
+        rm -f ~/.ssh/glossia_key
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
## Summary

- **Landing page**: Standalone splash page served as site root (nostr-mail.com) with macOS DMG and Android APK download links, feature highlights, 5-step How It Works flow, and comparison table
- **Backend test suite**: 116 tests across database (54), email (30), nostr (15), state (13), and crypto (4) modules
- **WASM crypto crate**: `nostr-mail-crypto/` — all 11 crypto functions ported to WebAssembly via wasm-bindgen for browser-side encryption
- **Windows CI**: GitHub Actions workflow to build NSIS/MSI installers, auto-attaches to releases on tag push
- **Site deploy**: Landing page as root, MkDocs docs moved to `/docs/` subpath
- **CI auth**: Deploy key for private glossia submodule in both workflows
- **Glossia submodule**: Added glossia integration

## Test plan

- [x] Backend tests pass locally (`cargo test` — 116 tests)
- [ ] Verify landing page renders at nostr-mail.com after merge
- [ ] Verify docs accessible at nostr-mail.com/docs/
- [ ] Trigger Windows build workflow to confirm CI works
- [ ] Verify WASM crate builds with `wasm-pack build --target web`