### PR TITLE
Android CI fix + mobile layout polish

### DIFF
--- a/tauri-app/frontend/styles/responsive.css
+++ b/tauri-app/frontend/styles/responsive.css
@@ -192,6 +192,58 @@
     }
 }
 
+/* Narrow viewports: relay row's actions overflow when kept inline with the
+   URL. Stack info above actions, and let the actions wrap if even one row
+   isn't enough. */
+@media (max-width: 600px) {
+    .relay-item {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .relay-item-info {
+        margin-right: 0;
+        margin-bottom: 8px;
+    }
+
+    .relay-item-actions {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        gap: 12px;
+    }
+
+    /* Reclaim horizontal space: settings cards eat ~30px of outer padding on
+       each side at desktop sizes; trim it on narrow screens. */
+    .settings-form {
+        padding: var(--spacing-md) var(--spacing-sm);
+    }
+
+    .settings-section-content {
+        padding: var(--spacing-md);
+    }
+
+    /* Email list: drop the side padding so each card spans the full width.
+       Internal .email-item padding keeps text off the edge. */
+    .email-list {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    /* Same treatment for the conversation/thread + single-email detail
+       containers. Cards have their own internal padding. */
+    .thread-detail-content,
+    .email-detail-content {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .email-detail-header,
+    .thread-subject-header {
+        padding-left: var(--spacing-md);
+        padding-right: var(--spacing-md);
+    }
+}
+
 /* Mobile Landscape Mode - Keep bottom navigation */
 @media (max-width: 1024px) and (orientation: landscape) {
     .app-container {


### PR DESCRIPTION
## Summary
- Unbreak the Android CI build: `cargo tauri android build --apk=true` is no longer valid in tauri-cli 2.11.1 (the flag is now a boolean); switched to `--apk`.
- Wire up the `android` branch as a CI trigger and gate the desktop matrix off it, so future Android-only iteration doesn't burn 4 platforms of CI minutes per push.
- Mobile layout cleanup (CSS-only, all guarded behind `@media (max-width: 600px)`):
  - Relay rows stack `info` above `actions` and let the toggles wrap, so the DM-inbox / Active controls stop bleeding past the card on phone widths.
  - Settings cards shrink their outer/inner padding to reclaim screen width.
  - Email list, conversation/thread view, and single-email detail view drop their side padding so cards span the full width; the detail header/subject keep a modest gutter.

## Test plan
- [x] Android CI: `android` branch runs only the android job and produces `nostr-mail-android-apk` (verified on run 26364324632).
- [x] Installed the resulting APK on a physical device and confirmed:
  - Settings → Relays no longer clips the Active/DM-inbox controls.
  - Settings cards have noticeably less side gutter.
  - Inbox list, thread, and single-email detail cards go edge-to-edge.
- [ ] Smoke-test on a wider tablet/landscape viewport that the `max-width: 600px` queries don't kick in unintentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)