### PR TITLE
NIP-04: respect X-Nostr-Sig header as MAC fallback

### DIFF
--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -2558,6 +2558,7 @@ fn decrypt_armor_tree(
     private_key: &str,
     user_pubkey_hex: &str,
     fallback_pubkey: &str,
+    raw_headers: Option<&str>,
 ) -> (Vec<crate::types::DecryptedBlock>, Option<JsonManifest>) {
     let mut results = Vec::new();
     let mut outer_manifest = None;
@@ -2573,7 +2574,11 @@ fn decrypt_armor_tree(
         } else {
             fallback_pubkey
         };
-        let (inner_results, _) = decrypt_armor_tree(quoted, private_key, user_pubkey_hex, inner_fallback);
+        // raw_headers (X-Nostr-Sig) signs the outermost canonical body bytes, which
+        // includes nested quoted bytes by concatenation. Inner subtrees only see a
+        // slice of that signed data, so the header sig would never verify against
+        // them — pass None so inner levels rely solely on their inline signatures.
+        let (inner_results, _) = decrypt_armor_tree(quoted, private_key, user_pubkey_hex, inner_fallback, None);
         results.extend(inner_results);
     }
 
@@ -2582,75 +2587,110 @@ fn decrypt_armor_tree(
     // serves as the MAC. Verification MUST happen before decryption to prevent
     // padding oracle attacks.
     if parsed.encryption_nip.as_deref() == Some("nip04") {
-        match (&parsed.signature_hex, &parsed.sig_pubkey_hex) {
-            (Some(sig_hex), Some(pubkey_hex)) => {
-                // Collect body bytes for verification — use raw decoded bytes (no NIP-04
-                // unpacking) to match extract_ciphertext_binary, which the inline
-                // signature verification uses successfully.
-                let verify_bytes = if let Some(ref b64) = parsed.body_bytes_b64 {
-                    general_purpose::STANDARD.decode(b64).unwrap_or_else(|_| parsed.body_text.as_bytes().to_vec())
-                } else {
-                    extract_ciphertext_binary(&parsed.body_text)
-                };
-                let mut all_bytes = verify_bytes;
+        // Compute the canonical signed bytes once: this level's raw decoded body
+        // concatenated with all nested quoted body bytes. Both the inline
+        // SIGNATURE block and the X-Nostr-Sig header sign these same bytes.
+        let verify_bytes = if let Some(ref b64) = parsed.body_bytes_b64 {
+            general_purpose::STANDARD.decode(b64).unwrap_or_else(|_| parsed.body_text.as_bytes().to_vec())
+        } else {
+            extract_ciphertext_binary(&parsed.body_text)
+        };
+        let mut all_bytes = verify_bytes;
 
-                // Concatenate nested quoted body bytes
-                fn collect_quoted_bytes(
-                    quoted: &Option<Box<crate::types::ParsedArmorMessage>>,
-                    buf: &mut Vec<u8>,
-                ) {
-                    if let Some(ref q) = quoted {
-                        if let Some(ref b64) = q.body_bytes_b64 {
-                            if let Ok(bytes) = general_purpose::STANDARD.decode(b64) {
-                                buf.extend_from_slice(&bytes);
-                            }
-                        }
-                        collect_quoted_bytes(&q.quoted, buf);
+        fn collect_quoted_bytes(
+            quoted: &Option<Box<crate::types::ParsedArmorMessage>>,
+            buf: &mut Vec<u8>,
+        ) {
+            if let Some(ref q) = quoted {
+                if let Some(ref b64) = q.body_bytes_b64 {
+                    if let Ok(bytes) = general_purpose::STANDARD.decode(b64) {
+                        buf.extend_from_slice(&bytes);
                     }
                 }
-                collect_quoted_bytes(&parsed.quoted, &mut all_bytes);
+                collect_quoted_bytes(&q.quoted, buf);
+            }
+        }
+        collect_quoted_bytes(&parsed.quoted, &mut all_bytes);
 
-                // Step 7: Verify signature against unpacked canonical bytes
-                let verified = matches!(
+        // Primary trust path: inline SIGNATURE block inside the armor.
+        let inline_verified = match (&parsed.signature_hex, &parsed.sig_pubkey_hex) {
+            (Some(sig_hex), Some(pubkey_hex)) => {
+                let ok = matches!(
                     crate::crypto::verify_signature_bytes(pubkey_hex, sig_hex, &all_bytes),
                     Ok(true)
                 );
-
-                if verified {
-                    println!("[RUST] NIP-04 signature verified ({} bytes), proceeding to decrypt", all_bytes.len());
+                if ok {
+                    println!("[RUST] NIP-04 inline signature verified ({} bytes)", all_bytes.len());
                 } else {
-                    println!("[RUST] NIP-04 signature INVALID — rejecting without decryption");
-                    results.push(crate::types::DecryptedBlock {
-                        decrypted_text: None,
-                        error: Some(
-                            "NIP-04 signature verification failed. The message was rejected \
-                             without decrypting to prevent potential ciphertext manipulation. \
-                             The message may have been tampered with in transit.".to_string()
-                        ),
-                        was_encrypted: true,
-                        profile_name: parsed.profile_name.clone().or(parsed.display_name.clone()),
-                        body_type: "encrypted".to_string(),
-                    });
-                    return (results, outer_manifest);
+                    println!("[RUST] NIP-04 inline signature INVALID");
                 }
+                Some(ok)
             }
-            _ => {
-                // No signature on NIP-04 message — reject
-                println!("[RUST] NIP-04 message has no signature — rejecting without decryption");
-                results.push(crate::types::DecryptedBlock {
-                    decrypted_text: None,
-                    error: Some(
-                        "This NIP-04 encrypted message has no signature. NIP-04 requires a \
-                         signature for authentication because it lacks built-in message \
-                         integrity (MAC). The message cannot be safely decrypted. The sender \
-                         may be using an older client that doesn't sign NIP-04 messages.".to_string()
-                    ),
-                    was_encrypted: true,
-                    profile_name: parsed.profile_name.clone().or(parsed.display_name.clone()),
-                    body_type: "encrypted".to_string(),
-                });
-                return (results, outer_manifest);
-            }
+            _ => None,
+        };
+
+        // Fallback trust path: X-Nostr-Sig + X-Nostr-Pubkey transport headers.
+        // Only consulted at the outermost armor level (raw_headers is None for
+        // recursive calls into nested quoted blocks), because the header sig
+        // signs the full canonical body, not inner subtrees.
+        let header_verified = if inline_verified != Some(true) {
+            raw_headers.and_then(|rh| {
+                let pk = extract_nostr_pubkey_from_headers(rh)?;
+                let sig = extract_nostr_sig_from_headers(rh)?;
+                let ok = matches!(
+                    crate::crypto::verify_signature_bytes(&pk, &sig, &all_bytes),
+                    Ok(true)
+                );
+                if ok {
+                    println!("[RUST] NIP-04 X-Nostr-Sig header verified ({} bytes)", all_bytes.len());
+                } else {
+                    println!("[RUST] NIP-04 X-Nostr-Sig header INVALID");
+                }
+                Some(ok)
+            })
+        } else {
+            None
+        };
+
+        let verified = inline_verified == Some(true) || header_verified == Some(true);
+        if !verified {
+            let (msg, log) = match (inline_verified, header_verified) {
+                (Some(false), Some(false)) => (
+                    "NIP-04 signature verification failed (both inline SIGNATURE block and \
+                     X-Nostr-Sig header). The message was rejected without decrypting to \
+                     prevent potential ciphertext manipulation.".to_string(),
+                    "NIP-04 both inline + header sigs INVALID — rejecting"
+                ),
+                (Some(false), None) => (
+                    "NIP-04 signature verification failed. The message was rejected without \
+                     decrypting to prevent potential ciphertext manipulation. The message may \
+                     have been tampered with in transit.".to_string(),
+                    "NIP-04 inline signature INVALID, no header sig — rejecting"
+                ),
+                (None, Some(false)) => (
+                    "NIP-04 X-Nostr-Sig header verification failed. No inline SIGNATURE block \
+                     was present, and the transport-header signature did not verify. The \
+                     message was rejected without decrypting.".to_string(),
+                    "NIP-04 header sig INVALID, no inline sig — rejecting"
+                ),
+                _ => (
+                    "This NIP-04 encrypted message has no signature (neither an inline \
+                     SIGNATURE block nor an X-Nostr-Sig header). NIP-04 requires a signature \
+                     for authentication because it lacks built-in message integrity (MAC). \
+                     To opt into decrypting unsigned messages anyway, disable \"Require \
+                     Signatures\" in Settings → Advanced.".to_string(),
+                    "NIP-04 message has no signature (inline or header) — rejecting"
+                ),
+            };
+            println!("[RUST] {}", log);
+            results.push(crate::types::DecryptedBlock {
+                decrypted_text: None,
+                error: Some(msg),
+                was_encrypted: true,
+                profile_name: parsed.profile_name.clone().or(parsed.display_name.clone()),
+                body_type: "encrypted".to_string(),
+            });
+            return (results, outer_manifest);
         }
     }
 
@@ -2682,6 +2722,7 @@ pub fn decrypt_email_body_pipeline(
     subject: &str,
     sender_pubkey: Option<&str>,
     recipient_pubkey: Option<&str>,
+    raw_headers: Option<&str>,
 ) -> Result<crate::types::DecryptEmailResult, String> {
     println!("[RUST] decrypt_email_body: armor_len={} subject_len={}", armor_text.len(), subject.len());
 
@@ -2721,7 +2762,7 @@ pub fn decrypt_email_body_pipeline(
         .unwrap_or("");
 
     // Walk the armor tree, decrypt each level
-    let (block_results, manifest) = decrypt_armor_tree(&parsed, private_key, &user_pubkey_hex, fallback);
+    let (block_results, manifest) = decrypt_armor_tree(&parsed, private_key, &user_pubkey_hex, fallback, raw_headers);
 
     // Extract outermost decrypted body (last element in innermost-first array)
     let outer_block = block_results.last();

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -4154,15 +4154,25 @@ fn decrypt_email_body(
     subject: String,
     sender_pubkey: Option<String>,
     recipient_pubkey: Option<String>,
+    message_id: Option<String>,
     state: tauri::State<AppState>,
 ) -> Result<types::DecryptEmailResult, String> {
     let pk = resolve_private_key(private_key, &state)?;
+    // Look up raw_headers from DB by message_id so the pipeline can fall back to
+    // the X-Nostr-Sig header for NIP-04 signature verification when the inline
+    // SIGNATURE block is missing.
+    let raw_headers = message_id.as_deref().and_then(|mid| {
+        state.get_database().ok()
+            .and_then(|db| db.get_email(mid).ok().flatten())
+            .and_then(|e| e.raw_headers)
+    });
     email::decrypt_email_body_pipeline(
         &pk,
         &armor_text,
         &subject,
         sender_pubkey.as_deref(),
         recipient_pubkey.as_deref(),
+        raw_headers.as_deref(),
     )
 }
 
@@ -4173,16 +4183,25 @@ fn decrypt_email_bodies_batch(
     state: tauri::State<AppState>,
 ) -> Result<Vec<types::BatchDecryptResultItem>, String> {
     let pk = resolve_private_key(private_key, &state)?;
+    // Open DB once for the whole batch so each item can look up its raw_headers
+    // by message_id for NIP-04 header-sig fallback verification.
+    let db_opt = state.get_database().ok();
     let results = emails
         .into_iter()
         .map(|e| {
             let id = e.id.clone();
+            let raw_headers = e.message_id.as_deref().and_then(|mid| {
+                db_opt.as_ref()
+                    .and_then(|db| db.get_email(mid).ok().flatten())
+                    .and_then(|row| row.raw_headers)
+            });
             match email::decrypt_email_body_pipeline(
                 &pk,
                 &e.armor_text,
                 &e.subject,
                 e.sender_pubkey.as_deref(),
                 e.recipient_pubkey.as_deref(),
+                raw_headers.as_deref(),
             ) {
                 Ok(result) => types::BatchDecryptResultItem {
                     id,
@@ -6582,7 +6601,7 @@ fn db_get_matching_email_body(dm_event_id: String, private_key: Option<String>, 
     for pubkey in &pubkeys_to_try {
         let sender_pk = if user_received_email { Some(pubkey.as_str()) } else { None };
         let recipient_pk = if user_sent_email { Some(pubkey.as_str()) } else { Some(pubkey.as_str()) };
-        match email::decrypt_email_body_pipeline(&private_key, &email.body, &email.subject, sender_pk, recipient_pk) {
+        match email::decrypt_email_body_pipeline(&private_key, &email.body, &email.subject, sender_pk, recipient_pk, email.raw_headers.as_deref()) {
             Ok(result) if result.success => {
                 println!("[RUST] decrypt_email_body_pipeline succeeded with pubkey: {}", pubkey);
                 return Ok(Some(types::MatchingEmailBodyResult {

--- a/tauri-app/backend/src/types.rs
+++ b/tauri-app/backend/src/types.rs
@@ -363,6 +363,9 @@ pub struct BatchDecryptInput {
     pub subject: String,
     pub sender_pubkey: Option<String>,
     pub recipient_pubkey: Option<String>,
+    /// Message-Id of the email row in the local DB, used to look up
+    /// raw_headers for header-based signature verification fallback (NIP-04).
+    pub message_id: Option<String>,
 }
 
 /// Per-item result from batch email decryption (wraps success or error).

--- a/tauri-app/backend/tests/email_integration.rs
+++ b/tauri-app/backend/tests/email_integration.rs
@@ -525,6 +525,114 @@ async fn nip04_legacy_decrypt() {
     assert_eq!(decrypted, plaintext);
 }
 
+/// Unsigned NIP-04 armor (no inline SIGNATURE block) sent with an X-Nostr-Sig
+/// transport header. decrypt_email_body_pipeline MUST reject when raw_headers
+/// is None (per NIP-04 MAC requirement) and MUST decrypt when raw_headers are
+/// supplied, by treating X-Nostr-Sig as the authentication MAC.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nip04_header_sig_fallback_unlocks_decrypt() {
+    let mock = spawn_mock_email().await;
+    let (alice_nsec, alice_npub, _) = test_keypair(1);
+    let (bob_nsec, bob_npub, _) = test_keypair(2);
+
+    let alice_config = email_config(
+        "alice@test.local",
+        "password-alice",
+        &alice_nsec,
+        mock.smtp_addr,
+        mock.imap_addr,
+    );
+
+    let plaintext = "Header-sig fallback should let me through.";
+    let ciphertext = crypto::encrypt_message(&alice_nsec, &bob_npub, plaintext, Some("nip04"))
+        .expect("nip04 encrypt");
+
+    // No inline SIGNATURE block — only the encrypted body armor.
+    let armored_body = format!(
+        "-----BEGIN NOSTR NIP-04 ENCRYPTED BODY-----\n{}\n-----END NOSTR MESSAGE-----",
+        ciphertext
+    );
+
+    email::send_email(
+        &alice_config,
+        "bob@test.local",
+        "nip04 header sig fallback",
+        &armored_body,
+        Some(&alice_npub),
+        None,
+        None,
+        None,
+        None,
+        None,
+        true, // include X-Nostr-Pubkey
+        true, // include X-Nostr-Sig
+        Some(&bob_npub),
+        true,
+    )
+    .await
+    .expect("send_email");
+
+    let inbox = mock.store.get_mailbox_emails("INBOX").await;
+    let delivered = &inbox[0];
+    let raw_headers = raw_headers_from_store(delivered);
+
+    // Sanity: the message we're testing really has X-Nostr-Sig but no inline sig.
+    assert!(
+        email::extract_nostr_sig_from_headers(&raw_headers).is_some(),
+        "precondition: X-Nostr-Sig must be present"
+    );
+    assert!(
+        !delivered.body.contains("BEGIN NOSTR SIGNATURE"),
+        "precondition: armor must NOT contain inline SIGNATURE block"
+    );
+
+    // Without raw_headers: pipeline rejects with the unsigned-message error.
+    let without_headers = email::decrypt_email_body_pipeline(
+        &bob_nsec,
+        &delivered.body,
+        &delivered.subject,
+        Some(&alice_npub),
+        Some(&bob_npub),
+        None,
+    )
+    .expect("pipeline returns Ok even on signature rejection");
+    assert!(
+        !without_headers.success,
+        "must reject unsigned NIP-04 when no header sig is available"
+    );
+    let err = without_headers
+        .block_results
+        .last()
+        .and_then(|b| b.error.clone())
+        .unwrap_or_default();
+    assert!(
+        err.contains("no signature") || err.contains("Require Signatures"),
+        "rejection error should explain the cause, got: {}",
+        err
+    );
+
+    // With raw_headers: header sig verifies, body decrypts to plaintext.
+    let with_headers = email::decrypt_email_body_pipeline(
+        &bob_nsec,
+        &delivered.body,
+        &delivered.subject,
+        Some(&alice_npub),
+        Some(&bob_npub),
+        Some(&raw_headers),
+    )
+    .expect("pipeline returns Ok when header sig verifies");
+    assert!(
+        with_headers.success,
+        "header sig fallback must unlock decrypt, error={:?}",
+        with_headers.error
+    );
+    assert_eq!(
+        with_headers.body.trim(),
+        plaintext,
+        "decrypted plaintext must round-trip"
+    );
+}
+
 /// Multipart text+html lettre → mailparse round-trip. The encrypted ENCRYPTED
 /// BODY armor lives in the text/plain part; the html part is a separate MIME
 /// section. Confirms both reach the receive side intact.
@@ -835,6 +943,7 @@ async fn sent_mail_decrypts_via_recipient_header_without_dm() {
         &delivered.subject,
         None,
         Some(&recipient_from_header),
+        None,
     )
     .expect("decrypt_email_body_pipeline");
 
@@ -922,6 +1031,7 @@ async fn sent_mail_undecryptable_without_any_counterparty_hint() {
         &alice_nsec,
         &delivered.body,
         &delivered.subject,
+        None,
         None,
         None,
     )
@@ -2114,6 +2224,7 @@ async fn nip44_reply_preserves_nested_encrypted_armor() {
         &reply.subject,
         Some(&bob_npub),
         Some(&alice_npub),
+        None,
     )
     .expect("decrypt_email_body_pipeline");
     assert!(decrypt.success, "decrypt must succeed: {:?}", decrypt.error);
@@ -2332,6 +2443,7 @@ async fn nip44_three_level_reply_chain() {
         &delivered.subject,
         Some(&alice_npub),
         Some(&bob_npub),
+        None,
     )
     .expect("decrypt pipeline");
     assert!(decrypt.success, "decrypt failed: {:?}", decrypt.error);

--- a/tauri-app/frontend/js/dm-service.js
+++ b/tauri-app/frontend/js/dm-service.js
@@ -2201,7 +2201,8 @@ class DMService {
                 const recipientPubkey = email.recipient_pubkey;
                 const decryptResult = await TauriService.decryptEmailBody(
                     email.body, email.subject || '',
-                    senderPubkey, recipientPubkey
+                    senderPubkey, recipientPubkey,
+                    email.message_id || null
                 );
 
                 if (!decryptResult.isManifest || !decryptResult.attachments || decryptResult.attachments.length === 0) {

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -3111,6 +3111,7 @@ class EmailService {
                                 subject: email.subject,
                                 senderPubkey: null,
                                 recipientPubkey,
+                                messageId: email.message_id || null,
                             };
                         }
                         return {
@@ -3119,6 +3120,7 @@ class EmailService {
                             subject: email.subject,
                             senderPubkey: email.sender_pubkey || email.nostr_pubkey || null,
                             recipientPubkey: null,
+                            messageId: email.message_id || null,
                         };
                     });
                     console.log(`[JS] Batch decrypting ${batchInput.length} inbox emails in one IPC call`);
@@ -3184,7 +3186,7 @@ class EmailService {
                                 const senderPubkey = isSent ? null : (email.sender_pubkey || email.nostr_pubkey || null);
                                 const recipientPubkey = isSent ? (email.recipient_pubkey || null) : null;
                                 const retry = await TauriService.decryptEmailBody(
-                                    email.body, email.subject, senderPubkey, recipientPubkey
+                                    email.body, email.subject, senderPubkey, recipientPubkey, email.message_id || null
                                 );
                                 if (retry && retry.success) {
                                     let previewText = Utils.escapeHtml(retry.body.substring(0, 100));
@@ -3335,7 +3337,8 @@ class EmailService {
                         }
                         const result = await TauriService.decryptEmailBody(
                             email.body, email.subject,
-                            senderPubkey, recipientPubkey
+                            senderPubkey, recipientPubkey,
+                            email.message_id || null
                         );
                         if (result.success) {
                             previewSubject = result.subject;
@@ -3797,7 +3800,7 @@ class EmailService {
                             // Run decryption and signature verification in parallel (they're independent)
                             console.log('[JS] Calling backend decrypt_email_body + verifyAllSignatures in parallel...');
                             const [result, allSigs] = await Promise.all([
-                                TauriService.decryptEmailBody(emailBody, email.subject, senderPubkey, null),
+                                TauriService.decryptEmailBody(emailBody, email.subject, senderPubkey, null, email.message_id || null),
                                 TauriService.verifyAllSignatures(emailBody).catch(e => {
                                     console.warn('[JS] Signature verification error:', e);
                                     return [];
@@ -3924,7 +3927,7 @@ class EmailService {
                                         const senderPubkey = email.sender_pubkey || email.nostr_pubkey;
                                         const decryptResult = await TauriService.decryptEmailBody(
                                             email.body, email.subject || '',
-                                            senderPubkey, null
+                                            senderPubkey, null, email.message_id || null
                                         );
                                         if (decryptResult.isManifest && decryptResult.attachments && decryptResult.attachments.length > 0) {
                                             manifestResult = {
@@ -4583,7 +4586,7 @@ ${attachmentsHtml}
 
                         try {
                             const [result, allSigs] = await Promise.all([
-                                TauriService.decryptEmailBody(emailBody, email.subject, senderPubkey, recipientPubkey),
+                                TauriService.decryptEmailBody(emailBody, email.subject, senderPubkey, recipientPubkey, email.message_id || null),
                                 TauriService.verifyAllSignatures(emailBody).catch(e => {
                                     console.warn('[JS] Thread sig verify error:', e);
                                     return [];
@@ -6591,6 +6594,7 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                             subject: email.subject,
                             senderPubkey: null,
                             recipientPubkey,
+                            messageId: email.message_id || null,
                         };
                     });
                     console.log(`[JS] Batch decrypting ${batchInput.length} sent emails in one IPC call`);
@@ -6642,7 +6646,7 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                                 const changed = await retrofitPromise;
                                 if (!changed || !email.recipient_pubkey) return;
                                 const retry = await TauriService.decryptEmailBody(
-                                    email.body, email.subject, null, email.recipient_pubkey
+                                    email.body, email.subject, null, email.recipient_pubkey, email.message_id || null
                                 );
                                 if (retry && retry.success) {
                                     let previewText = Utils.escapeHtml(retry.body.substring(0, 100));
@@ -6771,7 +6775,8 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                         try {
                             const result = await TauriService.decryptEmailBody(
                                 email.body, email.subject,
-                                null, recipientPubkey
+                                null, recipientPubkey,
+                                email.message_id || null
                             );
                             if (result.success) {
                                 previewSubject = result.subject;
@@ -7387,7 +7392,8 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                                 const recipientPubkey = email.recipient_pubkey || email.nostr_pubkey;
                                 const decryptResult = await TauriService.decryptEmailBody(
                                     email.body, email.subject || '',
-                                    null, recipientPubkey
+                                    null, recipientPubkey,
+                                    email.message_id || null
                                 );
                                 if (decryptResult.isManifest && decryptResult.attachments && decryptResult.attachments.length > 0) {
                                     manifestResult = {
@@ -7796,7 +7802,7 @@ ${attachmentsHtml}
                         // Run decryption and signature verification in parallel (they're independent)
                         console.log('[JS] Calling backend decrypt_email_body + verifyAllSignatures for sent email in parallel...');
                         const [result, allSigs] = await Promise.all([
-                            TauriService.decryptEmailBody(email.body, email.subject, null, recipientPubkey),
+                            TauriService.decryptEmailBody(email.body, email.subject, null, recipientPubkey, email.message_id || null),
                             TauriService.verifyAllSignatures(email.body).catch(e => {
                                 console.warn('[JS] Signature verification error:', e);
                                 return [];
@@ -7942,7 +7948,8 @@ ${attachmentsHtml}
 
             const result = await TauriService.decryptEmailBody(
                 email.body, email.subject || '',
-                null, recipientPubkey
+                null, recipientPubkey,
+                email.message_id || null
             );
 
             // Retrofit happens whether or not the body decrypted — the subject
@@ -8075,7 +8082,8 @@ ${attachmentsHtml}
                 console.log('[JS] Using backend decrypt_email_body to extract manifest for sent attachment...');
                 const decryptResult = await TauriService.decryptEmailBody(
                     email.body, email.subject || '',
-                    null, recipientPubkey
+                    null, recipientPubkey,
+                    email.message_id || null
                 );
 
                 if (!decryptResult.isManifest || !decryptResult.attachments || decryptResult.attachments.length === 0) {
@@ -8171,7 +8179,8 @@ ${attachmentsHtml}
                 const recipientPubkey = email.recipient_pubkey || email.nostr_pubkey;
                 const decryptResult = await TauriService.decryptEmailBody(
                     email.body, email.subject || '',
-                    null, recipientPubkey
+                    null, recipientPubkey,
+                    email.message_id || null
                 );
 
                 if (!decryptResult.isManifest || !decryptResult.attachments || decryptResult.attachments.length === 0) {
@@ -8317,7 +8326,8 @@ ${attachmentsHtml}
                 console.log('[JS] Using backend decrypt_email_body to extract manifest for attachment...');
                 const decryptResult = await TauriService.decryptEmailBody(
                     email.body, email.subject || '',
-                    senderPubkey, null
+                    senderPubkey, null,
+                    email.message_id || null
                 );
 
                 if (!decryptResult.isManifest || !decryptResult.attachments || decryptResult.attachments.length === 0) {
@@ -8416,7 +8426,8 @@ ${attachmentsHtml}
                 console.log('[JS] Using backend decrypt_email_body to extract manifest for ZIP...');
                 const decryptResult = await TauriService.decryptEmailBody(
                     email.body, email.subject || '',
-                    senderPubkey, null
+                    senderPubkey, null,
+                    email.message_id || null
                 );
 
                 if (!decryptResult.isManifest || !decryptResult.attachments || decryptResult.attachments.length === 0) {
@@ -8771,7 +8782,8 @@ ${attachmentsHtml}
                     const recipientPubkey = draft.recipient_pubkey || draft.nostr_pubkey || draft.sender_pubkey;
                     const result = await TauriService.decryptEmailBody(
                         draft.body, draft.subject || '',
-                        recipientPubkey, null
+                        recipientPubkey, null,
+                        draft.message_id || null
                     );
                     if (result.success) {
                         previewSubject = result.subject || draft.subject;
@@ -9196,7 +9208,8 @@ ${attachmentsHtml}
                             const recipientPubkey = draftRecipientPubkey;
                             const result = await TauriService.decryptEmailBody(
                                 draft.body, draft.subject || '',
-                                recipientPubkey, null
+                                recipientPubkey, null,
+                                draft.message_id || null
                             );
                             if (result.success) {
                                 decryptedSubject = result.subject || draft.subject;

--- a/tauri-app/frontend/js/tauri-service.js
+++ b/tauri-app/frontend/js/tauri-service.js
@@ -629,16 +629,17 @@ const TauriService = {
         return await this.invoke('parse_armor_message', { armorText });
     },
 
-    decryptEmailBody: async function(armorText, subject, senderPubkey, recipientPubkey) {
+    decryptEmailBody: async function(armorText, subject, senderPubkey, recipientPubkey, messageId) {
         return await this.invoke('decrypt_email_body', {
             armorText, subject,
             senderPubkey: senderPubkey || null,
             recipientPubkey: recipientPubkey || null,
+            messageId: messageId || null,
         });
     },
 
     // Batch decrypt multiple email bodies in a single IPC call.
-    // `emails` is an array of { id, armorText, subject, senderPubkey, recipientPubkey }.
+    // `emails` is an array of { id, armorText, subject, senderPubkey, recipientPubkey, messageId? }.
     // Returns an array of { id, result, error } in the same order.
     decryptEmailBodiesBatch: async function(emails) {
         return await this.invoke('decrypt_email_bodies_batch', { emails });


### PR DESCRIPTION
## Summary
- NIP-04 decrypt path now falls back to the `X-Nostr-Sig` + `X-Nostr-Pubkey` transport headers when the inline `BEGIN NOSTR SIGNATURE` block is absent, instead of unconditionally rejecting the message.
- Threads `raw_headers` through `decrypt_email_body_pipeline` / `decrypt_armor_tree`. Tauri commands look it up from the local DB by `messageId` so callers only need to pass an id.
- Header-sig fallback only applies at the outermost armor level — the transport sig signs the full canonical body, not nested subtrees, so inner recursive calls still rely solely on inline sigs.
- Improved rejection error message: when neither inline nor header sig is present, the error explicitly points users at the **Require Signatures** toggle in Settings → Advanced.

## Why
A user reported "This NIP-04 encrypted message has no signature" on an email that *did* carry `X-Nostr-Sig`. The backend's mandatory NIP-04 verification at `email.rs:2584` only consulted the inline armor signature, even though the frontend's `verify_email_signature_full` already accepts the header as an equally-valid trust path.

## Test plan
- [x] New integration test `nip04_header_sig_fallback_unlocks_decrypt` — proves the pipeline rejects unsigned NIP-04 when `raw_headers=None` and decrypts to plaintext when the headers are passed in.
- [x] All 19 existing integration tests pass (`cargo test --test email_integration`).
- [x] All 178 library unit tests pass (`cargo test --lib`).
- [ ] Manually open the reporter's affected thread and confirm the body decrypts.
- [ ] Toggle `require_signature=false` and confirm truly-unsigned NIP-04 messages still surface the new settings-aware error rather than silently decrypting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)