### PR TITLE
Email rendering perf: progressive UI + cached decrypt pipeline

### DIFF
--- a/tauri-app/backend/src/database.rs
+++ b/tauri-app/backend/src/database.rs
@@ -1788,7 +1788,7 @@ impl Database {
     /// Get inbox emails grouped by thread. Returns one row per thread (the most recent email)
     /// plus message_count and unread_count for that thread.
     /// Counts ALL emails in a thread (including sent replies) so threads span inbox/sent.
-    pub fn get_email_threads(&self, limit: Option<i64>, offset: Option<i64>, nostr_only: Option<bool>, user_email: Option<&str>, user_pubkey: Option<&str>) -> Result<Vec<(Email, i64, i64)>> {
+    pub fn get_email_threads(&self, limit: Option<i64>, offset: Option<i64>, nostr_only: Option<bool>, user_email: Option<&str>, user_pubkey: Option<&str>) -> Result<Vec<(Email, i64, i64, i64)>> {
         let conn = self.conn.lock().unwrap();
         let limit = limit.unwrap_or(50);
         let offset = offset.unwrap_or(0);
@@ -1864,7 +1864,8 @@ impl Database {
                    received_at, is_nostr_encrypted, sender_pubkey, recipient_pubkey, raw_headers,
                    is_draft, is_read, updated_at, created_at, signature_valid, signature_source,
                    transport_auth_verified, in_reply_to, references_, thread_id,
-                   message_count, unread_count
+                   message_count, unread_count,
+                   (SELECT COUNT(*) FROM attachments WHERE email_id = ranked.id) AS attachment_count
             FROM ranked WHERE rn = 1
             ORDER BY thread_last_activity DESC
             LIMIT ? OFFSET ?",
@@ -1911,14 +1912,15 @@ impl Database {
             };
             let message_count: i64 = row.get(23)?;
             let unread_count: i64 = row.get(24)?;
-            Ok((email, message_count, unread_count))
+            let attachment_count: i64 = row.get(25)?;
+            Ok((email, message_count, unread_count, attachment_count))
         })?;
         rows.collect()
     }
 
     /// Get sent emails grouped by thread.
     /// Counts ALL emails in a thread (including received messages) so threads span inbox/sent.
-    pub fn get_sent_email_threads(&self, limit: Option<i64>, offset: Option<i64>, user_email: Option<&str>) -> Result<Vec<(Email, i64, i64)>> {
+    pub fn get_sent_email_threads(&self, limit: Option<i64>, offset: Option<i64>, user_email: Option<&str>) -> Result<Vec<(Email, i64, i64, i64)>> {
         let conn = self.conn.lock().unwrap();
         let limit = limit.unwrap_or(50);
         let offset = offset.unwrap_or(0);
@@ -1984,7 +1986,8 @@ impl Database {
                    received_at, is_nostr_encrypted, sender_pubkey, recipient_pubkey, raw_headers,
                    is_draft, is_read, updated_at, created_at, signature_valid, signature_source,
                    transport_auth_verified, in_reply_to, references_, thread_id,
-                   message_count, unread_count
+                   message_count, unread_count,
+                   (SELECT COUNT(*) FROM attachments WHERE email_id = ranked.id) AS attachment_count
             FROM ranked WHERE rn = 1
             ORDER BY received_at DESC
             LIMIT ? OFFSET ?",
@@ -2023,7 +2026,8 @@ impl Database {
             };
             let message_count: i64 = row.get(23)?;
             let unread_count: i64 = row.get(24)?;
-            Ok((email, message_count, unread_count))
+            let attachment_count: i64 = row.get(25)?;
+            Ok((email, message_count, unread_count, attachment_count))
         })?;
         rows.collect()
     }

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -1368,36 +1368,12 @@ fn try_decode_raw_base_n_fixed(text: &str, expected_bytes: usize) -> Option<Vec<
 /// Uses catch_unwind because glossia's codec can panic on malformed input
 /// (e.g. partial wordlist matches with bad padding).
 fn try_glossia_decode_to_bytes(text: &str) -> Option<Vec<u8>> {
-    let words: Vec<String> = text.split_whitespace().map(|w| w.to_lowercase()).collect();
-    if words.is_empty() {
-        return None;
-    }
-    let best = glossia::detect_dialect_best(&words)?;
-    if best.hit_rate < 0.3 {
-        return None;
-    }
-    let text_owned = text.to_string();
-    let language = best.language.clone();
-    let wordlist = best.wordlist.clone();
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        glossia::decode_from_language(&text_owned, &language, &wordlist, false)
-    }));
-    let decoded = match result {
-        Ok(Ok(d)) => d,
-        Ok(Err(e)) => {
-            println!("[RUST] try_glossia_decode_to_bytes: decode error: {:?}", e);
-            return None;
-        }
-        Err(_) => {
-            println!("[RUST] try_glossia_decode_to_bytes: glossia panicked during decode, skipping");
-            return None;
-        }
-    };
+    let cached = glossia_detect_and_decode_cached(text)?;
     // decode_from_language returns hex when bytes aren't valid UTF-8 (i.e. binary ciphertext)
-    if let Some(bytes) = glossia::hex_decode(&decoded) {
+    if let Some(bytes) = glossia::hex_decode(&cached.decoded) {
         Some(bytes)
     } else {
-        Some(decoded.into_bytes())
+        Some(cached.decoded.clone().into_bytes())
     }
 }
 
@@ -2107,6 +2083,81 @@ fn is_base64_content(content: &str) -> bool {
 /// prose was encoded with, then decodes once with that pair. Mirrors the
 /// subject path (`glossia_decode_subject`) and `try_glossia_decode_to_bytes`.
 /// The `nip_hint` is "nip04" or "nip44" from the armor BEGIN tag.
+/// Result of glossia detect + decode for a piece of armored body text.
+/// Cached process-wide by hash of the input so repeated decodes of the
+/// same text (across nesting levels, sender_extract, sig verification,
+/// thread reopen, etc.) skip both `detect_dialect_best` and
+/// `decode_from_language`.
+#[derive(Clone, Debug)]
+struct GlossiaDecodeCached {
+    language: String,
+    wordlist: String,
+    /// Output of `glossia::decode_from_language` — either UTF-8 text or
+    /// hex of the underlying bytes when the bytes weren't valid UTF-8.
+    decoded: String,
+    hit_rate: f64,
+}
+
+static GLOSSIA_DECODE_CACHE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<u64, GlossiaDecodeCached>>>
+    = std::sync::OnceLock::new();
+
+fn hash_glossia_input(text: &str) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    text.hash(&mut h);
+    h.finish()
+}
+
+/// Cached `detect_dialect_best` + `decode_from_language`. Pure function of the
+/// input text — the same prose always produces the same dialect + decoded
+/// output, so a process-wide cache is safe. Returns None for plaintext or
+/// non-glossia input (low hit rate / detection failure).
+fn glossia_detect_and_decode_cached(text: &str) -> Option<GlossiaDecodeCached> {
+    let key = hash_glossia_input(text);
+    let cache = GLOSSIA_DECODE_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+    if let Some(entry) = cache.lock().unwrap().get(&key) {
+        println!("[RUST-PERF] glossia cache HIT key={:x} (in={}b, dialect={}/{}, out={}b)",
+            key, text.len(), entry.language, entry.wordlist, entry.decoded.len());
+        return Some(entry.clone());
+    }
+
+    let perf = std::time::Instant::now();
+    let words: Vec<String> = text.split_whitespace().map(|w| w.to_lowercase()).collect();
+    if words.is_empty() {
+        return None;
+    }
+    let detect_words = words.clone();
+    let best = match std::panic::catch_unwind(move || glossia::detect_dialect_best(&detect_words)) {
+        Ok(Some(b)) => b,
+        _ => return None,
+    };
+    if best.hit_rate < 0.3 {
+        return None;
+    }
+    let language = best.language.clone();
+    let wordlist = best.wordlist.clone();
+    let text_owned = text.to_string();
+    let decoded = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        glossia::decode_from_language(&text_owned, &language, &wordlist, false)
+    })) {
+        Ok(Ok(d)) => d,
+        _ => return None,
+    };
+    let entry = GlossiaDecodeCached {
+        language,
+        wordlist,
+        decoded,
+        hit_rate: best.hit_rate,
+    };
+    println!("[RUST-PERF] glossia cache MISS key={:x} compute={}ms (in={}b, words={}, dialect={}/{}, out={}b, hit_rate={:.3})",
+        key, perf.elapsed().as_millis(), text.len(), words.len(),
+        entry.language, entry.wordlist, entry.decoded.len(), entry.hit_rate);
+    cache.lock().unwrap().insert(key, entry.clone());
+    Some(entry)
+}
+
 fn glossia_decode_to_ciphertext(encoded_content: &str, nip_hint: &str) -> Result<String, String> {
     // If already base64 or base64?iv=base64, return as-is
     if is_base64_content(encoded_content) {
@@ -2114,66 +2165,13 @@ fn glossia_decode_to_ciphertext(encoded_content: &str, nip_hint: &str) -> Result
         return Ok(stripped);
     }
 
-    // Detect dialect (language + wordlist) from the prose itself.
-    let words: Vec<String> = encoded_content.split_whitespace().map(|w| w.to_lowercase()).collect();
-    if words.is_empty() {
-        return Err("Glossia decode failed: empty input".to_string());
-    }
-    let detect_words = words.clone();
-    let perf_detect = std::time::Instant::now();
-    let detect_result = std::panic::catch_unwind(move || {
-        glossia::detect_dialect_best(&detect_words)
-    });
-    let detect_ms = perf_detect.elapsed().as_millis();
-    let best = match detect_result {
-        Ok(Some(m)) => m,
-        Ok(None) => {
-            return Err("Glossia decode failed: no dialect detected".to_string());
-        }
-        Err(panic_info) => {
-            let msg = panic_info.downcast_ref::<String>()
-                .map(|s| s.as_str())
-                .or_else(|| panic_info.downcast_ref::<&str>().copied())
-                .unwrap_or("unknown panic");
-            return Err(format!("Glossia decode failed: detect panicked: {}", msg));
-        }
-    };
+    let cached = glossia_detect_and_decode_cached(encoded_content)
+        .ok_or_else(|| "Glossia decode failed: no dialect detected or hit_rate too low".to_string())?;
     println!("[RUST] glossia_decode_to_ciphertext: detected dialect={:?} wordlist={:?} hit_rate={}",
-        best.language, best.wordlist, best.hit_rate);
-    if best.hit_rate < 0.3 {
-        return Err(format!(
-            "Glossia decode failed: hit_rate {} too low (<0.3)", best.hit_rate
-        ));
-    }
+        cached.language, cached.wordlist, cached.hit_rate);
+    println!("[RUST] glossia_decode_to_ciphertext: decoded len={}", cached.decoded.len());
 
-    let text = encoded_content.to_string();
-    let language = best.language.clone();
-    let wordlist = best.wordlist.clone();
-    let perf_decode = std::time::Instant::now();
-    let decode_result = std::panic::catch_unwind(move || {
-        glossia::decode_from_language(&text, &language, &wordlist, false)
-    });
-    let decode_ms = perf_decode.elapsed().as_millis();
-    let decoded = match decode_result {
-        Ok(Ok(d)) => d,
-        Ok(Err(e)) => {
-            return Err(format!("Glossia decode failed for {}/{}: {:?}",
-                best.language, best.wordlist, e));
-        }
-        Err(panic_info) => {
-            let msg = panic_info.downcast_ref::<String>()
-                .map(|s| s.as_str())
-                .or_else(|| panic_info.downcast_ref::<&str>().copied())
-                .unwrap_or("unknown panic");
-            return Err(format!("Glossia decode failed for {}/{}: panic: {}",
-                best.language, best.wordlist, msg));
-        }
-    };
-    println!("[RUST] glossia_decode_to_ciphertext: decoded len={}", decoded.len());
-    println!("[RUST-PERF] glossia_decode_to_ciphertext: detect={}ms (words={}) decode_from_language={}ms (in={}b, out={}b)",
-        detect_ms, words.len(), decode_ms, encoded_content.len(), decoded.len());
-
-    glossia_postprocess(&decoded, nip_hint)
+    glossia_postprocess(&cached.decoded, nip_hint)
 }
 
 /// Glossia-decode subject (payload_only mode, hit_rate >= 0.8).

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -2442,6 +2442,7 @@ fn decrypt_single_block(
     let nip = encryption_nip.unwrap_or("nip44");
 
     // Step 1: Glossia-decode body text → ciphertext string
+    let perf_glossia = std::time::Instant::now();
     let ciphertext = match glossia_decode_to_ciphertext(body_text, nip) {
         Ok(ct) => {
             println!("[RUST] decrypt_single_block: glossia decoded, ciphertext len={}", ct.len());
@@ -2453,6 +2454,8 @@ fn decrypt_single_block(
             return (block, None);
         }
     };
+    let glossia_ms = perf_glossia.elapsed().as_millis();
+    let ciphertext_len = ciphertext.len();
 
     // Step 2: Determine which pubkey to decrypt with
     let decrypt_pubkey_hex = match determine_decrypt_pubkey(sig_pubkey_hex, seal_pubkey_hex, user_pubkey_hex, fallback_pubkey) {
@@ -2479,6 +2482,7 @@ fn decrypt_single_block(
         }
     };
 
+    let perf_nip = std::time::Instant::now();
     let decrypted = match crate::nostr::decrypt_dm_content(private_key, &decrypt_npub, &ciphertext) {
         Ok(d) => {
             println!("[RUST] decrypt_single_block: NIP decrypt SUCCESS, len={} preview={:?}", d.len(), &d[..d.len().min(40)]);
@@ -2490,6 +2494,9 @@ fn decrypt_single_block(
             return (block, None);
         }
     };
+    let nip_decrypt_ms = perf_nip.elapsed().as_millis();
+    println!("[RUST-PERF] decrypt_single_block: nip={} glossia={}ms (ct={}b) nip_decrypt={}ms (out={}b)",
+        nip, glossia_ms, ciphertext_len, nip_decrypt_ms, decrypted.len());
 
     // Step 4: Detect manifest vs legacy
     let trimmed = decrypted.trim();
@@ -2559,13 +2566,16 @@ fn decrypt_armor_tree(
     user_pubkey_hex: &str,
     fallback_pubkey: &str,
     raw_headers: Option<&str>,
+    depth: usize,
 ) -> (Vec<crate::types::DecryptedBlock>, Option<JsonManifest>) {
+    let perf_level = std::time::Instant::now();
     let mut results = Vec::new();
     let mut outer_manifest = None;
 
     // Recurse into quoted first (innermost-first ordering)
     // Propagate current level's sig/seal pubkey as fallback for inner blocks,
     // so nested blocks can identify the other party when their own sig matches the user.
+    let mut inner_ms = 0u128;
     if let Some(ref quoted) = parsed.quoted {
         let inner_fallback = if fallback_pubkey.is_empty() {
             parsed.sig_pubkey_hex.as_deref()
@@ -2578,7 +2588,9 @@ fn decrypt_armor_tree(
         // includes nested quoted bytes by concatenation. Inner subtrees only see a
         // slice of that signed data, so the header sig would never verify against
         // them — pass None so inner levels rely solely on their inline signatures.
-        let (inner_results, _) = decrypt_armor_tree(quoted, private_key, user_pubkey_hex, inner_fallback, None);
+        let perf_inner = std::time::Instant::now();
+        let (inner_results, _) = decrypt_armor_tree(quoted, private_key, user_pubkey_hex, inner_fallback, None, depth + 1);
+        inner_ms = perf_inner.elapsed().as_millis();
         results.extend(inner_results);
     }
 
@@ -2586,7 +2598,11 @@ fn decrypt_armor_tree(
     // NIP-04 (AES-256-CBC) lacks authenticated encryption; the Schnorr signature
     // serves as the MAC. Verification MUST happen before decryption to prevent
     // padding oracle attacks.
+    let perf_sig = std::time::Instant::now();
+    let mut sig_verify_ran = false;
+    let mut sig_verify_bytes_len: usize = 0;
     if parsed.encryption_nip.as_deref() == Some("nip04") {
+        sig_verify_ran = true;
         // Compute the canonical signed bytes once: this level's raw decoded body
         // concatenated with all nested quoted body bytes. Both the inline
         // SIGNATURE block and the X-Nostr-Sig header sign these same bytes.
@@ -2611,6 +2627,7 @@ fn decrypt_armor_tree(
             }
         }
         collect_quoted_bytes(&parsed.quoted, &mut all_bytes);
+        sig_verify_bytes_len = all_bytes.len();
 
         // Primary trust path: inline SIGNATURE block inside the armor.
         let inline_verified = match (&parsed.signature_hex, &parsed.sig_pubkey_hex) {
@@ -2690,11 +2707,18 @@ fn decrypt_armor_tree(
                 profile_name: parsed.profile_name.clone().or(parsed.display_name.clone()),
                 body_type: "encrypted".to_string(),
             });
+            let sig_ms_reject = perf_sig.elapsed().as_millis();
+            println!("[RUST-PERF] decrypt_armor_tree depth={} body_len={}b nip={:?} inner={}ms sig_verify={}ms (verify_bytes={}b) decrypt_block=SKIPPED(sig fail) total={}ms",
+                depth, parsed.body_text.len(), parsed.encryption_nip.as_deref(),
+                inner_ms, sig_ms_reject, sig_verify_bytes_len,
+                perf_level.elapsed().as_millis());
             return (results, outer_manifest);
         }
     }
+    let sig_verify_ms = if sig_verify_ran { perf_sig.elapsed().as_millis() } else { 0 };
 
     // Decrypt this level
+    let perf_block = std::time::Instant::now();
     let (block, manifest) = decrypt_single_block(
         &parsed.body_text,
         &parsed.body_type,
@@ -2706,10 +2730,16 @@ fn decrypt_armor_tree(
         user_pubkey_hex,
         fallback_pubkey,
     );
+    let block_ms = perf_block.elapsed().as_millis();
     if manifest.is_some() {
         outer_manifest = manifest;
     }
     results.push(block);
+
+    println!("[RUST-PERF] decrypt_armor_tree depth={} body_len={}b nip={:?} inner={}ms sig_verify={}ms (verify_bytes={}b) decrypt_block={}ms total={}ms",
+        depth, parsed.body_text.len(), parsed.encryption_nip.as_deref(),
+        inner_ms, sig_verify_ms, sig_verify_bytes_len, block_ms,
+        perf_level.elapsed().as_millis());
 
     (results, outer_manifest)
 }
@@ -2724,12 +2754,14 @@ pub fn decrypt_email_body_pipeline(
     recipient_pubkey: Option<&str>,
     raw_headers: Option<&str>,
 ) -> Result<crate::types::DecryptEmailResult, String> {
+    let perf_total = std::time::Instant::now();
     println!("[RUST] decrypt_email_body: armor_len={} subject_len={}", armor_text.len(), subject.len());
 
     // Normalize line endings (spec section 8 step 2)
     let normalized = armor_text.replace("\r\n", "\n");
 
     // Parse armor into capnp ArmorMessage → serde struct
+    let perf_parse = std::time::Instant::now();
     let parsed = match parse_armor_components(&normalized) {
         Some(p) => p,
         None => {
@@ -2747,14 +2779,17 @@ pub fn decrypt_email_body_pipeline(
             });
         }
     };
+    let parse_ms = perf_parse.elapsed().as_millis();
 
     // Derive user's pubkey hex from private key
+    let perf_derive = std::time::Instant::now();
     let user_pubkey_hex = {
         let sk = nostr_sdk::prelude::SecretKey::parse(private_key)
             .map_err(|e| format!("Invalid private key: {:?}", e))?;
         let keys = nostr_sdk::prelude::Keys::new(sk);
         keys.public_key().to_hex()
     };
+    let derive_pk_ms = perf_derive.elapsed().as_millis();
 
     // Determine fallback pubkey (the other party's pubkey for decryption)
     let fallback = sender_pubkey
@@ -2762,7 +2797,9 @@ pub fn decrypt_email_body_pipeline(
         .unwrap_or("");
 
     // Walk the armor tree, decrypt each level
-    let (block_results, manifest) = decrypt_armor_tree(&parsed, private_key, &user_pubkey_hex, fallback, raw_headers);
+    let perf_tree = std::time::Instant::now();
+    let (block_results, manifest) = decrypt_armor_tree(&parsed, private_key, &user_pubkey_hex, fallback, raw_headers, 0);
+    let tree_ms = perf_tree.elapsed().as_millis();
 
     // Extract outermost decrypted body (last element in innermost-first array)
     let outer_block = block_results.last();
@@ -2800,6 +2837,7 @@ pub fn decrypt_email_body_pipeline(
     };
 
     // Decrypt subject — use armor's embedded pubkey as fallback when sender_pubkey wasn't provided
+    let perf_subject = std::time::Instant::now();
     let (decrypted_subject, subject_ciphertext) = if parsed.body_type == "encrypted" {
         let nip_hint = parsed.encryption_nip.as_deref().unwrap_or("nip44");
         let subject_fallback = if fallback.is_empty() {
@@ -2814,8 +2852,10 @@ pub fn decrypt_email_body_pipeline(
     } else {
         (subject.to_string(), None)
     };
+    let subject_ms = perf_subject.elapsed().as_millis();
 
     // Extract sender pubkey from outermost armor signature (for avatar fallback)
+    let perf_sender = std::time::Instant::now();
     let armor_sender_pubkey = if sender_pubkey.is_none() {
         // No header-provided pubkey — try to derive from verified armor signature
         parsed.sig_pubkey_hex.as_deref().and_then(|pk_hex| {
@@ -2833,10 +2873,14 @@ pub fn decrypt_email_body_pipeline(
     } else {
         None
     };
+    let sender_extract_ms = perf_sender.elapsed().as_millis();
 
     println!("[RUST] decrypt_email_body: success={} is_manifest={} blocks={} attachments={} armor_sender_pubkey={:?}",
         success, is_manifest, block_results.len(), attachments.len(),
         armor_sender_pubkey.as_deref().map(|s: &str| &s[..std::cmp::min(s.len(), 20)]));
+    println!("[RUST-PERF] decrypt_email_body_pipeline: total={}ms parse={}ms derive_pk={}ms tree={}ms subject={}ms sender_extract={}ms (armor_len={}b, levels={})",
+        perf_total.elapsed().as_millis(), parse_ms, derive_pk_ms, tree_ms, subject_ms, sender_extract_ms,
+        armor_text.len(), block_results.len());
 
     Ok(crate::types::DecryptEmailResult {
         subject: decrypted_subject,

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -13,6 +13,42 @@ use tokio::time::timeout;
 use std::time::Duration;
 use crate::types::{TransportAuthVerdict, TransportAuthMethod};
 use std::net::TcpStream;
+
+// Verbose [RUST] logs in the decrypt hot path are silent by default — set the
+// NOSTR_MAIL_DEBUG environment variable to any value to re-enable them for
+// diagnostics. [RUST-PERF] lines (regular println!) remain on so profiling
+// info is always available.
+fn debug_log_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("NOSTR_MAIL_DEBUG").is_ok())
+}
+
+macro_rules! debug_log {
+    ($($arg:tt)*) => {
+        if debug_log_enabled() {
+            println!($($arg)*);
+        }
+    };
+}
+
+// Soft cap on cache size. When a cache grows beyond this, ~25% of entries are
+// dropped (HashMap iteration order is unspecified, so this is effectively a
+// random eviction). Realistic inboxes have a few thousand unique armor bodies
+// at most; this guard exists for the pathological "100k+ encrypted messages"
+// case.
+const CACHE_MAX: usize = 10_000;
+
+fn maybe_evict<K: Clone + Eq + std::hash::Hash, V>(
+    map: &mut std::collections::HashMap<K, V>,
+) {
+    if map.len() > CACHE_MAX {
+        let drop_count = map.len() / 4;
+        let keys: Vec<K> = map.keys().take(drop_count).cloned().collect();
+        for k in keys {
+            map.remove(&k);
+        }
+    }
+}
 #[cfg(not(target_os = "android"))]
 use native_tls::TlsConnector;
 #[cfg(target_os = "android")]
@@ -168,8 +204,8 @@ pub fn construct_email_headers(
     recipient_pubkey: Option<&str>,
     include_recipient_header: bool,
 ) -> Result<String> {
-    println!("[RUST] construct_email_headers: Constructing email headers");
-    println!("[RUST] construct_email_headers: From: {}, To: {}", config.email_address, to_address);
+    debug_log!("[RUST] construct_email_headers: Constructing email headers");
+    debug_log!("[RUST] construct_email_headers: From: {}, To: {}", config.email_address, to_address);
     
     let mut builder = Message::builder()
         .from(config.email_address.parse()?)
@@ -179,7 +215,7 @@ pub fn construct_email_headers(
 
     // Add custom message ID if provided
     if let Some(msg_id) = message_id {
-        println!("[RUST] construct_email_headers: Setting message ID: {}", msg_id);
+        debug_log!("[RUST] construct_email_headers: Setting message ID: {}", msg_id);
         // Try using the builder's message_id method
         builder = builder.message_id(Some(msg_id.to_string()));
         
@@ -187,18 +223,18 @@ pub fn construct_email_headers(
         // Note: This might not work with lettre's builder pattern, but worth trying
         // builder = builder.header(("Message-ID", msg_id));
     } else {
-        println!("[RUST] construct_email_headers: No message ID provided");
+        debug_log!("[RUST] construct_email_headers: No message ID provided");
     }
 
     // Add In-Reply-To header if provided (for email threading)
     if let Some(reply_id) = in_reply_to {
-        println!("[RUST] construct_email_headers: Setting In-Reply-To: {}", reply_id);
+        debug_log!("[RUST] construct_email_headers: Setting In-Reply-To: {}", reply_id);
         builder = builder.in_reply_to(reply_id.to_string());
     }
 
     // Add References header if provided (for email threading)
     if let Some(refs) = references {
-        println!("[RUST] construct_email_headers: Setting References: {}", refs);
+        debug_log!("[RUST] construct_email_headers: Setting References: {}", refs);
         builder = builder.references(refs.to_string());
     }
 
@@ -212,10 +248,10 @@ pub fn construct_email_headers(
             match crypto::get_public_key_from_private(private_key) {
                 Ok(sender_pubkey) => {
                     if include_pubkey_header {
-                        println!("[RUST] construct_email_headers: Adding sender pubkey to headers: {}", sender_pubkey);
+                        debug_log!("[RUST] construct_email_headers: Adding sender pubkey to headers: {}", sender_pubkey);
                         builder = builder.header(XNostrPubkey(sender_pubkey));
                     } else {
-                        println!("[RUST] construct_email_headers: Skipping X-Nostr-Pubkey (disabled by user)");
+                        debug_log!("[RUST] construct_email_headers: Skipping X-Nostr-Pubkey (disabled by user)");
                     }
 
                     if include_sig_header && include_pubkey_header {
@@ -223,21 +259,21 @@ pub fn construct_email_headers(
                         let binary = extract_ciphertext_binary(body);
                         match crypto::sign_data_bytes(private_key, &binary) {
                             Ok(signature) => {
-                                println!("[RUST] construct_email_headers: Signing email body (binary, {} bytes), signature length: {}", binary.len(), signature.len());
+                                debug_log!("[RUST] construct_email_headers: Signing email body (binary, {} bytes), signature length: {}", binary.len(), signature.len());
                                 builder = builder.header(XNostrSig(signature));
                             }
                             Err(e) => {
-                                println!("[RUST] construct_email_headers: Failed to sign email body: {}", e);
+                                debug_log!("[RUST] construct_email_headers: Failed to sign email body: {}", e);
                             }
                         }
                     } else if include_sig_header && !include_pubkey_header {
-                        println!("[RUST] construct_email_headers: Skipping X-Nostr-Sig because X-Nostr-Pubkey is disabled");
+                        debug_log!("[RUST] construct_email_headers: Skipping X-Nostr-Sig because X-Nostr-Pubkey is disabled");
                     } else {
-                        println!("[RUST] construct_email_headers: Skipping X-Nostr-Sig (disabled by user)");
+                        debug_log!("[RUST] construct_email_headers: Skipping X-Nostr-Sig (disabled by user)");
                     }
                 }
                 Err(e) => {
-                    println!("[RUST] construct_email_headers: Failed to get public key from private key: {}", e);
+                    debug_log!("[RUST] construct_email_headers: Failed to get public key from private key: {}", e);
                 }
             }
         }
@@ -249,7 +285,7 @@ pub fn construct_email_headers(
     if include_recipient_header {
         if let Some(rp) = recipient_pubkey {
             if !rp.is_empty() {
-                println!("[RUST] construct_email_headers: Adding recipient pubkey to headers: {}", rp);
+                debug_log!("[RUST] construct_email_headers: Adding recipient pubkey to headers: {}", rp);
                 builder = builder.header(XNostrRecipient(rp.to_string()));
             }
         }
@@ -261,7 +297,7 @@ pub fn construct_email_headers(
         .body(body.to_string());
 
     let body_part: Option<MultiPart> = if let Some(html) = html_body {
-        println!("[RUST] construct_email_headers: Building multipart/alternative with HTML body");
+        debug_log!("[RUST] construct_email_headers: Building multipart/alternative with HTML body");
         let html_part = SinglePart::builder()
             .header(ContentType::TEXT_HTML)
             .body(html.to_string());
@@ -281,7 +317,7 @@ pub fn construct_email_headers(
                 builder.body(body.to_string())?
             }
         } else {
-            println!("[RUST] construct_email_headers: Building multipart email with {} attachments", attachments.len());
+            debug_log!("[RUST] construct_email_headers: Building multipart email with {} attachments", attachments.len());
 
             // Create multipart/mixed; nest alternative or plain text inside
             let mut multipart = if let Some(alt) = body_part {
@@ -294,7 +330,7 @@ pub fn construct_email_headers(
 
             // Add each attachment (for header construction, we don't need the actual data)
             for attachment in attachments {
-                println!("[RUST] construct_email_headers: Adding attachment header: {}", attachment.filename);
+                debug_log!("[RUST] construct_email_headers: Adding attachment header: {}", attachment.filename);
 
                 // Parse content type
                 let content_type = attachment.content_type.parse::<ContentType>()
@@ -321,7 +357,7 @@ pub fn construct_email_headers(
     let email_bytes = email.formatted();
     let email_string = String::from_utf8(email_bytes)?;
     
-    println!("[RUST] construct_email_headers: Full email string length: {}", email_string.len());
+    debug_log!("[RUST] construct_email_headers: Full email string length: {}", email_string.len());
     
     // Extract headers from the email string
     let lines: Vec<&str> = email_string.lines().collect();
@@ -338,19 +374,19 @@ pub fn construct_email_headers(
     }
     
     let final_headers = headers.join("\n");
-    println!("[RUST] construct_email_headers: Final headers:");
+    debug_log!("[RUST] construct_email_headers: Final headers:");
     println!("{}", final_headers);
     
     // Check if Message-ID is present in the headers
     if final_headers.to_lowercase().contains("message-id:") {
-        println!("[RUST] construct_email_headers: Message-ID found in headers");
+        debug_log!("[RUST] construct_email_headers: Message-ID found in headers");
     } else {
-        println!("[RUST] construct_email_headers: Message-ID NOT found in headers");
+        debug_log!("[RUST] construct_email_headers: Message-ID NOT found in headers");
         // If Message-ID is not present, manually add it
         if let Some(msg_id) = message_id {
-            println!("[RUST] construct_email_headers: Manually adding Message-ID: {}", msg_id);
+            debug_log!("[RUST] construct_email_headers: Manually adding Message-ID: {}", msg_id);
             let headers_with_message_id = format!("Message-ID: {}\n{}", msg_id, final_headers);
-            println!("[RUST] construct_email_headers: Headers with manually added Message-ID:");
+            debug_log!("[RUST] construct_email_headers: Headers with manually added Message-ID:");
             println!("{}", headers_with_message_id);
             return Ok(headers_with_message_id);
         }
@@ -376,10 +412,10 @@ pub async fn send_email(
     recipient_pubkey: Option<&str>,
     include_recipient_header: bool,
 ) -> Result<String> {
-    println!("[RUST] send_email: Starting email send process");
-    println!("[RUST] send_email: SMTP Host: {}, Port: {}", config.smtp_host, config.smtp_port);
-    println!("[RUST] send_email: From: {}, To: {}", config.email_address, to_address);
-    println!("[RUST] send_email: Use TLS: {}", config.use_tls);
+    debug_log!("[RUST] send_email: Starting email send process");
+    debug_log!("[RUST] send_email: SMTP Host: {}, Port: {}", config.smtp_host, config.smtp_port);
+    debug_log!("[RUST] send_email: From: {}, To: {}", config.email_address, to_address);
+    debug_log!("[RUST] send_email: Use TLS: {}", config.use_tls);
     
     let mut builder = Message::builder()
         .from(config.email_address.parse()?)
@@ -395,13 +431,13 @@ pub async fn send_email(
 
     // Add In-Reply-To header if provided (for email threading)
     if let Some(reply_id) = in_reply_to {
-        println!("[RUST] send_email: Setting In-Reply-To: {}", reply_id);
+        debug_log!("[RUST] send_email: Setting In-Reply-To: {}", reply_id);
         builder = builder.in_reply_to(reply_id.to_string());
     }
 
     // Add References header if provided (for email threading)
     if let Some(refs) = references {
-        println!("[RUST] send_email: Setting References: {}", refs);
+        debug_log!("[RUST] send_email: Setting References: {}", refs);
         builder = builder.references(refs.to_string());
     }
 
@@ -414,14 +450,14 @@ pub async fn send_email(
             match crypto::get_public_key_from_private(private_key) {
                 Ok(sender_pubkey) => {
                     if include_pubkey_header {
-                        println!("[RUST] send_email: Adding sender pubkey to headers: {}", sender_pubkey);
+                        debug_log!("[RUST] send_email: Adding sender pubkey to headers: {}", sender_pubkey);
                         builder = builder.header(XNostrPubkey(sender_pubkey));
                     } else {
-                        println!("[RUST] send_email: Skipping X-Nostr-Pubkey (disabled by user)");
+                        debug_log!("[RUST] send_email: Skipping X-Nostr-Pubkey (disabled by user)");
                     }
 
                     if include_sig_header && include_pubkey_header {
-                        println!("[RUST] send_email: body passed to extract_ciphertext_binary ({} chars):\n{}", body.len(), &body[..body.len().min(500)]);
+                        debug_log!("[RUST] send_email: body passed to extract_ciphertext_binary ({} chars):\n{}", body.len(), &body[..body.len().min(500)]);
                         let binary = extract_ciphertext_binary(body);
                         let binary_hash = {
                             use sha2::{Sha256, Digest};
@@ -429,24 +465,24 @@ pub async fn send_email(
                             h.update(&binary);
                             hex::encode(&h.finalize()[..8])
                         };
-                        println!("[RUST] send_email: extracted binary {} bytes, sha256_prefix: {}", binary.len(), binary_hash);
+                        debug_log!("[RUST] send_email: extracted binary {} bytes, sha256_prefix: {}", binary.len(), binary_hash);
                         match crypto::sign_data_bytes(private_key, &binary) {
                             Ok(signature) => {
-                                println!("[RUST] send_email: Signing email body (binary, {} bytes), signature length: {}", binary.len(), signature.len());
+                                debug_log!("[RUST] send_email: Signing email body (binary, {} bytes), signature length: {}", binary.len(), signature.len());
                                 builder = builder.header(XNostrSig(signature));
                             }
                             Err(e) => {
-                                println!("[RUST] send_email: Failed to sign email body: {}", e);
+                                debug_log!("[RUST] send_email: Failed to sign email body: {}", e);
                             }
                         }
                     } else if include_sig_header && !include_pubkey_header {
-                        println!("[RUST] send_email: Skipping X-Nostr-Sig because X-Nostr-Pubkey is disabled");
+                        debug_log!("[RUST] send_email: Skipping X-Nostr-Sig because X-Nostr-Pubkey is disabled");
                     } else {
-                        println!("[RUST] send_email: Skipping X-Nostr-Sig (disabled by user)");
+                        debug_log!("[RUST] send_email: Skipping X-Nostr-Sig (disabled by user)");
                     }
                 }
                 Err(e) => {
-                    println!("[RUST] send_email: Failed to get public key from private key: {}", e);
+                    debug_log!("[RUST] send_email: Failed to get public key from private key: {}", e);
                 }
             }
         }
@@ -458,7 +494,7 @@ pub async fn send_email(
     if include_recipient_header {
         if let Some(rp) = recipient_pubkey {
             if !rp.is_empty() {
-                println!("[RUST] send_email: Adding recipient pubkey to headers: {}", rp);
+                debug_log!("[RUST] send_email: Adding recipient pubkey to headers: {}", rp);
                 builder = builder.header(XNostrRecipient(rp.to_string()));
             }
         }
@@ -470,7 +506,7 @@ pub async fn send_email(
         .body(body.to_string());
 
     let body_part: Option<MultiPart> = if let Some(html) = html_body {
-        println!("[RUST] send_email: Building multipart/alternative with HTML body");
+        debug_log!("[RUST] send_email: Building multipart/alternative with HTML body");
         let html_part = SinglePart::builder()
             .header(ContentType::TEXT_HTML)
             .body(html.to_string());
@@ -490,7 +526,7 @@ pub async fn send_email(
                 builder.body(body.to_string())?
             }
         } else {
-            println!("[RUST] send_email: Building multipart email with {} attachments", attachments.len());
+            debug_log!("[RUST] send_email: Building multipart email with {} attachments", attachments.len());
 
             // Create multipart/mixed; nest alternative or plain text inside
             let mut multipart = if let Some(alt) = body_part {
@@ -503,13 +539,13 @@ pub async fn send_email(
 
             // Add each attachment
             for attachment in attachments {
-                println!("[RUST] send_email: Adding attachment: {} ({})", attachment.filename, attachment.size);
+                debug_log!("[RUST] send_email: Adding attachment: {} ({})", attachment.filename, attachment.size);
 
                 // Decode base64 data
                 let attachment_data = match general_purpose::STANDARD.decode(&attachment.data) {
                     Ok(data) => data,
                     Err(e) => {
-                        println!("[RUST] send_email: Failed to decode base64 attachment data for {}: {}", attachment.filename, e);
+                        debug_log!("[RUST] send_email: Failed to decode base64 attachment data for {}: {}", attachment.filename, e);
                         continue;
                     }
                 };
@@ -554,14 +590,14 @@ pub async fn send_email(
 
     let mailer = mailer_builder.build();
 
-    println!("[RUST] send_email: Mailer built, attempting to send...");
+    debug_log!("[RUST] send_email: Mailer built, attempting to send...");
     
     // Run the blocking SMTP send operation in a separate thread with a 60-second timeout
     let mailer_clone = mailer.clone();
     let email_clone = email.clone();
     
     let send_future = task::spawn_blocking(move || {
-        println!("[RUST] send_email: Executing SMTP send in blocking thread");
+        debug_log!("[RUST] send_email: Executing SMTP send in blocking thread");
         mailer_clone.send(&email_clone)
     });
     
@@ -569,11 +605,11 @@ pub async fn send_email(
         Ok(join_res) => match join_res {
             Ok(send_res) => match send_res {
                 Ok(_) => {
-                    println!("[RUST] send_email: Email sent successfully");
+                    debug_log!("[RUST] send_email: Email sent successfully");
                     Ok(format!("Email sent successfully to {}", to_address))
                 }
                 Err(e) => {
-                    println!("[RUST] send_email: Failed to send email: {}", e);
+                    debug_log!("[RUST] send_email: Failed to send email: {}", e);
                     let error_msg = if e.to_string().to_lowercase().contains("authentication") {
                         "Authentication failed. For Gmail, make sure you're using an App Password, not your regular password.".to_string()
                     } else if e.to_string().to_lowercase().contains("connection") || e.to_string().to_lowercase().contains("host") {
@@ -589,12 +625,12 @@ pub async fn send_email(
                 }
             },
             Err(e) => {
-                println!("[RUST] send_email: Task join error: {}", e);
+                debug_log!("[RUST] send_email: Task join error: {}", e);
                 Err(anyhow::anyhow!("Task join error: {}", e))
             }
         },
         Err(_) => {
-            println!("[RUST] send_email: SMTP send operation timed out after 60 seconds");
+            debug_log!("[RUST] send_email: SMTP send operation timed out after 60 seconds");
             Err(anyhow::anyhow!("SMTP send operation timed out after 60 seconds. Check your internet connection and SMTP settings."))
         }
     }
@@ -611,7 +647,7 @@ pub async fn delete_sent_email_from_server(config: &EmailConfig, message_id: &st
     let use_tls = config.use_tls;
     let message_id = message_id.to_string();
 
-    println!("[RUST] delete_sent_email_from_server: Attempting to delete email with Message-ID: {}", message_id);
+    debug_log!("[RUST] delete_sent_email_from_server: Attempting to delete email with Message-ID: {}", message_id);
 
     // Run all blocking IMAP I/O on a dedicated thread to avoid blocking the Tokio runtime
     tokio::task::spawn_blocking(move || {
@@ -624,7 +660,7 @@ pub async fn delete_sent_email_from_server(config: &EmailConfig, message_id: &st
             let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
             let result = delete_sent_email_from_session_sync(&mut session, is_gmail, &message_id);
             let _ = session.logout();
-            println!("[RUST] delete_sent_email_from_server: Session closed");
+            debug_log!("[RUST] delete_sent_email_from_server: Session closed");
             result
         } else {
             let tcp_stream = TcpStream::connect(&addr)?;
@@ -632,7 +668,7 @@ pub async fn delete_sent_email_from_server(config: &EmailConfig, message_id: &st
             let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
             let result = delete_sent_email_from_session_sync(&mut session, is_gmail, &message_id);
             let _ = session.logout();
-            println!("[RUST] delete_sent_email_from_server: Session closed");
+            debug_log!("[RUST] delete_sent_email_from_server: Session closed");
             result
         };
         result
@@ -664,13 +700,13 @@ fn extract_text_body(email: &mailparse::ParsedMail) -> Option<String> {
 /// Extract the text/html body from a parsed email (multipart/alternative).
 /// Returns None if no HTML part is found.
 fn extract_html_body(email: &mailparse::ParsedMail) -> Option<String> {
-    println!("[RUST] extract_html_body: top-level mimetype={}, subparts={}", email.ctype.mimetype, email.subparts.len());
+    debug_log!("[RUST] extract_html_body: top-level mimetype={}, subparts={}", email.ctype.mimetype, email.subparts.len());
     for (i, subpart) in email.subparts.iter().enumerate() {
         let ctype = &subpart.ctype;
-        println!("[RUST] extract_html_body: subpart[{}] mimetype={}", i, ctype.mimetype);
+        debug_log!("[RUST] extract_html_body: subpart[{}] mimetype={}", i, ctype.mimetype);
         if ctype.mimetype == "text/html" {
             let body = subpart.get_body().ok();
-            println!("[RUST] extract_html_body: found text/html, body length={}", body.as_ref().map(|b| b.len()).unwrap_or(0));
+            debug_log!("[RUST] extract_html_body: found text/html, body length={}", body.as_ref().map(|b| b.len()).unwrap_or(0));
             return body;
         }
         // Recurse into nested multipart
@@ -680,7 +716,7 @@ fn extract_html_body(email: &mailparse::ParsedMail) -> Option<String> {
             }
         }
     }
-    println!("[RUST] extract_html_body: no text/html found");
+    debug_log!("[RUST] extract_html_body: no text/html found");
     None
 }
 
@@ -698,7 +734,7 @@ fn delete_sent_email_from_session_sync(
         "Sent"
     };
     
-    println!("[RUST] delete_sent_email_from_session: Selecting sent folder: {}", sent_folder);
+    debug_log!("[RUST] delete_sent_email_from_session: Selecting sent folder: {}", sent_folder);
     
     // Try to select the sent folder, fallback to common variations
     let folder_selected = session.select(sent_folder).is_ok() || 
@@ -707,7 +743,7 @@ fn delete_sent_email_from_session_sync(
                          session.select("Sent").is_ok();
     
     if !folder_selected {
-        println!("[RUST] delete_sent_email_from_session: Could not select sent folder, aborting server deletion");
+        debug_log!("[RUST] delete_sent_email_from_session: Could not select sent folder, aborting server deletion");
         return Err(anyhow::anyhow!("Could not select sent folder"));
     }
     
@@ -733,28 +769,28 @@ fn delete_sent_email_from_session_sync(
     
     let mut matching_messages = std::collections::HashSet::new();
     for search_query in &search_queries {
-        println!("[RUST] delete_sent_email_from_session: Searching for email with query: {}", search_query);
+        debug_log!("[RUST] delete_sent_email_from_session: Searching for email with query: {}", search_query);
         match session.search(search_query) {
             Ok(results) => {
                 let result_count = results.len();
                 if !results.is_empty() {
                     matching_messages.extend(results);
-                    println!("[RUST] delete_sent_email_from_session: Found {} matching message(s) with query: {}", result_count, search_query);
+                    debug_log!("[RUST] delete_sent_email_from_session: Found {} matching message(s) with query: {}", result_count, search_query);
                     break; // Found results, no need to try other formats
                 }
             }
             Err(e) => {
-                println!("[RUST] delete_sent_email_from_session: Search query failed: {} - {}", search_query, e);
+                debug_log!("[RUST] delete_sent_email_from_session: Search query failed: {} - {}", search_query, e);
             }
         }
     }
     
     if matching_messages.is_empty() {
-        println!("[RUST] delete_sent_email_from_session: No email found with Message-ID (tried: {}, {}, {})", full_msg_id, normalized_msg_id, message_id.trim());
+        debug_log!("[RUST] delete_sent_email_from_session: No email found with Message-ID (tried: {}, {}, {})", full_msg_id, normalized_msg_id, message_id.trim());
         return Err(anyhow::anyhow!("Email not found on server"));
     }
     
-    println!("[RUST] delete_sent_email_from_session: Found {} matching message(s)", matching_messages.len());
+    debug_log!("[RUST] delete_sent_email_from_session: Found {} matching message(s)", matching_messages.len());
     
     // Get the message sequence number (should be just one)
     // Convert HashSet to Vec to get the first element
@@ -768,18 +804,18 @@ fn delete_sent_email_from_session_sync(
         "Trash"
     };
     
-    println!("[RUST] delete_sent_email_from_session: Moving message {} to trash folder: {}", message_seq, trash_folder);
+    debug_log!("[RUST] delete_sent_email_from_session: Moving message {} to trash folder: {}", message_seq, trash_folder);
     
     // Use MOVE command (mv method) to move the message to trash
     // This is supported by Gmail and other modern IMAP servers
     let message_seq_str = format!("{}", message_seq);
     match session.mv(&message_seq_str, trash_folder) {
         Ok(_) => {
-            println!("[RUST] delete_sent_email_from_session: Successfully moved email to trash using MOVE command");
+            debug_log!("[RUST] delete_sent_email_from_session: Successfully moved email to trash using MOVE command");
             return Ok(());
         }
         Err(e) => {
-            println!("[RUST] delete_sent_email_from_session: MOVE command failed: {}, trying COPY + DELETE", e);
+            debug_log!("[RUST] delete_sent_email_from_session: MOVE command failed: {}, trying COPY + DELETE", e);
         }
     }
     
@@ -788,12 +824,12 @@ fn delete_sent_email_from_session_sync(
     let copy_result = session.copy(&message_seq_str, trash_folder);
     match copy_result {
         Ok(_) => {
-            println!("[RUST] delete_sent_email_from_session: Successfully copied email to trash");
+            debug_log!("[RUST] delete_sent_email_from_session: Successfully copied email to trash");
             // Mark original as deleted
             session.store(&message_seq_str, "+FLAGS (\\Deleted)")?;
             // Expunge to actually delete
             session.expunge()?;
-            println!("[RUST] delete_sent_email_from_session: Successfully deleted email from sent folder");
+            debug_log!("[RUST] delete_sent_email_from_session: Successfully deleted email from sent folder");
             Ok(())
         }
         Err(e) => {
@@ -805,11 +841,11 @@ fn delete_sent_email_from_session_sync(
             };
             
             for alt_trash in alternative_trash_folders {
-                println!("[RUST] delete_sent_email_from_session: Trying alternative trash folder: {}", alt_trash);
+                debug_log!("[RUST] delete_sent_email_from_session: Trying alternative trash folder: {}", alt_trash);
                 if session.copy(&message_seq_str, alt_trash).is_ok() {
                     session.store(&message_seq_str, "+FLAGS (\\Deleted)")?;
                     session.expunge()?;
-                    println!("[RUST] delete_sent_email_from_session: Successfully moved email to {} using COPY", alt_trash);
+                    debug_log!("[RUST] delete_sent_email_from_session: Successfully moved email to {} using COPY", alt_trash);
                     return Ok(());
                 }
             }
@@ -828,7 +864,7 @@ pub async fn delete_inbox_email_from_server(config: &EmailConfig, message_id: &s
     let use_tls = config.use_tls;
     let message_id = message_id.to_string();
 
-    println!("[RUST] delete_inbox_email_from_server: Attempting to delete email with Message-ID: {}", message_id);
+    debug_log!("[RUST] delete_inbox_email_from_server: Attempting to delete email with Message-ID: {}", message_id);
 
     tokio::task::spawn_blocking(move || {
         use std::net::TcpStream;
@@ -863,7 +899,7 @@ fn delete_email_from_folder_sync(
     // Try each source folder until we find and delete the email
     let mut folder_selected = false;
     for folder in source_folders {
-        println!("[RUST] delete_email_from_folder_sync: Trying folder: {}", folder);
+        debug_log!("[RUST] delete_email_from_folder_sync: Trying folder: {}", folder);
         if session.select(folder).is_ok() {
             folder_selected = true;
 
@@ -886,7 +922,7 @@ fn delete_email_from_folder_sync(
                 if let Ok(results) = session.search(search_query) {
                     if !results.is_empty() {
                         matching_messages.extend(results);
-                        println!("[RUST] delete_email_from_folder_sync: Found {} match(es) in {} with query: {}", matching_messages.len(), folder, search_query);
+                        debug_log!("[RUST] delete_email_from_folder_sync: Found {} match(es) in {} with query: {}", matching_messages.len(), folder, search_query);
                         break;
                     }
                 }
@@ -914,11 +950,11 @@ fn move_to_trash(
     let trash_folder = if is_gmail { "[Gmail]/Trash" } else { "Trash" };
     let seq_str = format!("{}", message_seq);
 
-    println!("[RUST] move_to_trash: Moving message {} to {}", message_seq, trash_folder);
+    debug_log!("[RUST] move_to_trash: Moving message {} to {}", message_seq, trash_folder);
 
     // Try MOVE first
     if session.mv(&seq_str, trash_folder).is_ok() {
-        println!("[RUST] move_to_trash: Successfully moved via MOVE command");
+        debug_log!("[RUST] move_to_trash: Successfully moved via MOVE command");
         return Ok(());
     }
 
@@ -933,7 +969,7 @@ fn move_to_trash(
         if session.copy(&seq_str, folder).is_ok() {
             session.store(&seq_str, "+FLAGS (\\Deleted)")?;
             session.expunge()?;
-            println!("[RUST] move_to_trash: Successfully moved to {} via COPY", folder);
+            debug_log!("[RUST] move_to_trash: Successfully moved to {} via COPY", folder);
             return Ok(());
         }
     }
@@ -950,7 +986,7 @@ pub async fn list_imap_folders(config: &EmailConfig) -> Result<Vec<String>> {
     let use_tls = config.use_tls;
     let addr = format!("{}:{}", host, port);
     
-    println!("[RUST] list_imap_folders: Connecting to IMAP server: {}", addr);
+    debug_log!("[RUST] list_imap_folders: Connecting to IMAP server: {}", addr);
     
     let mailboxes = if use_tls {
         let client = create_imap_tls_client!(host, &addr)?;
@@ -971,7 +1007,7 @@ pub async fn list_imap_folders(config: &EmailConfig) -> Result<Vec<String>> {
         .map(|mb| mb.name().to_string())
         .collect();
     
-    println!("[RUST] list_imap_folders: Found {} folders", folder_names.len());
+    debug_log!("[RUST] list_imap_folders: Found {} folders", folder_names.len());
     Ok(folder_names)
 }
 
@@ -985,8 +1021,8 @@ pub async fn test_imap_connection(config: &EmailConfig) -> Result<()> {
 
     let addr = format!("{}:{}", host, port);
     
-    println!("[RUST] Testing IMAP connection to: {}", addr);
-    println!("[RUST] Host: {}, Port: {}, Use TLS: {}", host, port, use_tls);
+    debug_log!("[RUST] Testing IMAP connection to: {}", addr);
+    debug_log!("[RUST] Host: {}, Port: {}, Use TLS: {}", host, port, use_tls);
 
     if use_tls {
         let client = create_imap_tls_client!(host, &addr)?;
@@ -998,15 +1034,15 @@ pub async fn test_imap_connection(config: &EmailConfig) -> Result<()> {
         let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
         session.logout()?;
     }
-    println!("[RUST] IMAP connection test successful");
+    debug_log!("[RUST] IMAP connection test successful");
     Ok(())
 }
 
 /// Test SMTP connection with the given config. Returns Ok(()) if successful, Err otherwise.
 pub async fn test_smtp_connection(config: &EmailConfig) -> Result<()> {
-    println!("[RUST] test_smtp_connection: Starting SMTP connection test");
-    println!("[RUST] test_smtp_connection: SMTP Host: {}, Port: {}", config.smtp_host, config.smtp_port);
-    println!("[RUST] test_smtp_connection: Email: {}, Use TLS: {}", config.email_address, config.use_tls);
+    debug_log!("[RUST] test_smtp_connection: Starting SMTP connection test");
+    debug_log!("[RUST] test_smtp_connection: SMTP Host: {}, Port: {}", config.smtp_host, config.smtp_port);
+    debug_log!("[RUST] test_smtp_connection: Email: {}, Use TLS: {}", config.email_address, config.use_tls);
     
     let creds = Credentials::new(config.email_address.clone(), config.password.clone());
 
@@ -1026,12 +1062,12 @@ pub async fn test_smtp_connection(config: &EmailConfig) -> Result<()> {
 
     let mailer = mailer_builder.build();
 
-    println!("[RUST] test_smtp_connection: Mailer built, testing connection...");
+    debug_log!("[RUST] test_smtp_connection: Mailer built, testing connection...");
     
     // Test the connection with a timeout
     let mailer_clone = mailer.clone();
     let test_future = task::spawn_blocking(move || {
-        println!("[RUST] test_smtp_connection: Executing connection test in blocking thread");
+        debug_log!("[RUST] test_smtp_connection: Executing connection test in blocking thread");
         mailer_clone.test_connection()
     });
     
@@ -1039,11 +1075,11 @@ pub async fn test_smtp_connection(config: &EmailConfig) -> Result<()> {
         Ok(join_res) => match join_res {
             Ok(test_res) => match test_res {
                 Ok(_) => {
-                    println!("[RUST] test_smtp_connection: SMTP connection test successful");
+                    debug_log!("[RUST] test_smtp_connection: SMTP connection test successful");
                     Ok(())
                 }
                 Err(e) => {
-                    println!("[RUST] test_smtp_connection: SMTP connection test failed: {}", e);
+                    debug_log!("[RUST] test_smtp_connection: SMTP connection test failed: {}", e);
                     let error_msg = if e.to_string().to_lowercase().contains("authentication") {
                         "Authentication failed. For Gmail, make sure you're using an App Password, not your regular password.".to_string()
                     } else if e.to_string().to_lowercase().contains("connection") || e.to_string().to_lowercase().contains("host") {
@@ -1059,12 +1095,12 @@ pub async fn test_smtp_connection(config: &EmailConfig) -> Result<()> {
                 }
             },
             Err(e) => {
-                println!("[RUST] test_smtp_connection: Task join error: {}", e);
+                debug_log!("[RUST] test_smtp_connection: Task join error: {}", e);
                 Err(anyhow::anyhow!("SMTP connection join error: {}", e))
             }
         },
         Err(_) => {
-            println!("[RUST] test_smtp_connection: SMTP connection test timed out after 30 seconds");
+            debug_log!("[RUST] test_smtp_connection: SMTP connection test timed out after 30 seconds");
             Err(anyhow::anyhow!("SMTP connection test timed out after 30 seconds. Check your internet connection and SMTP settings."))
         }
     }
@@ -1153,7 +1189,7 @@ fn extract_attachments_recursive(
             };
             
             attachments.push(db_attachment);
-            println!("[RUST] Extracted attachment: {} ({} bytes)", filename, attachment_data.len());
+            debug_log!("[RUST] Extracted attachment: {} ({} bytes)", filename, attachment_data.len());
         }
     }
 }
@@ -1224,7 +1260,7 @@ pub fn extract_sender_pubkey_with_armor_fallback(raw_headers: &str, body_text: &
                 if let Ok(pk) = nostr_sdk::prelude::PublicKey::from_hex(pubkey_hex) {
                     // to_bech32 is infallible for PublicKey
                     let npub = nostr_sdk::prelude::ToBech32::to_bech32(&pk).expect("bech32 encode");
-                    println!("[RUST] extract_sender_pubkey_with_armor_fallback: using verified armor pubkey {} ({})", &npub[..std::cmp::min(npub.len(), 20)], &pubkey_hex[..std::cmp::min(pubkey_hex.len(), 16)]);
+                    debug_log!("[RUST] extract_sender_pubkey_with_armor_fallback: using verified armor pubkey {} ({})", &npub[..std::cmp::min(npub.len(), 20)], &pubkey_hex[..std::cmp::min(pubkey_hex.len(), 16)]);
                     return Some(npub);
                 }
             }
@@ -1399,7 +1435,7 @@ pub fn glossia_roundtrip_to_bytes(text: &str, encoding: &str) -> Option<Vec<u8>>
     let encoded = match result {
         Ok(Ok((encoded_text, _, _, _))) => encoded_text,
         _ => {
-            println!("[RUST] glossia_roundtrip_to_bytes: encode failed for encoding={}", encoding);
+            debug_log!("[RUST] glossia_roundtrip_to_bytes: encode failed for encoding={}", encoding);
             return None;
         }
     };
@@ -1692,7 +1728,7 @@ pub fn parse_armor_components(armor_text: &str) -> Option<crate::types::ParsedAr
     }
 
     let preview: String = armor_text.chars().take(120).collect();
-    println!("[RUST] parse_armor_components: input length={} preview={:?}", armor_text.len(), preview);
+    debug_log!("[RUST] parse_armor_components: input length={} preview={:?}", armor_text.len(), preview);
 
     let perf = std::time::Instant::now();
 
@@ -1714,7 +1750,7 @@ pub fn parse_armor_components(armor_text: &str) -> Option<crate::types::ParsedAr
         result.quoted_armor_text = raw_quoted_text;
     }
 
-    println!("[RUST] parse_armor_components: success body_type={} nip={:?} has_sig={} has_seal={} has_quoted={}",
+    debug_log!("[RUST] parse_armor_components: success body_type={} nip={:?} has_sig={} has_seal={} has_quoted={}",
         result.body_type, result.encryption_nip, result.signature_hex.is_some(),
         result.seal_pubkey_hex.is_some(), result.quoted.is_some());
     println!("[RUST-PERF] parse_armor cache MISS key={:x} compute={}ms (in={}b, has_quoted={})",
@@ -1724,6 +1760,7 @@ pub fn parse_armor_components(armor_text: &str) -> Option<crate::types::ParsedAr
     // verify_all_signatures' recursive parse calls hit cache as well.
     {
         let mut guard = cache_map.lock().unwrap();
+        maybe_evict(&mut guard);
         guard.insert(cache_key, result.clone());
         populate_parse_subtree_cache(&result, &mut guard);
     }
@@ -1758,7 +1795,7 @@ fn populate_armor_from_text(
     let armor_start = match armor_start {
         Some(idx) => idx,
         None => {
-            println!("[RUST] populate_armor_from_text: no armor delimiter found");
+            debug_log!("[RUST] populate_armor_from_text: no armor delimiter found");
             return None;
         }
     };
@@ -1837,7 +1874,7 @@ fn populate_armor_from_text(
     }
 
     if state == "before" {
-        println!("[RUST] populate_armor_from_text: state machine never left 'before'");
+        debug_log!("[RUST] populate_armor_from_text: state machine never left 'before'");
         return None;
     }
 
@@ -2215,7 +2252,11 @@ fn glossia_detect_and_decode_cached(text: &str) -> Option<GlossiaDecodeCached> {
     println!("[RUST-PERF] glossia cache MISS key={:x} compute={}ms (in={}b, words={}, dialect={}/{}, out={}b, hit_rate={:.3})",
         key, perf.elapsed().as_millis(), text.len(), words.len(),
         entry.language, entry.wordlist, entry.decoded.len(), entry.hit_rate);
-    cache.lock().unwrap().insert(key, entry.clone());
+    {
+        let mut guard = cache.lock().unwrap();
+        maybe_evict(&mut guard);
+        guard.insert(key, entry.clone());
+    }
     Some(entry)
 }
 
@@ -2228,9 +2269,9 @@ fn glossia_decode_to_ciphertext(encoded_content: &str, nip_hint: &str) -> Result
 
     let cached = glossia_detect_and_decode_cached(encoded_content)
         .ok_or_else(|| "Glossia decode failed: no dialect detected or hit_rate too low".to_string())?;
-    println!("[RUST] glossia_decode_to_ciphertext: detected dialect={:?} wordlist={:?} hit_rate={}",
+    debug_log!("[RUST] glossia_decode_to_ciphertext: detected dialect={:?} wordlist={:?} hit_rate={}",
         cached.language, cached.wordlist, cached.hit_rate);
-    println!("[RUST] glossia_decode_to_ciphertext: decoded len={}", cached.decoded.len());
+    debug_log!("[RUST] glossia_decode_to_ciphertext: decoded len={}", cached.decoded.len());
 
     glossia_postprocess(&cached.decoded, nip_hint)
 }
@@ -2343,15 +2384,15 @@ fn glossia_decode_subject(subject: &str, nip_hint: &str) -> Option<String> {
     // Compute the result via an IIFE so every (early-) return path flows into
     // the cache insertion below without scattering insert calls everywhere.
     let result: Option<String> = (|| -> Option<String> {
-        println!("[RUST] glossia_decode_subject: len={} nip_hint={} preview={:?}", subject.len(), nip_hint, &subject[..subject.len().min(80)]);
+        debug_log!("[RUST] glossia_decode_subject: len={} nip_hint={} preview={:?}", subject.len(), nip_hint, &subject[..subject.len().min(80)]);
         if subject.is_empty() || is_likely_encrypted_content(subject) {
-            println!("[RUST] glossia_decode_subject: empty or already encrypted, returning None");
+            debug_log!("[RUST] glossia_decode_subject: empty or already encrypted, returning None");
             return None;
         }
 
         // Detect dialect with hit_rate filtering
         let words: Vec<String> = subject.split_whitespace().map(|w| w.to_lowercase()).collect();
-        println!("[RUST] glossia_decode_subject: word_count={} words={:?}", words.len(), &words[..words.len().min(6)]);
+        debug_log!("[RUST] glossia_decode_subject: word_count={} words={:?}", words.len(), &words[..words.len().min(6)]);
         if words.is_empty() {
             return None;
         }
@@ -2360,20 +2401,20 @@ fn glossia_decode_subject(subject: &str, nip_hint: &str) -> Option<String> {
         });
         let dialect = match detect_result {
             Ok(Some(best)) => {
-                println!("[RUST] glossia_decode_subject: detected dialect={:?} hit_rate={}", best.language, best.hit_rate);
+                debug_log!("[RUST] glossia_decode_subject: detected dialect={:?} hit_rate={}", best.language, best.hit_rate);
                 if best.hit_rate >= 0.8 {
                     best.language.clone()
                 } else {
-                    println!("[RUST] glossia_decode_subject: hit_rate too low (<0.8), returning None");
+                    debug_log!("[RUST] glossia_decode_subject: hit_rate too low (<0.8), returning None");
                     return None;
                 }
             }
             Ok(None) => {
-                println!("[RUST] glossia_decode_subject: no dialect detected, returning None");
+                debug_log!("[RUST] glossia_decode_subject: no dialect detected, returning None");
                 return None;
             }
             Err(e) => {
-                println!("[RUST] glossia_decode_subject: detect_dialect_best panicked: {:?}", e.downcast_ref::<String>());
+                debug_log!("[RUST] glossia_decode_subject: detect_dialect_best panicked: {:?}", e.downcast_ref::<String>());
                 return None;
             }
         };
@@ -2390,17 +2431,17 @@ fn glossia_decode_subject(subject: &str, nip_hint: &str) -> Option<String> {
             });
             match decode_result {
                 Ok(Ok(decoded)) => {
-                    println!("[RUST] glossia_decode_subject: wl={} decoded len={} preview={:?}", wl, decoded.len(), &decoded[..decoded.len().min(40)]);
+                    debug_log!("[RUST] glossia_decode_subject: wl={} decoded len={} preview={:?}", wl, decoded.len(), &decoded[..decoded.len().min(40)]);
                     match &best_decoded {
                         Some(prev) if prev.len() >= decoded.len() => {}
                         _ => { best_decoded = Some(decoded); }
                     }
                 }
                 Ok(Err(e)) => {
-                    println!("[RUST] glossia_decode_subject: wl={} decode error: {:?}", wl, e);
+                    debug_log!("[RUST] glossia_decode_subject: wl={} decode error: {:?}", wl, e);
                 }
                 Err(e) => {
-                    println!("[RUST] glossia_decode_subject: wl={} decode panicked: {:?}", wl, e.downcast_ref::<String>());
+                    debug_log!("[RUST] glossia_decode_subject: wl={} decode panicked: {:?}", wl, e.downcast_ref::<String>());
                 }
             }
         }
@@ -2408,17 +2449,21 @@ fn glossia_decode_subject(subject: &str, nip_hint: &str) -> Option<String> {
         match best_decoded {
             Some(decoded) => {
                 let result = glossia_postprocess(&decoded, nip_hint);
-                println!("[RUST] glossia_decode_subject: postprocess result={:?}", result.as_ref().map(|s| &s[..s.len().min(40)]));
+                debug_log!("[RUST] glossia_decode_subject: postprocess result={:?}", result.as_ref().map(|s| &s[..s.len().min(40)]));
                 result.ok()
             }
             _ => {
-                println!("[RUST] glossia_decode_subject: no successful decode from any wordlist");
+                debug_log!("[RUST] glossia_decode_subject: no successful decode from any wordlist");
                 None
             }
         }
     })();
 
-    cache.lock().unwrap().insert(key, result.clone());
+    {
+        let mut guard = cache.lock().unwrap();
+        maybe_evict(&mut guard);
+        guard.insert(key, result.clone());
+    }
     result
 }
 
@@ -2516,7 +2561,7 @@ fn decrypt_single_block(
 ) -> (crate::types::DecryptedBlock, Option<JsonManifest>) {
     use base64::Engine;
 
-    println!("[RUST] decrypt_single_block: type={} nip={:?} sig_pk={:?} seal_pk={:?} fallback={:?} body_preview={:?}",
+    debug_log!("[RUST] decrypt_single_block: type={} nip={:?} sig_pk={:?} seal_pk={:?} fallback={:?} body_preview={:?}",
         body_type, encryption_nip, sig_pubkey_hex.map(|s| &s[..s.len().min(16)]),
         seal_pubkey_hex.map(|s| &s[..s.len().min(16)]),
         &fallback_pubkey[..fallback_pubkey.len().min(16)],
@@ -2536,7 +2581,7 @@ fn decrypt_single_block(
         let decoded = try_glossia_decode_to_bytes(body_text)
             .and_then(|bytes| String::from_utf8(bytes).ok());
         if let Some(ref text) = decoded {
-            println!("[RUST] decrypt_single_block: glossia decoded signed/plain body, len={} preview={:?}",
+            debug_log!("[RUST] decrypt_single_block: glossia decoded signed/plain body, len={} preview={:?}",
                 text.len(), &text[..text.len().min(60)]);
         }
         block.decrypted_text = Some(decoded.unwrap_or_else(|| body_text.to_string()));
@@ -2549,11 +2594,11 @@ fn decrypt_single_block(
     let perf_glossia = std::time::Instant::now();
     let ciphertext = match glossia_decode_to_ciphertext(body_text, nip) {
         Ok(ct) => {
-            println!("[RUST] decrypt_single_block: glossia decoded, ciphertext len={}", ct.len());
+            debug_log!("[RUST] decrypt_single_block: glossia decoded, ciphertext len={}", ct.len());
             ct
         }
         Err(e) => {
-            println!("[RUST] decrypt_single_block: glossia decode FAILED: {}", e);
+            debug_log!("[RUST] decrypt_single_block: glossia decode FAILED: {}", e);
             block.error = Some(format!("Glossia decode failed: {}", e));
             return (block, None);
         }
@@ -2564,11 +2609,11 @@ fn decrypt_single_block(
     // Step 2: Determine which pubkey to decrypt with
     let decrypt_pubkey_hex = match determine_decrypt_pubkey(sig_pubkey_hex, seal_pubkey_hex, user_pubkey_hex, fallback_pubkey) {
         Ok(pk) => {
-            println!("[RUST] decrypt_single_block: decrypt pubkey={}", &pk[..pk.len().min(16)]);
+            debug_log!("[RUST] decrypt_single_block: decrypt pubkey={}", &pk[..pk.len().min(16)]);
             pk
         }
         Err(e) => {
-            println!("[RUST] decrypt_single_block: determine_decrypt_pubkey FAILED: {}", e);
+            debug_log!("[RUST] decrypt_single_block: determine_decrypt_pubkey FAILED: {}", e);
             block.error = Some(e);
             return (block, None);
         }
@@ -2589,11 +2634,11 @@ fn decrypt_single_block(
     let perf_nip = std::time::Instant::now();
     let decrypted = match crate::nostr::decrypt_dm_content(private_key, &decrypt_npub, &ciphertext) {
         Ok(d) => {
-            println!("[RUST] decrypt_single_block: NIP decrypt SUCCESS, len={} preview={:?}", d.len(), &d[..d.len().min(40)]);
+            debug_log!("[RUST] decrypt_single_block: NIP decrypt SUCCESS, len={} preview={:?}", d.len(), &d[..d.len().min(40)]);
             d
         }
         Err(e) => {
-            println!("[RUST] decrypt_single_block: NIP decrypt FAILED: {}", e);
+            debug_log!("[RUST] decrypt_single_block: NIP decrypt FAILED: {}", e);
             block.error = Some(format!("NIP decrypt failed: {}", e));
             return (block, None);
         }
@@ -2741,9 +2786,9 @@ fn decrypt_armor_tree(
                     Ok(true)
                 );
                 if ok {
-                    println!("[RUST] NIP-04 inline signature verified ({} bytes)", all_bytes.len());
+                    debug_log!("[RUST] NIP-04 inline signature verified ({} bytes)", all_bytes.len());
                 } else {
-                    println!("[RUST] NIP-04 inline signature INVALID");
+                    debug_log!("[RUST] NIP-04 inline signature INVALID");
                 }
                 Some(ok)
             }
@@ -2763,9 +2808,9 @@ fn decrypt_armor_tree(
                     Ok(true)
                 );
                 if ok {
-                    println!("[RUST] NIP-04 X-Nostr-Sig header verified ({} bytes)", all_bytes.len());
+                    debug_log!("[RUST] NIP-04 X-Nostr-Sig header verified ({} bytes)", all_bytes.len());
                 } else {
-                    println!("[RUST] NIP-04 X-Nostr-Sig header INVALID");
+                    debug_log!("[RUST] NIP-04 X-Nostr-Sig header INVALID");
                 }
                 Some(ok)
             })
@@ -2803,7 +2848,7 @@ fn decrypt_armor_tree(
                     "NIP-04 message has no signature (inline or header) — rejecting"
                 ),
             };
-            println!("[RUST] {}", log);
+            debug_log!("[RUST] {}", log);
             results.push(crate::types::DecryptedBlock {
                 decrypted_text: None,
                 error: Some(msg),
@@ -2859,7 +2904,7 @@ pub fn decrypt_email_body_pipeline(
     raw_headers: Option<&str>,
 ) -> Result<crate::types::DecryptEmailResult, String> {
     let perf_total = std::time::Instant::now();
-    println!("[RUST] decrypt_email_body: armor_len={} subject_len={}", armor_text.len(), subject.len());
+    debug_log!("[RUST] decrypt_email_body: armor_len={} subject_len={}", armor_text.len(), subject.len());
 
     // Normalize line endings (spec section 8 step 2)
     let normalized = armor_text.replace("\r\n", "\n");
@@ -2869,7 +2914,7 @@ pub fn decrypt_email_body_pipeline(
     let parsed = match parse_armor_components(&normalized) {
         Some(p) => p,
         None => {
-            println!("[RUST] decrypt_email_body: no armor found");
+            debug_log!("[RUST] decrypt_email_body: no armor found");
             return Ok(crate::types::DecryptEmailResult {
                 subject: subject.to_string(),
                 body: armor_text.to_string(),
@@ -2979,7 +3024,7 @@ pub fn decrypt_email_body_pipeline(
     };
     let sender_extract_ms = perf_sender.elapsed().as_millis();
 
-    println!("[RUST] decrypt_email_body: success={} is_manifest={} blocks={} attachments={} armor_sender_pubkey={:?}",
+    debug_log!("[RUST] decrypt_email_body: success={} is_manifest={} blocks={} attachments={} armor_sender_pubkey={:?}",
         success, is_manifest, block_results.len(), attachments.len(),
         armor_sender_pubkey.as_deref().map(|s: &str| &s[..std::cmp::min(s.len(), 20)]));
     println!("[RUST-PERF] decrypt_email_body_pipeline: total={}ms parse={}ms derive_pk={}ms tree={}ms subject={}ms sender_extract={}ms (armor_len={}b, levels={})",
@@ -3011,23 +3056,23 @@ fn decrypt_subject(
     fallback_pubkey: &str,
     nip_hint: &str,
 ) -> (String, Option<String>) {
-    println!("[RUST] decrypt_subject: len={} nip_hint={} preview={:?}", subject.len(), nip_hint, &subject[..subject.len().min(80)]);
+    debug_log!("[RUST] decrypt_subject: len={} nip_hint={} preview={:?}", subject.len(), nip_hint, &subject[..subject.len().min(80)]);
     if subject.is_empty() {
-        println!("[RUST] decrypt_subject: empty subject, returning as-is");
+        debug_log!("[RUST] decrypt_subject: empty subject, returning as-is");
         return (subject.to_string(), None);
     }
 
     // Try to get ciphertext from subject
     let is_encrypted = is_likely_encrypted_content(subject);
-    println!("[RUST] decrypt_subject: is_likely_encrypted={}", is_encrypted);
+    debug_log!("[RUST] decrypt_subject: is_likely_encrypted={}", is_encrypted);
     let ciphertext = if is_encrypted {
-        println!("[RUST] decrypt_subject: using subject directly as ciphertext");
+        debug_log!("[RUST] decrypt_subject: using subject directly as ciphertext");
         subject.to_string()
     } else if let Some(decoded) = glossia_decode_subject(subject, nip_hint) {
-        println!("[RUST] decrypt_subject: glossia decoded to ciphertext len={} preview={:?}", decoded.len(), &decoded[..decoded.len().min(60)]);
+        debug_log!("[RUST] decrypt_subject: glossia decoded to ciphertext len={} preview={:?}", decoded.len(), &decoded[..decoded.len().min(60)]);
         decoded
     } else {
-        println!("[RUST] decrypt_subject: glossia decode failed, returning subject as-is");
+        debug_log!("[RUST] decrypt_subject: glossia decode failed, returning subject as-is");
         return (subject.to_string(), None);
     };
 
@@ -3035,7 +3080,7 @@ fn decrypt_subject(
 
     // Determine which pubkey to use — use fallback (other party's pubkey)
     let decrypt_pubkey = if fallback_pubkey.is_empty() {
-        println!("[RUST] decrypt_subject: no fallback pubkey, returning subject as-is");
+        debug_log!("[RUST] decrypt_subject: no fallback pubkey, returning subject as-is");
         return (subject.to_string(), subject_ciphertext);
     } else if fallback_pubkey.starts_with("npub1") {
         fallback_pubkey.to_string()
@@ -3044,20 +3089,20 @@ fn decrypt_subject(
         match nostr_sdk::prelude::PublicKey::parse(fallback_pubkey) {
             Ok(pk) => pk.to_bech32().unwrap_or_else(|_| fallback_pubkey.to_string()),
             Err(_) => {
-                println!("[RUST] decrypt_subject: failed to parse fallback pubkey {:?}", fallback_pubkey);
+                debug_log!("[RUST] decrypt_subject: failed to parse fallback pubkey {:?}", fallback_pubkey);
                 return (subject.to_string(), subject_ciphertext);
             }
         }
     };
 
-    println!("[RUST] decrypt_subject: attempting NIP decrypt with pubkey prefix={:?}", &decrypt_pubkey[..decrypt_pubkey.len().min(20)]);
+    debug_log!("[RUST] decrypt_subject: attempting NIP decrypt with pubkey prefix={:?}", &decrypt_pubkey[..decrypt_pubkey.len().min(20)]);
     match crate::nostr::decrypt_dm_content(private_key, &decrypt_pubkey, &ciphertext) {
         Ok(decrypted) => {
-            println!("[RUST] decrypt_subject: success! decrypted={:?}", &decrypted[..decrypted.len().min(60)]);
+            debug_log!("[RUST] decrypt_subject: success! decrypted={:?}", &decrypted[..decrypted.len().min(60)]);
             (decrypted, subject_ciphertext)
         }
         Err(e) => {
-            println!("[RUST] decrypt_subject: NIP decrypt failed: {:?}", e);
+            debug_log!("[RUST] decrypt_subject: NIP decrypt failed: {:?}", e);
             (subject.to_string(), subject_ciphertext)
         }
     }
@@ -3074,7 +3119,7 @@ pub fn decrypt_attachment_pipeline(
     use base64::Engine;
     use sha2::{Sha256, Digest};
 
-    println!("[RUST] decrypt_attachment: data_len={} filename={:?}", attachment_data_b64.len(), orig_filename);
+    debug_log!("[RUST] decrypt_attachment: data_len={} filename={:?}", attachment_data_b64.len(), orig_filename);
 
     let b64 = base64::engine::general_purpose::STANDARD;
 
@@ -3092,7 +3137,7 @@ pub fn decrypt_attachment_pipeline(
         hasher.update(&encrypted_data);
         let actual_hash = hex::encode(hasher.finalize());
         if actual_hash != expected_hash {
-            println!("[RUST] decrypt_attachment_pipeline: hash mismatch (expected {}, got {}) — continuing anyway", expected_hash, actual_hash);
+            debug_log!("[RUST] decrypt_attachment_pipeline: hash mismatch (expected {}, got {}) — continuing anyway", expected_hash, actual_hash);
         }
     }
 
@@ -3123,7 +3168,7 @@ pub fn extract_ciphertext_binary(body: &str) -> Vec<u8> {
         if let Some(mut bytes) = decode_armor_section(&body_text) {
             if let Some(ref nested) = nested_armor {
                 let nested_bytes = extract_ciphertext_binary(nested);
-                println!("[RUST] extract_ciphertext_binary: concatenating {} outer + {} nested bytes",
+                debug_log!("[RUST] extract_ciphertext_binary: concatenating {} outer + {} nested bytes",
                     bytes.len(), nested_bytes.len());
                 bytes.extend_from_slice(&nested_bytes);
             }
@@ -3132,7 +3177,7 @@ pub fn extract_ciphertext_binary(body: &str) -> Vec<u8> {
     }
 
     // Non-armored body: return UTF-8 bytes
-    println!("[RUST] extract_ciphertext_binary: plain text, {} bytes", body.len());
+    debug_log!("[RUST] extract_ciphertext_binary: plain text, {} bytes", body.len());
     body.as_bytes().to_vec()
 }
 
@@ -3143,11 +3188,11 @@ pub fn verify_email_signature(sender_pubkey: &str, signature: &str, body: &str) 
     let binary = extract_ciphertext_binary(body);
     match crypto::verify_signature_bytes(sender_pubkey, signature, &binary) {
         Ok(valid) => {
-            println!("[RUST] verify_email_signature: {} ({} bytes)", if valid { "valid" } else { "INVALID" }, binary.len());
+            debug_log!("[RUST] verify_email_signature: {} ({} bytes)", if valid { "valid" } else { "INVALID" }, binary.len());
             valid
         },
         Err(e) => {
-            println!("[RUST] verify_email_signature: error: {}", e);
+            debug_log!("[RUST] verify_email_signature: error: {}", e);
             false
         }
     }
@@ -3162,12 +3207,12 @@ pub fn verify_email_signature_inline(body: &str) -> Option<bool> {
     let binary = extract_ciphertext_binary(body);
     match crypto::verify_signature_bytes(pubkey_hex, sig_hex, &binary) {
         Ok(valid) => {
-            println!("[RUST] verify_email_signature_inline: {} ({} bytes, pubkey={}...)",
+            debug_log!("[RUST] verify_email_signature_inline: {} ({} bytes, pubkey={}...)",
                 if valid { "valid" } else { "INVALID" }, binary.len(), &pubkey_hex[..8.min(pubkey_hex.len())]);
             Some(valid)
         }
         Err(e) => {
-            println!("[RUST] verify_email_signature_inline: error: {}", e);
+            debug_log!("[RUST] verify_email_signature_inline: error: {}", e);
             Some(false)
         }
     }
@@ -3187,7 +3232,7 @@ pub fn verify_email_signature_full(body: &str, raw_headers: &str) -> (Option<boo
         }
     };
 
-    println!("[RUST] verify_email_signature_full: body={:?}, header={:?}", body_result, header_result);
+    debug_log!("[RUST] verify_email_signature_full: body={:?}, header={:?}", body_result, header_result);
 
     match (body_result, header_result) {
         (Some(true), Some(true)) => (Some(true), Some("both".to_string())),
@@ -3208,19 +3253,19 @@ pub fn verify_all_signatures_inline(body: &str) -> Vec<crate::types::SignatureVe
 fn verify_all_signatures_recursive(body: &str, depth: usize) -> Vec<crate::types::SignatureVerificationResult> {
     let mut results = Vec::new();
 
-    println!("[RUST] verify_all_sigs_recursive: depth={}, body_len={}, preview={:?}",
+    debug_log!("[RUST] verify_all_sigs_recursive: depth={}, body_len={}, preview={:?}",
         depth, body.len(), &body[..80.min(body.len())]);
 
     // Parse armor at this level to get sig/pubkey and body type
     let parsed = match parse_armor_components(body) {
         Some(p) => p,
         None => {
-            println!("[RUST] verify_all_sigs_recursive: depth={}, parse_armor_components returned None", depth);
+            debug_log!("[RUST] verify_all_sigs_recursive: depth={}, parse_armor_components returned None", depth);
             return results;
         }
     };
 
-    println!("[RUST] verify_all_sigs_recursive: depth={}, parsed: body_type={}, has_sig={}, has_pubkey={}, has_quoted={}",
+    debug_log!("[RUST] verify_all_sigs_recursive: depth={}, parsed: body_type={}, has_sig={}, has_pubkey={}, has_quoted={}",
         depth, parsed.body_type,
         parsed.signature_hex.is_some(), parsed.sig_pubkey_hex.is_some(),
         parsed.quoted.is_some());
@@ -3229,18 +3274,18 @@ fn verify_all_signatures_recursive(body: &str, depth: usize) -> Vec<crate::types
     let depth_result = parse_armor_depth(body);
     match &depth_result {
         Some((_body_text, Some(ref nested_armor))) => {
-            println!("[RUST] verify_all_sigs_recursive: depth={}, found nested armor ({} bytes), recursing",
+            debug_log!("[RUST] verify_all_sigs_recursive: depth={}, found nested armor ({} bytes), recursing",
                 depth, nested_armor.len());
             let inner_results = verify_all_signatures_recursive(nested_armor, depth + 1);
-            println!("[RUST] verify_all_sigs_recursive: depth={}, inner recursion returned {} results",
+            debug_log!("[RUST] verify_all_sigs_recursive: depth={}, inner recursion returned {} results",
                 depth, inner_results.len());
             results.extend(inner_results);
         }
         Some((_body_text, None)) => {
-            println!("[RUST] verify_all_sigs_recursive: depth={}, no nested armor (leaf node)", depth);
+            debug_log!("[RUST] verify_all_sigs_recursive: depth={}, no nested armor (leaf node)", depth);
         }
         None => {
-            println!("[RUST] verify_all_sigs_recursive: depth={}, parse_armor_depth returned None", depth);
+            debug_log!("[RUST] verify_all_sigs_recursive: depth={}, parse_armor_depth returned None", depth);
         }
     }
 
@@ -3253,13 +3298,13 @@ fn verify_all_signatures_recursive(body: &str, depth: usize) -> Vec<crate::types
         let binary = extract_ciphertext_binary(body);
         let is_valid = match crate::crypto::verify_signature_bytes(pk, sig, &binary) {
             Ok(valid) => {
-                println!("[RUST] verify_all_signatures: depth={}, {} ({} bytes, pubkey={}...)",
+                debug_log!("[RUST] verify_all_signatures: depth={}, {} ({} bytes, pubkey={}...)",
                     depth, if valid { "valid" } else { "INVALID" }, binary.len(),
                     &pk[..8.min(pk.len())]);
                 valid
             }
             Err(e) => {
-                println!("[RUST] verify_all_signatures: depth={}, error: {}", depth, e);
+                debug_log!("[RUST] verify_all_signatures: depth={}, error: {}", depth, e);
                 false
             }
         };
@@ -3273,11 +3318,11 @@ fn verify_all_signatures_recursive(body: &str, depth: usize) -> Vec<crate::types
             profile_name: parsed.profile_name.clone(),
         });
     } else {
-        println!("[RUST] verify_all_sigs_recursive: depth={}, no sig/pubkey at this level (sig={}, pk={})",
+        debug_log!("[RUST] verify_all_sigs_recursive: depth={}, no sig/pubkey at this level (sig={}, pk={})",
             depth, sig_hex.is_some(), pubkey_hex.is_some());
     }
 
-    println!("[RUST] verify_all_sigs_recursive: depth={}, returning {} total results", depth, results.len());
+    debug_log!("[RUST] verify_all_sigs_recursive: depth={}, returning {} total results", depth, results.len());
     results
 }
 
@@ -3305,7 +3350,7 @@ pub fn extract_message_id_from_headers(raw_headers: &str) -> Option<String> {
                 .to_string();
             
             if !msg_id_clean.is_empty() {
-                println!("[RUST] extract_message_id_from_headers: Found Message-ID: {} (cleaned: {})", msg_id, msg_id_clean);
+                debug_log!("[RUST] extract_message_id_from_headers: Found Message-ID: {} (cleaned: {})", msg_id, msg_id_clean);
                 return Some(msg_id_clean);
             }
         }
@@ -3322,13 +3367,13 @@ pub fn extract_message_id_from_headers(raw_headers: &str) -> Option<String> {
                 .trim()
                 .to_string();
             if !msg_id_clean.is_empty() {
-                println!("[RUST] extract_message_id_from_headers: Found Message-ID via mailparse: {} (cleaned: {})", msg_id, msg_id_clean);
+                debug_log!("[RUST] extract_message_id_from_headers: Found Message-ID via mailparse: {} (cleaned: {})", msg_id, msg_id_clean);
                 return Some(msg_id_clean);
             }
         }
     }
     
-    println!("[RUST] extract_message_id_from_headers: No Message-ID header found in headers ({} chars). First 200 chars: {}", 
+    debug_log!("[RUST] extract_message_id_from_headers: No Message-ID header found in headers ({} chars). First 200 chars: {}", 
         raw_headers.len(), raw_headers.chars().take(200).collect::<String>());
     None
 }
@@ -3602,7 +3647,7 @@ pub fn decrypt_nostr_email_content(config: &EmailConfig, raw_headers: &str, subj
     let private_key = match &config.private_key {
         Some(key) => key,
         None => {
-            println!("[RUST] No private key available for decryption");
+            debug_log!("[RUST] No private key available for decryption");
             return Ok((subject.to_string(), body.to_string()));
         }
     };
@@ -3612,23 +3657,23 @@ pub fn decrypt_nostr_email_content(config: &EmailConfig, raw_headers: &str, subj
     let sender_pubkey = match extract_nostr_pubkey_from_headers(raw_headers) {
         Some(pubkey) => pubkey,
         None => {
-            println!("[RUST] No X-Nostr-Pubkey header found");
+            debug_log!("[RUST] No X-Nostr-Pubkey header found");
             return Ok((subject.to_string(), body.to_string()));
         }
     };
     
-    println!("[RUST] Attempting to decrypt inbox email using sender_pubkey (shared secret: user_privkey × sender_pubkey): {}", sender_pubkey);
+    debug_log!("[RUST] Attempting to decrypt inbox email using sender_pubkey (shared secret: user_privkey × sender_pubkey): {}", sender_pubkey);
     
     // Try to decrypt subject - encrypted subjects are typically just the raw encrypted content
     // without ASCII armor, and are usually base64 encoded
     let decrypted_subject = if is_likely_encrypted_content(subject) {
         match crypto::decrypt_message(private_key, &sender_pubkey, subject) {
             Ok(decrypted) => {
-                println!("[RUST] Successfully decrypted subject");
+                debug_log!("[RUST] Successfully decrypted subject");
                 decrypted
             }
             Err(e) => {
-                println!("[RUST] Failed to decrypt subject: {}", e);
+                debug_log!("[RUST] Failed to decrypt subject: {}", e);
                 subject.to_string()
             }
         }
@@ -3652,15 +3697,15 @@ pub fn decrypt_nostr_email_content(config: &EmailConfig, raw_headers: &str, subj
         
         // Detect format for logging
         let detected_format = crypto::detect_encryption_format(&clean_body);
-        println!("[RUST] Detected encryption format: {} for email body", detected_format);
+        debug_log!("[RUST] Detected encryption format: {} for email body", detected_format);
         
         match crypto::decrypt_message(private_key, &sender_pubkey, &clean_body) {
             Ok(decrypted) => {
-                println!("[RUST] Successfully decrypted body using format: {}", detected_format);
+                debug_log!("[RUST] Successfully decrypted body using format: {}", detected_format);
                 decrypted
             }
             Err(e) => {
-                println!("[RUST] Failed to decrypt body (detected format: {}): {}", detected_format, e);
+                debug_log!("[RUST] Failed to decrypt body (detected format: {}): {}", detected_format, e);
                 body.to_string()
             }
         }
@@ -4695,7 +4740,7 @@ pub async fn sync_nostr_emails_to_db(config: &EmailConfig, folder: Option<&str>,
                     }
                     raw_nostr_emails.extend(r.emails);
                 }
-                Err(e) => println!("[RUST] sync_nostr_emails_to_db: folder '{}' failed: {}", f, e),
+                Err(e) => debug_log!("[RUST] sync_nostr_emails_to_db: folder '{}' failed: {}", f, e),
             }
         }
     } else {
@@ -4711,7 +4756,7 @@ pub async fn sync_nostr_emails_to_db(config: &EmailConfig, folder: Option<&str>,
                     }
                     raw_nostr_emails.extend(r.emails);
                 }
-                Err(e) => println!("[RUST] sync_nostr_emails_to_db: folder '{}' failed: {}", f, e),
+                Err(e) => debug_log!("[RUST] sync_nostr_emails_to_db: folder '{}' failed: {}", f, e),
             }
         }
     }
@@ -4719,7 +4764,7 @@ pub async fn sync_nostr_emails_to_db(config: &EmailConfig, folder: Option<&str>,
     // Filter emails based on transport authentication - always filter out unauthenticated emails
     raw_nostr_emails.retain(|email| {
         if let Some(false) = email.transport_auth_verified {
-            println!("[RUST] sync_nostr_emails_to_db: Filtering out email {} - transport authentication failed", email.message_id);
+            debug_log!("[RUST] sync_nostr_emails_to_db: Filtering out email {} - transport authentication failed", email.message_id);
             false
         } else {
             true
@@ -4752,14 +4797,14 @@ pub async fn sync_nostr_emails_to_db(config: &EmailConfig, folder: Option<&str>,
             Ok(Some(existing)) => Some(existing),
             Ok(None) => None,
             Err(e) => {
-                println!("[RUST] ERROR: Failed to check if email exists: {}", e);
+                debug_log!("[RUST] ERROR: Failed to check if email exists: {}", e);
                 return Err(anyhow::anyhow!("Failed to check email {} in DB: {}", email.message_id, e));
             }
         };
         
         if let Some(existing_email) = existing_email {
             // Email already exists - update it with IMAP data (but preserve attachments)
-            println!("[RUST] Email with message_id {} already exists (id: {:?}), updating with IMAP data (preserving attachments)", 
+            debug_log!("[RUST] Email with message_id {} already exists (id: {:?}), updating with IMAP data (preserving attachments)", 
                 email.message_id, existing_email.id);
             let updated_email = DbEmail {
                 id: existing_email.id,
@@ -4788,7 +4833,7 @@ pub async fn sync_nostr_emails_to_db(config: &EmailConfig, folder: Option<&str>,
                 thread_id: None,
             };
             db.save_email(&updated_email)?;
-            println!("[RUST] Updated existing email in DB: message_id={}", email.message_id);
+            debug_log!("[RUST] Updated existing email in DB: message_id={}", email.message_id);
         } else {
             // Save raw email to DB
             // For inbox emails, sender_pubkey comes from headers (already extracted)
@@ -4818,48 +4863,48 @@ pub async fn sync_nostr_emails_to_db(config: &EmailConfig, folder: Option<&str>,
                 references: None,
                 thread_id: None,
             };
-            println!("[RUST] Saving email to DB: message_id={}", email.message_id);
+            debug_log!("[RUST] Saving email to DB: message_id={}", email.message_id);
             let email_id = db.save_email(&db_email)?;
-            println!("[RUST] Saved email to DB: message_id={}, id={}", email.message_id, email_id);
+            debug_log!("[RUST] Saved email to DB: message_id={}, id={}", email.message_id, email_id);
             
             // Save attachments for this email
-            println!("[RUST] sync_nostr_emails_to_db: Email {} has {} attachments in RawNostrEmail", email.message_id, email.attachments.len());
+            debug_log!("[RUST] sync_nostr_emails_to_db: Email {} has {} attachments in RawNostrEmail", email.message_id, email.attachments.len());
             if !email.attachments.is_empty() {
-                println!("[RUST] Saving {} attachments for email {} (id: {})", email.attachments.len(), email.message_id, email_id);
+                debug_log!("[RUST] Saving {} attachments for email {} (id: {})", email.attachments.len(), email.message_id, email_id);
                 for mut attachment in email.attachments.iter().cloned() {
                     attachment.email_id = email_id;
-                    println!("[RUST] Saving attachment: filename={}, size={}, encrypted={}, email_id={}",
+                    debug_log!("[RUST] Saving attachment: filename={}, size={}, encrypted={}, email_id={}",
                         attachment.filename, attachment.size, attachment.is_encrypted, email_id);
                     match db.save_attachment(&attachment) {
                         Ok(att_id) => {
-                            println!("[RUST] Successfully saved attachment {} (id: {}) for email {}", attachment.filename, att_id, email_id);
+                            debug_log!("[RUST] Successfully saved attachment {} (id: {}) for email {}", attachment.filename, att_id, email_id);
                         }
                         Err(e) => {
-                            println!("[RUST] ERROR: Failed to save attachment {}: {}", attachment.filename, e);
+                            debug_log!("[RUST] ERROR: Failed to save attachment {}: {}", attachment.filename, e);
                         }
                     }
                 }
             } else {
-                println!("[RUST] sync_nostr_emails_to_db: Email {} has no attachments in RawNostrEmail, trying to extract from body", email.message_id);
+                debug_log!("[RUST] sync_nostr_emails_to_db: Email {} has no attachments in RawNostrEmail, trying to extract from body", email.message_id);
                 // Try to extract attachments by parsing the raw RFC822 email body
                 if let Ok(parsed_email) = mailparse::parse_mail(email.body.as_bytes()) {
                     let extracted_attachments = extract_attachments_from_parsed_email(&parsed_email, &email.body);
                     if !extracted_attachments.is_empty() {
-                        println!("[RUST] Extracted {} attachments from email body for email {}", extracted_attachments.len(), email_id);
+                        debug_log!("[RUST] Extracted {} attachments from email body for email {}", extracted_attachments.len(), email_id);
                         for mut attachment in extracted_attachments {
                             attachment.email_id = email_id;
                             match db.save_attachment(&attachment) {
                                 Ok(att_id) => {
-                                    println!("[RUST] Saved extracted attachment {} (id: {}) for email {}", attachment.filename, att_id, email_id);
+                                    debug_log!("[RUST] Saved extracted attachment {} (id: {}) for email {}", attachment.filename, att_id, email_id);
                                 }
                                 Err(e) => {
-                                    println!("[RUST] ERROR: Failed to save extracted attachment {}: {}", attachment.filename, e);
+                                    debug_log!("[RUST] ERROR: Failed to save extracted attachment {}: {}", attachment.filename, e);
                                 }
                             }
                         }
                     }
                 } else {
-                    println!("[RUST] Could not parse email body to extract attachments for email {}", email_id);
+                    debug_log!("[RUST] Could not parse email body to extract attachments for email {}", email_id);
                 }
             }
             
@@ -4883,12 +4928,12 @@ pub async fn sync_nostr_emails_to_db(config: &EmailConfig, folder: Option<&str>,
         }
     }
 
-    println!("[RUST] sync_nostr_emails_to_db: Completed sync, {} new emails saved", new_count);
+    debug_log!("[RUST] sync_nostr_emails_to_db: Completed sync, {} new emails saved", new_count);
     Ok(new_count)
 }
 
 pub async fn sync_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str, db: &Database) -> anyhow::Result<usize> {
-    println!("[RUST] sync_sent_emails_to_db: Starting sync for email: {}", config.email_address);
+    debug_log!("[RUST] sync_sent_emails_to_db: Starting sync for email: {}", config.email_address);
     let account_key = config.email_address.trim().to_lowercase();
     let sync_cutoff_days = lookup_sync_cutoff_days(db, active_pubkey);
 
@@ -4916,7 +4961,7 @@ pub async fn sync_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str, d
                     }
                     raw_sent_emails.extend(r.emails);
                 }
-                Err(e) => println!("[RUST] sync_sent_emails_to_db: folder '{}' failed: {}", f, e),
+                Err(e) => debug_log!("[RUST] sync_sent_emails_to_db: folder '{}' failed: {}", f, e),
             }
         }
     } else {
@@ -4934,37 +4979,37 @@ pub async fn sync_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str, d
                     }
                     raw_sent_emails.extend(r.emails);
                 }
-                Err(e) => println!("[RUST] sync_sent_emails_to_db: folder '{}' failed: {}", f, e),
+                Err(e) => debug_log!("[RUST] sync_sent_emails_to_db: folder '{}' failed: {}", f, e),
             }
         }
     }
 
-    println!("[RUST] sync_sent_emails_to_db: Fetched {} emails from IMAP", raw_sent_emails.len());
+    debug_log!("[RUST] sync_sent_emails_to_db: Fetched {} emails from IMAP", raw_sent_emails.len());
 
     let mut new_count = 0;
-    println!("[RUST] sync_sent_emails_to_db: Processing {} emails for saving", raw_sent_emails.len());
+    debug_log!("[RUST] sync_sent_emails_to_db: Processing {} emails for saving", raw_sent_emails.len());
     for (idx, email) in raw_sent_emails.iter().enumerate() {
-        println!("[RUST] sync_sent_emails_to_db: Processing email {} of {}: message_id={}, from={}, date={}", 
+        debug_log!("[RUST] sync_sent_emails_to_db: Processing email {} of {}: message_id={}, from={}, date={}", 
             idx + 1, raw_sent_emails.len(), email.message_id, email.from, email.date);
         // Skip emails that failed transport authentication
         if let Some(false) = email.transport_auth_verified {
-            println!("[RUST] sync_nostr_emails_to_db: Skipping email {} - transport authentication failed", email.message_id);
+            debug_log!("[RUST] sync_nostr_emails_to_db: Skipping email {} - transport authentication failed", email.message_id);
             continue;
         }
         
         // Check if already in DB by message_id (only check, don't save yet)
-        println!("[RUST] sync_sent_emails_to_db: Checking for existing email with message_id: {}", email.message_id);
+        debug_log!("[RUST] sync_sent_emails_to_db: Checking for existing email with message_id: {}", email.message_id);
         let existing_email = match db.get_email(&email.message_id) {
             Ok(Some(existing)) => {
-                println!("[RUST] sync_sent_emails_to_db: Found existing email in DB: id={:?}, message_id={}", existing.id, existing.message_id);
+                debug_log!("[RUST] sync_sent_emails_to_db: Found existing email in DB: id={:?}, message_id={}", existing.id, existing.message_id);
                 Some(existing)
             },
             Ok(None) => {
-                println!("[RUST] sync_sent_emails_to_db: No existing email found in DB for message_id: {}", email.message_id);
+                debug_log!("[RUST] sync_sent_emails_to_db: No existing email found in DB for message_id: {}", email.message_id);
                 None
             },
             Err(e) => {
-                println!("[RUST] ERROR: Failed to check if email exists: {}", e);
+                debug_log!("[RUST] ERROR: Failed to check if email exists: {}", e);
                 return Err(anyhow::anyhow!("Failed to check email {} in DB: {}", email.message_id, e));
             }
         };
@@ -4972,7 +5017,7 @@ pub async fn sync_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str, d
         if let Some(existing_email) = existing_email {
                 // Email already exists - update it with IMAP data (but preserve attachments)
                 // Only update fields that might have changed from IMAP, don't overwrite attachment data
-                println!("[RUST] Email with message_id {} already exists (id: {:?}), updating with IMAP data (preserving attachments)", 
+                debug_log!("[RUST] Email with message_id {} already exists (id: {:?}), updating with IMAP data (preserving attachments)", 
                     email.message_id, existing_email.id);
                 let updated_email = DbEmail {
                     id: existing_email.id,
@@ -5001,15 +5046,15 @@ pub async fn sync_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str, d
                     thread_id: None,
                 };
                 match db.save_email(&updated_email) {
-                    Ok(id) => println!("[RUST] Updated existing email with IMAP data, id: {}", id),
+                    Ok(id) => debug_log!("[RUST] Updated existing email with IMAP data, id: {}", id),
                     Err(e) => {
-                        println!("[RUST] ERROR: Failed to update email {}: {}", email.message_id, e);
+                        debug_log!("[RUST] ERROR: Failed to update email {}: {}", email.message_id, e);
                         return Err(anyhow::anyhow!("Failed to update email {}: {}", email.message_id, e));
                     }
                 }
         } else {
             // New email - save raw email to DB directly without checking again
-            println!("[RUST] Email is new, inserting directly to DB (skipping redundant get_email check)");
+            debug_log!("[RUST] Email is new, inserting directly to DB (skipping redundant get_email check)");
             let db_email = DbEmail {
                 id: None,
                 message_id: email.message_id.clone(),
@@ -5036,42 +5081,42 @@ pub async fn sync_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str, d
                 references: None,
                 thread_id: None,
             };
-            println!("[RUST] Inserting new sent email to DB: message_id={}, from={}, to={}, subject_len={}, body_len={}",
+            debug_log!("[RUST] Inserting new sent email to DB: message_id={}, from={}, to={}, subject_len={}, body_len={}",
                 db_email.message_id, db_email.from_address, db_email.to_address, 
                 db_email.subject.len(), db_email.body.len());
             let email_id = match db.insert_email_direct(&db_email) {
                 Ok(id) => {
-                    println!("[RUST] Successfully inserted new sent email to DB with id: {}", id);
+                    debug_log!("[RUST] Successfully inserted new sent email to DB with id: {}", id);
                     new_count += 1;
                     id
                 }
                 Err(e) => {
-                    println!("[RUST] ERROR: Failed to insert email to DB: {}", e);
+                    debug_log!("[RUST] ERROR: Failed to insert email to DB: {}", e);
                     return Err(anyhow::anyhow!("Failed to insert email {} to DB: {}", email.message_id, e));
                 }
             };
             
             // Extract and save attachments from the email body
             // Parse the email body to extract attachments (they're in encrypted form)
-            println!("[RUST] sync_sent_emails_to_db: Email {} has {} attachments in RawNostrEmail", email.message_id, email.attachments.len());
+            debug_log!("[RUST] sync_sent_emails_to_db: Email {} has {} attachments in RawNostrEmail", email.message_id, email.attachments.len());
             if !email.attachments.is_empty() {
-                println!("[RUST] Saving {} attachments for email {} (id: {})", email.attachments.len(), email.message_id, email_id);
+                debug_log!("[RUST] Saving {} attachments for email {} (id: {})", email.attachments.len(), email.message_id, email_id);
                 for mut attachment in email.attachments.iter().cloned() {
                     attachment.email_id = email_id;
-                    println!("[RUST] Saving attachment: filename={}, size={}, encrypted={}, email_id={}", 
+                    debug_log!("[RUST] Saving attachment: filename={}, size={}, encrypted={}, email_id={}", 
                         attachment.filename, attachment.size, attachment.is_encrypted, attachment.email_id);
                     match db.save_attachment(&attachment) {
                         Ok(att_id) => {
-                            println!("[RUST] Successfully saved attachment {} (id: {}) for email {}", attachment.filename, att_id, email_id);
+                            debug_log!("[RUST] Successfully saved attachment {} (id: {}) for email {}", attachment.filename, att_id, email_id);
                         }
                         Err(e) => {
-                            println!("[RUST] ERROR: Failed to save attachment {}: {}", attachment.filename, e);
+                            debug_log!("[RUST] ERROR: Failed to save attachment {}: {}", attachment.filename, e);
                             // Don't fail the whole sync if attachment save fails
                         }
                     }
                 }
             } else {
-                println!("[RUST] sync_sent_emails_to_db: Email {} has no attachments in RawNostrEmail, trying to extract from body", email.message_id);
+                debug_log!("[RUST] sync_sent_emails_to_db: Email {} has no attachments in RawNostrEmail, trying to extract from body", email.message_id);
                 // Try to extract attachments by parsing the raw RFC822 email body
                 // The email.body might just be the text part, so we need to re-fetch the full email
                 // For now, try parsing the body - if it's multipart, we can extract attachments
@@ -5079,15 +5124,15 @@ pub async fn sync_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str, d
                 if let Ok(parsed_email) = mailparse::parse_mail(email.body.as_bytes()) {
                     let extracted_attachments = extract_attachments_from_parsed_email(&parsed_email, &email.body);
                     if !extracted_attachments.is_empty() {
-                        println!("[RUST] Extracted {} attachments from email body for email {}", extracted_attachments.len(), email_id);
+                        debug_log!("[RUST] Extracted {} attachments from email body for email {}", extracted_attachments.len(), email_id);
                         for mut attachment in extracted_attachments {
                             attachment.email_id = email_id;
                             match db.save_attachment(&attachment) {
                                 Ok(att_id) => {
-                                    println!("[RUST] Saved extracted attachment {} (id: {}) for email {}", attachment.filename, att_id, email_id);
+                                    debug_log!("[RUST] Saved extracted attachment {} (id: {}) for email {}", attachment.filename, att_id, email_id);
                                 }
                                 Err(e) => {
-                                    println!("[RUST] ERROR: Failed to save extracted attachment {}: {}", attachment.filename, e);
+                                    debug_log!("[RUST] ERROR: Failed to save extracted attachment {}: {}", attachment.filename, e);
                                 }
                             }
                         }
@@ -5095,7 +5140,7 @@ pub async fn sync_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str, d
                 } else {
                     // Body is not parseable as multipart - might need to re-fetch from IMAP
                     // For now, log and continue
-                    println!("[RUST] Could not parse email body to extract attachments for email {}", email_id);
+                    debug_log!("[RUST] Could not parse email body to extract attachments for email {}", email_id);
                 }
             }
         }
@@ -5115,7 +5160,7 @@ pub async fn sync_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str, d
         }
     }
 
-    println!("[RUST] sync_sent_emails_to_db: Completed sync, {} new emails saved", new_count);
+    debug_log!("[RUST] sync_sent_emails_to_db: Completed sync, {} new emails saved", new_count);
     Ok(new_count)
 }
 
@@ -5202,7 +5247,7 @@ fn parse_nostr_email_from_imap_body_inner(
                 reason: format!("Error verifying transport auth: {}", e),
             });
         if !verdict.transport_verified {
-            println!("[RUST] parse_nostr_email_from_imap_body: Email {} failed transport authentication: {}", message_id, verdict.reason);
+            debug_log!("[RUST] parse_nostr_email_from_imap_body: Email {} failed transport authentication: {}", message_id, verdict.reason);
             return None;
         }
         Some(true)
@@ -5302,7 +5347,7 @@ fn uid_sync_folder<S: std::io::Read + std::io::Write>(
         }
     };
 
-    println!("[RUST] uid_sync_folder: '{}' UID SEARCH {}", folder_name, query);
+    debug_log!("[RUST] uid_sync_folder: '{}' UID SEARCH {}", folder_name, query);
     let uid_set = session.uid_search(&query)?;
     if uid_set.is_empty() {
         return Ok(UidSyncResult {
@@ -5315,7 +5360,7 @@ fn uid_sync_folder<S: std::io::Read + std::io::Write>(
 
     let mut uids: Vec<u32> = uid_set.into_iter().collect();
     uids.sort_unstable();
-    println!("[RUST] uid_sync_folder: '{}' matched {} UIDs (min {}, max {})",
+    debug_log!("[RUST] uid_sync_folder: '{}' matched {} UIDs (min {}, max {})",
         folder_name, uids.len(), uids.first().copied().unwrap_or(0), uids.last().copied().unwrap_or(0));
 
     // Chunk into ~500-UID batches to stay well under Gmail's ~8KB IMAP line limit.
@@ -5379,7 +5424,7 @@ fn discover_sent_mailbox(session: &mut imap::Session<impl std::io::Read + std::i
     for mailbox in mailboxes.iter() {
         let mailbox_name = mailbox.name().to_lowercase();
         if mailbox_name == "[gmail]/sent mail" {
-            println!("[RUST] discover_sent_mailbox: Found sent mailbox: {}", mailbox.name());
+            debug_log!("[RUST] discover_sent_mailbox: Found sent mailbox: {}", mailbox.name());
             return Ok(Some(mailbox.name().to_string()));
         }
     }
@@ -5397,12 +5442,12 @@ fn discover_sent_mailbox(session: &mut imap::Session<impl std::io::Read + std::i
         // Check if this mailbox matches any sent pattern
         for pattern in &sent_patterns {
             if mailbox_name.contains(pattern) {
-                println!("[RUST] discover_sent_mailbox: Found sent mailbox: {}", mailbox.name());
+                debug_log!("[RUST] discover_sent_mailbox: Found sent mailbox: {}", mailbox.name());
                 return Ok(Some(mailbox.name().to_string()));
             }
         }
     }
     
-    println!("[RUST] discover_sent_mailbox: No sent mailbox found");
+    debug_log!("[RUST] discover_sent_mailbox: No sent mailbox found");
     Ok(None)
 }

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -2558,6 +2558,7 @@ fn decrypt_armor_tree(
     private_key: &str,
     user_pubkey_hex: &str,
     fallback_pubkey: &str,
+    raw_headers: Option<&str>,
 ) -> (Vec<crate::types::DecryptedBlock>, Option<JsonManifest>) {
     let mut results = Vec::new();
     let mut outer_manifest = None;
@@ -2573,7 +2574,11 @@ fn decrypt_armor_tree(
         } else {
             fallback_pubkey
         };
-        let (inner_results, _) = decrypt_armor_tree(quoted, private_key, user_pubkey_hex, inner_fallback);
+        // raw_headers (X-Nostr-Sig) signs the outermost canonical body bytes, which
+        // includes nested quoted bytes by concatenation. Inner subtrees only see a
+        // slice of that signed data, so the header sig would never verify against
+        // them — pass None so inner levels rely solely on their inline signatures.
+        let (inner_results, _) = decrypt_armor_tree(quoted, private_key, user_pubkey_hex, inner_fallback, None);
         results.extend(inner_results);
     }
 
@@ -2582,75 +2587,110 @@ fn decrypt_armor_tree(
     // serves as the MAC. Verification MUST happen before decryption to prevent
     // padding oracle attacks.
     if parsed.encryption_nip.as_deref() == Some("nip04") {
-        match (&parsed.signature_hex, &parsed.sig_pubkey_hex) {
-            (Some(sig_hex), Some(pubkey_hex)) => {
-                // Collect body bytes for verification — use raw decoded bytes (no NIP-04
-                // unpacking) to match extract_ciphertext_binary, which the inline
-                // signature verification uses successfully.
-                let verify_bytes = if let Some(ref b64) = parsed.body_bytes_b64 {
-                    general_purpose::STANDARD.decode(b64).unwrap_or_else(|_| parsed.body_text.as_bytes().to_vec())
-                } else {
-                    extract_ciphertext_binary(&parsed.body_text)
-                };
-                let mut all_bytes = verify_bytes;
+        // Compute the canonical signed bytes once: this level's raw decoded body
+        // concatenated with all nested quoted body bytes. Both the inline
+        // SIGNATURE block and the X-Nostr-Sig header sign these same bytes.
+        let verify_bytes = if let Some(ref b64) = parsed.body_bytes_b64 {
+            general_purpose::STANDARD.decode(b64).unwrap_or_else(|_| parsed.body_text.as_bytes().to_vec())
+        } else {
+            extract_ciphertext_binary(&parsed.body_text)
+        };
+        let mut all_bytes = verify_bytes;
 
-                // Concatenate nested quoted body bytes
-                fn collect_quoted_bytes(
-                    quoted: &Option<Box<crate::types::ParsedArmorMessage>>,
-                    buf: &mut Vec<u8>,
-                ) {
-                    if let Some(ref q) = quoted {
-                        if let Some(ref b64) = q.body_bytes_b64 {
-                            if let Ok(bytes) = general_purpose::STANDARD.decode(b64) {
-                                buf.extend_from_slice(&bytes);
-                            }
-                        }
-                        collect_quoted_bytes(&q.quoted, buf);
+        fn collect_quoted_bytes(
+            quoted: &Option<Box<crate::types::ParsedArmorMessage>>,
+            buf: &mut Vec<u8>,
+        ) {
+            if let Some(ref q) = quoted {
+                if let Some(ref b64) = q.body_bytes_b64 {
+                    if let Ok(bytes) = general_purpose::STANDARD.decode(b64) {
+                        buf.extend_from_slice(&bytes);
                     }
                 }
-                collect_quoted_bytes(&parsed.quoted, &mut all_bytes);
+                collect_quoted_bytes(&q.quoted, buf);
+            }
+        }
+        collect_quoted_bytes(&parsed.quoted, &mut all_bytes);
 
-                // Step 7: Verify signature against unpacked canonical bytes
-                let verified = matches!(
+        // Primary trust path: inline SIGNATURE block inside the armor.
+        let inline_verified = match (&parsed.signature_hex, &parsed.sig_pubkey_hex) {
+            (Some(sig_hex), Some(pubkey_hex)) => {
+                let ok = matches!(
                     crate::crypto::verify_signature_bytes(pubkey_hex, sig_hex, &all_bytes),
                     Ok(true)
                 );
-
-                if verified {
-                    println!("[RUST] NIP-04 signature verified ({} bytes), proceeding to decrypt", all_bytes.len());
+                if ok {
+                    println!("[RUST] NIP-04 inline signature verified ({} bytes)", all_bytes.len());
                 } else {
-                    println!("[RUST] NIP-04 signature INVALID — rejecting without decryption");
-                    results.push(crate::types::DecryptedBlock {
-                        decrypted_text: None,
-                        error: Some(
-                            "NIP-04 signature verification failed. The message was rejected \
-                             without decrypting to prevent potential ciphertext manipulation. \
-                             The message may have been tampered with in transit.".to_string()
-                        ),
-                        was_encrypted: true,
-                        profile_name: parsed.profile_name.clone().or(parsed.display_name.clone()),
-                        body_type: "encrypted".to_string(),
-                    });
-                    return (results, outer_manifest);
+                    println!("[RUST] NIP-04 inline signature INVALID");
                 }
+                Some(ok)
             }
-            _ => {
-                // No signature on NIP-04 message — reject
-                println!("[RUST] NIP-04 message has no signature — rejecting without decryption");
-                results.push(crate::types::DecryptedBlock {
-                    decrypted_text: None,
-                    error: Some(
-                        "This NIP-04 encrypted message has no signature. NIP-04 requires a \
-                         signature for authentication because it lacks built-in message \
-                         integrity (MAC). The message cannot be safely decrypted. The sender \
-                         may be using an older client that doesn't sign NIP-04 messages.".to_string()
-                    ),
-                    was_encrypted: true,
-                    profile_name: parsed.profile_name.clone().or(parsed.display_name.clone()),
-                    body_type: "encrypted".to_string(),
-                });
-                return (results, outer_manifest);
-            }
+            _ => None,
+        };
+
+        // Fallback trust path: X-Nostr-Sig + X-Nostr-Pubkey transport headers.
+        // Only consulted at the outermost armor level (raw_headers is None for
+        // recursive calls into nested quoted blocks), because the header sig
+        // signs the full canonical body, not inner subtrees.
+        let header_verified = if inline_verified != Some(true) {
+            raw_headers.and_then(|rh| {
+                let pk = extract_nostr_pubkey_from_headers(rh)?;
+                let sig = extract_nostr_sig_from_headers(rh)?;
+                let ok = matches!(
+                    crate::crypto::verify_signature_bytes(&pk, &sig, &all_bytes),
+                    Ok(true)
+                );
+                if ok {
+                    println!("[RUST] NIP-04 X-Nostr-Sig header verified ({} bytes)", all_bytes.len());
+                } else {
+                    println!("[RUST] NIP-04 X-Nostr-Sig header INVALID");
+                }
+                Some(ok)
+            })
+        } else {
+            None
+        };
+
+        let verified = inline_verified == Some(true) || header_verified == Some(true);
+        if !verified {
+            let (msg, log) = match (inline_verified, header_verified) {
+                (Some(false), Some(false)) => (
+                    "NIP-04 signature verification failed (both inline SIGNATURE block and \
+                     X-Nostr-Sig header). The message was rejected without decrypting to \
+                     prevent potential ciphertext manipulation.".to_string(),
+                    "NIP-04 both inline + header sigs INVALID — rejecting"
+                ),
+                (Some(false), None) => (
+                    "NIP-04 signature verification failed. The message was rejected without \
+                     decrypting to prevent potential ciphertext manipulation. The message may \
+                     have been tampered with in transit.".to_string(),
+                    "NIP-04 inline signature INVALID, no header sig — rejecting"
+                ),
+                (None, Some(false)) => (
+                    "NIP-04 X-Nostr-Sig header verification failed. No inline SIGNATURE block \
+                     was present, and the transport-header signature did not verify. The \
+                     message was rejected without decrypting.".to_string(),
+                    "NIP-04 header sig INVALID, no inline sig — rejecting"
+                ),
+                _ => (
+                    "This NIP-04 encrypted message has no signature (neither an inline \
+                     SIGNATURE block nor an X-Nostr-Sig header). NIP-04 requires a signature \
+                     for authentication because it lacks built-in message integrity (MAC). \
+                     To opt into decrypting unsigned messages anyway, disable \"Require \
+                     Signatures\" in Settings → Advanced.".to_string(),
+                    "NIP-04 message has no signature (inline or header) — rejecting"
+                ),
+            };
+            println!("[RUST] {}", log);
+            results.push(crate::types::DecryptedBlock {
+                decrypted_text: None,
+                error: Some(msg),
+                was_encrypted: true,
+                profile_name: parsed.profile_name.clone().or(parsed.display_name.clone()),
+                body_type: "encrypted".to_string(),
+            });
+            return (results, outer_manifest);
         }
     }
 
@@ -2682,6 +2722,7 @@ pub fn decrypt_email_body_pipeline(
     subject: &str,
     sender_pubkey: Option<&str>,
     recipient_pubkey: Option<&str>,
+    raw_headers: Option<&str>,
 ) -> Result<crate::types::DecryptEmailResult, String> {
     println!("[RUST] decrypt_email_body: armor_len={} subject_len={}", armor_text.len(), subject.len());
 
@@ -2721,7 +2762,7 @@ pub fn decrypt_email_body_pipeline(
         .unwrap_or("");
 
     // Walk the armor tree, decrypt each level
-    let (block_results, manifest) = decrypt_armor_tree(&parsed, private_key, &user_pubkey_hex, fallback);
+    let (block_results, manifest) = decrypt_armor_tree(&parsed, private_key, &user_pubkey_hex, fallback, raw_headers);
 
     // Extract outermost decrypted body (last element in innermost-first array)
     let outer_block = block_results.last();

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -1823,8 +1823,16 @@ fn populate_armor_from_text(
             nostr_mail_capnp::NipVersion::Nip44
         };
         enc.set_nip(nip_version);
-        if let Some(bytes) = decode_armor_section(&body_text) {
-            enc.set_ciphertext(&bytes);
+        // Only NIP-04 actually consumes the pre-decoded ciphertext bytes (used as
+        // the MAC payload during signature verification, see decrypt_armor_tree).
+        // NIP-44 re-runs glossia decode in decrypt_single_block on the encoded
+        // body_text and never reads enc.ciphertext, so doing the decode here
+        // wastes a full glossia detect+decode round trip per nesting level — the
+        // single biggest cost in parse_armor_components according to profiling.
+        if matches!(nip_version, nostr_mail_capnp::NipVersion::Nip04) {
+            if let Some(bytes) = decode_armor_section(&body_text) {
+                enc.set_ciphertext(&bytes);
+            }
         }
     } else if is_signed_body {
         let mut sgn = body_builder.reborrow().init_signed();
@@ -2112,9 +2120,11 @@ fn glossia_decode_to_ciphertext(encoded_content: &str, nip_hint: &str) -> Result
         return Err("Glossia decode failed: empty input".to_string());
     }
     let detect_words = words.clone();
+    let perf_detect = std::time::Instant::now();
     let detect_result = std::panic::catch_unwind(move || {
         glossia::detect_dialect_best(&detect_words)
     });
+    let detect_ms = perf_detect.elapsed().as_millis();
     let best = match detect_result {
         Ok(Some(m)) => m,
         Ok(None) => {
@@ -2139,9 +2149,11 @@ fn glossia_decode_to_ciphertext(encoded_content: &str, nip_hint: &str) -> Result
     let text = encoded_content.to_string();
     let language = best.language.clone();
     let wordlist = best.wordlist.clone();
+    let perf_decode = std::time::Instant::now();
     let decode_result = std::panic::catch_unwind(move || {
         glossia::decode_from_language(&text, &language, &wordlist, false)
     });
+    let decode_ms = perf_decode.elapsed().as_millis();
     let decoded = match decode_result {
         Ok(Ok(d)) => d,
         Ok(Err(e)) => {
@@ -2158,6 +2170,8 @@ fn glossia_decode_to_ciphertext(encoded_content: &str, nip_hint: &str) -> Result
         }
     };
     println!("[RUST] glossia_decode_to_ciphertext: decoded len={}", decoded.len());
+    println!("[RUST-PERF] glossia_decode_to_ciphertext: detect={}ms (words={}) decode_from_language={}ms (in={}b, out={}b)",
+        detect_ms, words.len(), decode_ms, encoded_content.len(), decoded.len());
 
     glossia_postprocess(&decoded, nip_hint)
 }

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -1639,17 +1639,68 @@ fn decode_sig_and_pubkey(content: &str) -> Option<(String, String)> {
 ///
 /// Returns a serde-friendly ParsedArmorMessage for Tauri JSON IPC.
 /// All serde fields are derived from reading the capnp message — nothing bypasses the schema.
+/// Process-wide cache for parse_armor_components results. Keyed by hash of the
+/// line-ending-normalized armor text — both decrypt and verify Tauri commands
+/// call into this function with the same body, and on first parse we walk the
+/// returned tree to pre-populate sub-tree entries (one per nesting level), so
+/// verify_all_signatures' recursive parse calls hit cache too. Across thread
+/// reopens the entire parse becomes a HashMap lookup.
+static PARSE_ARMOR_CACHE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<u64, crate::types::ParsedArmorMessage>>>
+    = std::sync::OnceLock::new();
+
+fn hash_armor_text(text: &str) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    text.hash(&mut h);
+    h.finish()
+}
+
+/// Recursively insert each nested level of the parsed tree into the cache.
+/// Each level's cache key is hash(level.quoted_armor_text), matching what a
+/// top-level parse_armor_components(quoted_armor_text) would compute.
+fn populate_parse_subtree_cache(
+    node: &crate::types::ParsedArmorMessage,
+    cache: &mut std::collections::HashMap<u64, crate::types::ParsedArmorMessage>,
+) {
+    if let (Some(quoted_text), Some(quoted_box)) = (node.quoted_armor_text.as_ref(), node.quoted.as_ref()) {
+        let key = hash_armor_text(quoted_text);
+        cache.entry(key).or_insert_with(|| (**quoted_box).clone());
+        populate_parse_subtree_cache(quoted_box, cache);
+    }
+}
+
 pub fn parse_armor_components(armor_text: &str) -> Option<crate::types::ParsedArmorMessage> {
     use crate::nostr_mail_capnp;
 
+    // Normalize line endings up front so the cache key doesn't fragment between
+    // callers (verify_all_signatures passes raw \r\n text from the DB, decrypt_email_body_pipeline
+    // passes its own pre-normalized copy). The downstream populate_armor_from_text
+    // also normalizes, but that's a cheap no-op on already-normalized input.
+    let normalized: std::borrow::Cow<str> = if armor_text.contains("\r\n") {
+        std::borrow::Cow::Owned(armor_text.replace("\r\n", "\n"))
+    } else {
+        std::borrow::Cow::Borrowed(armor_text)
+    };
+    let cache_key = hash_armor_text(&normalized);
+
+    let cache_map = PARSE_ARMOR_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Some(cached) = cache_map.lock().unwrap().get(&cache_key) {
+        println!("[RUST-PERF] parse_armor cache HIT key={:x} (in={}b, has_quoted={})",
+            cache_key, armor_text.len(), cached.quoted.is_some());
+        return Some(cached.clone());
+    }
+
     let preview: String = armor_text.chars().take(120).collect();
     println!("[RUST] parse_armor_components: input length={} preview={:?}", armor_text.len(), preview);
+
+    let perf = std::time::Instant::now();
 
     // Build the capnp ArmorMessage — this is the parsing target
     let mut capnp_msg = ::capnp::message::Builder::new_default();
     let (prefix_text, raw_quoted_text) = {
         let armor_builder = capnp_msg.init_root::<nostr_mail_capnp::armor_message::Builder>();
-        populate_armor_from_text(armor_builder, armor_text)?
+        populate_armor_from_text(armor_builder, &normalized)?
     };
 
     // Read the capnp message → serde struct (all fields derived from capnp)
@@ -1666,6 +1717,16 @@ pub fn parse_armor_components(armor_text: &str) -> Option<crate::types::ParsedAr
     println!("[RUST] parse_armor_components: success body_type={} nip={:?} has_sig={} has_seal={} has_quoted={}",
         result.body_type, result.encryption_nip, result.signature_hex.is_some(),
         result.seal_pubkey_hex.is_some(), result.quoted.is_some());
+    println!("[RUST-PERF] parse_armor cache MISS key={:x} compute={}ms (in={}b, has_quoted={})",
+        cache_key, perf.elapsed().as_millis(), armor_text.len(), result.quoted.is_some());
+
+    // Insert outer + each nested level under its own hash key so
+    // verify_all_signatures' recursive parse calls hit cache as well.
+    {
+        let mut guard = cache_map.lock().unwrap();
+        guard.insert(cache_key, result.clone());
+        populate_parse_subtree_cache(&result, &mut guard);
+    }
 
     Some(result)
 }
@@ -2254,80 +2315,111 @@ pub fn compute_subject_ciphertext_hash(subject: &str, body: &str) -> Option<Stri
     Some(format!("{:x}", hasher.finalize()))
 }
 
+static GLOSSIA_SUBJECT_CACHE: std::sync::OnceLock<std::sync::Mutex<std::collections::HashMap<u64, Option<String>>>>
+    = std::sync::OnceLock::new();
+
+fn hash_subject(subject: &str, nip_hint: &str) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    subject.hash(&mut h);
+    nip_hint.hash(&mut h);
+    h.finish()
+}
+
 fn glossia_decode_subject(subject: &str, nip_hint: &str) -> Option<String> {
-    println!("[RUST] glossia_decode_subject: len={} nip_hint={} preview={:?}", subject.len(), nip_hint, &subject[..subject.len().min(80)]);
-    if subject.is_empty() || is_likely_encrypted_content(subject) {
-        println!("[RUST] glossia_decode_subject: empty or already encrypted, returning None");
-        return None;
+    // Subject decode tries multiple wordlists and applies nip-specific
+    // postprocess, so we memoize the final Option<String> result keyed by
+    // (subject, nip_hint). Re-opens of the same email skip the entire
+    // detect + decode + postprocess flow.
+    let key = hash_subject(subject, nip_hint);
+    let cache = GLOSSIA_SUBJECT_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Some(cached) = cache.lock().unwrap().get(&key) {
+        println!("[RUST-PERF] glossia subject cache HIT key={:x} (in={}b, nip={})",
+            key, subject.len(), nip_hint);
+        return cached.clone();
     }
 
-    // Detect dialect with hit_rate filtering
-    let words: Vec<String> = subject.split_whitespace().map(|w| w.to_lowercase()).collect();
-    println!("[RUST] glossia_decode_subject: word_count={} words={:?}", words.len(), &words[..words.len().min(6)]);
-    if words.is_empty() {
-        return None;
-    }
-    let detect_result = std::panic::catch_unwind(move || {
-        glossia::detect_dialect_best(&words)
-    });
-    let dialect = match detect_result {
-        Ok(Some(best)) => {
-            println!("[RUST] glossia_decode_subject: detected dialect={:?} hit_rate={}", best.language, best.hit_rate);
-            if best.hit_rate >= 0.8 {
-                best.language.clone()
-            } else {
-                println!("[RUST] glossia_decode_subject: hit_rate too low (<0.8), returning None");
-                return None;
-            }
-        }
-        Ok(None) => {
-            println!("[RUST] glossia_decode_subject: no dialect detected, returning None");
+    // Compute the result via an IIFE so every (early-) return path flows into
+    // the cache insertion below without scattering insert calls everywhere.
+    let result: Option<String> = (|| -> Option<String> {
+        println!("[RUST] glossia_decode_subject: len={} nip_hint={} preview={:?}", subject.len(), nip_hint, &subject[..subject.len().min(80)]);
+        if subject.is_empty() || is_likely_encrypted_content(subject) {
+            println!("[RUST] glossia_decode_subject: empty or already encrypted, returning None");
             return None;
         }
-        Err(e) => {
-            println!("[RUST] glossia_decode_subject: detect_dialect_best panicked: {:?}", e.downcast_ref::<String>());
-            return None;
-        }
-    };
 
-    // Try decoding with both "default" and "raw" wordlists, pick longest
-    let wordlists = ["default", "raw"];
-    let mut best_decoded: Option<String> = None;
-    for wl in &wordlists {
-        let text = subject.to_string();
-        let lang = dialect.clone();
-        let wl_str = wl.to_string();
-        let decode_result = std::panic::catch_unwind(move || {
-            glossia::decode_from_language(&text, &lang, &wl_str, false)
+        // Detect dialect with hit_rate filtering
+        let words: Vec<String> = subject.split_whitespace().map(|w| w.to_lowercase()).collect();
+        println!("[RUST] glossia_decode_subject: word_count={} words={:?}", words.len(), &words[..words.len().min(6)]);
+        if words.is_empty() {
+            return None;
+        }
+        let detect_result = std::panic::catch_unwind(move || {
+            glossia::detect_dialect_best(&words)
         });
-        match decode_result {
-            Ok(Ok(decoded)) => {
-                println!("[RUST] glossia_decode_subject: wl={} decoded len={} preview={:?}", wl, decoded.len(), &decoded[..decoded.len().min(40)]);
-                match &best_decoded {
-                    Some(prev) if prev.len() >= decoded.len() => {}
-                    _ => { best_decoded = Some(decoded); }
+        let dialect = match detect_result {
+            Ok(Some(best)) => {
+                println!("[RUST] glossia_decode_subject: detected dialect={:?} hit_rate={}", best.language, best.hit_rate);
+                if best.hit_rate >= 0.8 {
+                    best.language.clone()
+                } else {
+                    println!("[RUST] glossia_decode_subject: hit_rate too low (<0.8), returning None");
+                    return None;
                 }
             }
-            Ok(Err(e)) => {
-                println!("[RUST] glossia_decode_subject: wl={} decode error: {:?}", wl, e);
+            Ok(None) => {
+                println!("[RUST] glossia_decode_subject: no dialect detected, returning None");
+                return None;
             }
             Err(e) => {
-                println!("[RUST] glossia_decode_subject: wl={} decode panicked: {:?}", wl, e.downcast_ref::<String>());
+                println!("[RUST] glossia_decode_subject: detect_dialect_best panicked: {:?}", e.downcast_ref::<String>());
+                return None;
+            }
+        };
+
+        // Try decoding with both "default" and "raw" wordlists, pick longest
+        let wordlists = ["default", "raw"];
+        let mut best_decoded: Option<String> = None;
+        for wl in &wordlists {
+            let text = subject.to_string();
+            let lang = dialect.clone();
+            let wl_str = wl.to_string();
+            let decode_result = std::panic::catch_unwind(move || {
+                glossia::decode_from_language(&text, &lang, &wl_str, false)
+            });
+            match decode_result {
+                Ok(Ok(decoded)) => {
+                    println!("[RUST] glossia_decode_subject: wl={} decoded len={} preview={:?}", wl, decoded.len(), &decoded[..decoded.len().min(40)]);
+                    match &best_decoded {
+                        Some(prev) if prev.len() >= decoded.len() => {}
+                        _ => { best_decoded = Some(decoded); }
+                    }
+                }
+                Ok(Err(e)) => {
+                    println!("[RUST] glossia_decode_subject: wl={} decode error: {:?}", wl, e);
+                }
+                Err(e) => {
+                    println!("[RUST] glossia_decode_subject: wl={} decode panicked: {:?}", wl, e.downcast_ref::<String>());
+                }
             }
         }
-    }
 
-    match best_decoded {
-        Some(decoded) => {
-            let result = glossia_postprocess(&decoded, nip_hint);
-            println!("[RUST] glossia_decode_subject: postprocess result={:?}", result.as_ref().map(|s| &s[..s.len().min(40)]));
-            result.ok()
+        match best_decoded {
+            Some(decoded) => {
+                let result = glossia_postprocess(&decoded, nip_hint);
+                println!("[RUST] glossia_decode_subject: postprocess result={:?}", result.as_ref().map(|s| &s[..s.len().min(40)]));
+                result.ok()
+            }
+            _ => {
+                println!("[RUST] glossia_decode_subject: no successful decode from any wordlist");
+                None
+            }
         }
-        _ => {
-            println!("[RUST] glossia_decode_subject: no successful decode from any wordlist");
-            None
-        }
-    }
+    })();
+
+    cache.lock().unwrap().insert(key, result.clone());
+    result
 }
 
 // ── Decrypt pipeline ─────────────────────────────────────────────────

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -4154,15 +4154,25 @@ fn decrypt_email_body(
     subject: String,
     sender_pubkey: Option<String>,
     recipient_pubkey: Option<String>,
+    message_id: Option<String>,
     state: tauri::State<AppState>,
 ) -> Result<types::DecryptEmailResult, String> {
     let pk = resolve_private_key(private_key, &state)?;
+    // Look up raw_headers from DB by message_id so the pipeline can fall back to
+    // the X-Nostr-Sig header for NIP-04 signature verification when the inline
+    // SIGNATURE block is missing.
+    let raw_headers = message_id.as_deref().and_then(|mid| {
+        state.get_database().ok()
+            .and_then(|db| db.get_email(mid).ok().flatten())
+            .and_then(|e| e.raw_headers)
+    });
     email::decrypt_email_body_pipeline(
         &pk,
         &armor_text,
         &subject,
         sender_pubkey.as_deref(),
         recipient_pubkey.as_deref(),
+        raw_headers.as_deref(),
     )
 }
 
@@ -4173,16 +4183,25 @@ fn decrypt_email_bodies_batch(
     state: tauri::State<AppState>,
 ) -> Result<Vec<types::BatchDecryptResultItem>, String> {
     let pk = resolve_private_key(private_key, &state)?;
+    // Open DB once for the whole batch so each item can look up its raw_headers
+    // by message_id for NIP-04 header-sig fallback verification.
+    let db_opt = state.get_database().ok();
     let results = emails
         .into_iter()
         .map(|e| {
             let id = e.id.clone();
+            let raw_headers = e.message_id.as_deref().and_then(|mid| {
+                db_opt.as_ref()
+                    .and_then(|db| db.get_email(mid).ok().flatten())
+                    .and_then(|row| row.raw_headers)
+            });
             match email::decrypt_email_body_pipeline(
                 &pk,
                 &e.armor_text,
                 &e.subject,
                 e.sender_pubkey.as_deref(),
                 e.recipient_pubkey.as_deref(),
+                raw_headers.as_deref(),
             ) {
                 Ok(result) => types::BatchDecryptResultItem {
                     id,
@@ -6582,7 +6601,7 @@ fn db_get_matching_email_body(dm_event_id: String, private_key: Option<String>, 
     for pubkey in &pubkeys_to_try {
         let sender_pk = if user_received_email { Some(pubkey.as_str()) } else { None };
         let recipient_pk = if user_sent_email { Some(pubkey.as_str()) } else { Some(pubkey.as_str()) };
-        match email::decrypt_email_body_pipeline(&private_key, &email.body, &email.subject, sender_pk, recipient_pk) {
+        match email::decrypt_email_body_pipeline(&private_key, &email.body, &email.subject, sender_pk, recipient_pk, email.raw_headers.as_deref()) {
             Ok(result) if result.success => {
                 println!("[RUST] decrypt_email_body_pipeline succeeded with pubkey: {}", pubkey);
                 return Ok(Some(types::MatchingEmailBodyResult {

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -440,7 +440,7 @@ fn map_db_email_to_email_message(email: &DbEmail) -> EmailMessage {
     }
 }
 
-fn map_email_thread_to_summary(email: &DbEmail, message_count: i64, unread_count: i64) -> EmailThreadSummary {
+fn map_email_thread_to_summary(email: &DbEmail, message_count: i64, unread_count: i64, attachment_count: i64) -> EmailThreadSummary {
     let raw_headers = email.raw_headers.clone().unwrap_or_default();
     EmailThreadSummary {
         id: email.id.map(|id| id.to_string()).unwrap_or_else(|| email.message_id.clone()),
@@ -462,6 +462,7 @@ fn map_email_thread_to_summary(email: &DbEmail, message_count: i64, unread_count
         thread_id: email.thread_id.clone().unwrap_or_else(|| email.message_id.clone()),
         message_count,
         unread_count,
+        attachment_count,
     }
 }
 
@@ -3105,8 +3106,8 @@ fn db_get_sent_emails(limit: Option<i64>, offset: Option<i64>, user_email: Optio
 fn db_get_email_threads(limit: Option<i64>, offset: Option<i64>, nostr_only: Option<bool>, user_email: Option<String>, user_pubkey: Option<String>, state: tauri::State<AppState>) -> Result<Vec<EmailThreadSummary>, String> {
     let db = state.get_database()?;
     let threads = db.get_email_threads(limit, offset, nostr_only, user_email.as_deref(), user_pubkey.as_deref()).map_err(|e| e.to_string())?;
-    let mapped: Vec<EmailThreadSummary> = threads.iter().map(|(email, count, unread)| {
-        map_email_thread_to_summary(email, *count, *unread)
+    let mapped: Vec<EmailThreadSummary> = threads.iter().map(|(email, count, unread, attachments)| {
+        map_email_thread_to_summary(email, *count, *unread, *attachments)
     }).collect();
     Ok(mapped)
 }
@@ -3117,7 +3118,7 @@ fn db_get_sent_email_threads(limit: Option<i64>, offset: Option<i64>, user_email
     let threads = db.get_sent_email_threads(limit, offset, user_email.as_deref()).map_err(|e| e.to_string())?;
     // Filter by sender_pubkey if user_pubkey is provided (same as db_get_sent_emails)
     let filtered: Vec<_> = if let Some(ref upk) = user_pubkey {
-        threads.into_iter().filter(|(e, _, _)| {
+        threads.into_iter().filter(|(e, _, _, _)| {
             match &e.sender_pubkey {
                 Some(spk) => spk == upk,
                 None => true,
@@ -3126,8 +3127,8 @@ fn db_get_sent_email_threads(limit: Option<i64>, offset: Option<i64>, user_email
     } else {
         threads
     };
-    let mapped: Vec<EmailThreadSummary> = filtered.iter().map(|(email, count, unread)| {
-        map_email_thread_to_summary(email, *count, *unread)
+    let mapped: Vec<EmailThreadSummary> = filtered.iter().map(|(email, count, unread, attachments)| {
+        map_email_thread_to_summary(email, *count, *unread, *attachments)
     }).collect();
     Ok(mapped)
 }

--- a/tauri-app/backend/src/types.rs
+++ b/tauri-app/backend/src/types.rs
@@ -363,6 +363,9 @@ pub struct BatchDecryptInput {
     pub subject: String,
     pub sender_pubkey: Option<String>,
     pub recipient_pubkey: Option<String>,
+    /// Message-Id of the email row in the local DB, used to look up
+    /// raw_headers for header-based signature verification fallback (NIP-04).
+    pub message_id: Option<String>,
 }
 
 /// Per-item result from batch email decryption (wraps success or error).

--- a/tauri-app/backend/src/types.rs
+++ b/tauri-app/backend/src/types.rs
@@ -75,6 +75,7 @@ pub struct EmailThreadSummary {
     pub thread_id: String,
     pub message_count: i64,
     pub unread_count: i64,
+    pub attachment_count: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tauri-app/backend/tests/email_integration.rs
+++ b/tauri-app/backend/tests/email_integration.rs
@@ -525,6 +525,114 @@ async fn nip04_legacy_decrypt() {
     assert_eq!(decrypted, plaintext);
 }
 
+/// Unsigned NIP-04 armor (no inline SIGNATURE block) sent with an X-Nostr-Sig
+/// transport header. decrypt_email_body_pipeline MUST reject when raw_headers
+/// is None (per NIP-04 MAC requirement) and MUST decrypt when raw_headers are
+/// supplied, by treating X-Nostr-Sig as the authentication MAC.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nip04_header_sig_fallback_unlocks_decrypt() {
+    let mock = spawn_mock_email().await;
+    let (alice_nsec, alice_npub, _) = test_keypair(1);
+    let (bob_nsec, bob_npub, _) = test_keypair(2);
+
+    let alice_config = email_config(
+        "alice@test.local",
+        "password-alice",
+        &alice_nsec,
+        mock.smtp_addr,
+        mock.imap_addr,
+    );
+
+    let plaintext = "Header-sig fallback should let me through.";
+    let ciphertext = crypto::encrypt_message(&alice_nsec, &bob_npub, plaintext, Some("nip04"))
+        .expect("nip04 encrypt");
+
+    // No inline SIGNATURE block — only the encrypted body armor.
+    let armored_body = format!(
+        "-----BEGIN NOSTR NIP-04 ENCRYPTED BODY-----\n{}\n-----END NOSTR MESSAGE-----",
+        ciphertext
+    );
+
+    email::send_email(
+        &alice_config,
+        "bob@test.local",
+        "nip04 header sig fallback",
+        &armored_body,
+        Some(&alice_npub),
+        None,
+        None,
+        None,
+        None,
+        None,
+        true, // include X-Nostr-Pubkey
+        true, // include X-Nostr-Sig
+        Some(&bob_npub),
+        true,
+    )
+    .await
+    .expect("send_email");
+
+    let inbox = mock.store.get_mailbox_emails("INBOX").await;
+    let delivered = &inbox[0];
+    let raw_headers = raw_headers_from_store(delivered);
+
+    // Sanity: the message we're testing really has X-Nostr-Sig but no inline sig.
+    assert!(
+        email::extract_nostr_sig_from_headers(&raw_headers).is_some(),
+        "precondition: X-Nostr-Sig must be present"
+    );
+    assert!(
+        !delivered.body.contains("BEGIN NOSTR SIGNATURE"),
+        "precondition: armor must NOT contain inline SIGNATURE block"
+    );
+
+    // Without raw_headers: pipeline rejects with the unsigned-message error.
+    let without_headers = email::decrypt_email_body_pipeline(
+        &bob_nsec,
+        &delivered.body,
+        &delivered.subject,
+        Some(&alice_npub),
+        Some(&bob_npub),
+        None,
+    )
+    .expect("pipeline returns Ok even on signature rejection");
+    assert!(
+        !without_headers.success,
+        "must reject unsigned NIP-04 when no header sig is available"
+    );
+    let err = without_headers
+        .block_results
+        .last()
+        .and_then(|b| b.error.clone())
+        .unwrap_or_default();
+    assert!(
+        err.contains("no signature") || err.contains("Require Signatures"),
+        "rejection error should explain the cause, got: {}",
+        err
+    );
+
+    // With raw_headers: header sig verifies, body decrypts to plaintext.
+    let with_headers = email::decrypt_email_body_pipeline(
+        &bob_nsec,
+        &delivered.body,
+        &delivered.subject,
+        Some(&alice_npub),
+        Some(&bob_npub),
+        Some(&raw_headers),
+    )
+    .expect("pipeline returns Ok when header sig verifies");
+    assert!(
+        with_headers.success,
+        "header sig fallback must unlock decrypt, error={:?}",
+        with_headers.error
+    );
+    assert_eq!(
+        with_headers.body.trim(),
+        plaintext,
+        "decrypted plaintext must round-trip"
+    );
+}
+
 /// Multipart text+html lettre → mailparse round-trip. The encrypted ENCRYPTED
 /// BODY armor lives in the text/plain part; the html part is a separate MIME
 /// section. Confirms both reach the receive side intact.
@@ -835,6 +943,7 @@ async fn sent_mail_decrypts_via_recipient_header_without_dm() {
         &delivered.subject,
         None,
         Some(&recipient_from_header),
+        None,
     )
     .expect("decrypt_email_body_pipeline");
 
@@ -922,6 +1031,7 @@ async fn sent_mail_undecryptable_without_any_counterparty_hint() {
         &alice_nsec,
         &delivered.body,
         &delivered.subject,
+        None,
         None,
         None,
     )
@@ -2114,6 +2224,7 @@ async fn nip44_reply_preserves_nested_encrypted_armor() {
         &reply.subject,
         Some(&bob_npub),
         Some(&alice_npub),
+        None,
     )
     .expect("decrypt_email_body_pipeline");
     assert!(decrypt.success, "decrypt must succeed: {:?}", decrypt.error);
@@ -2332,6 +2443,7 @@ async fn nip44_three_level_reply_chain() {
         &delivered.subject,
         Some(&alice_npub),
         Some(&bob_npub),
+        None,
     )
     .expect("decrypt pipeline");
     assert!(decrypt.success, "decrypt failed: {:?}", decrypt.error);

--- a/tauri-app/frontend/js/contacts-service.js
+++ b/tauri-app/frontend/js/contacts-service.js
@@ -2661,7 +2661,7 @@ class ContactsService {
                 }
                 
                 // Update contact detail if this contact is currently selected
-                const selectedContact = this.getSelectedContact();
+                const selectedContact = window.appState.getSelectedContact();
                 if (selectedContact && selectedContact.pubkey === pubkey) {
                     this.renderContactDetail(contact);
                 }

--- a/tauri-app/frontend/js/dm-service.js
+++ b/tauri-app/frontend/js/dm-service.js
@@ -2201,7 +2201,8 @@ class DMService {
                 const recipientPubkey = email.recipient_pubkey;
                 const decryptResult = await TauriService.decryptEmailBody(
                     email.body, email.subject || '',
-                    senderPubkey, recipientPubkey
+                    senderPubkey, recipientPubkey,
+                    email.message_id || null
                 );
 
                 if (!decryptResult.isManifest || !decryptResult.attachments || decryptResult.attachments.length === 0) {

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -4660,9 +4660,12 @@ ${attachmentsHtml}
                 let earliestDecryptedSubjectIdx = Infinity;
                 const lastIdx = threadEmails.length - 1;
 
+                const taskStartAll = performance.now();
                 await Promise.allSettled(threadEmails.map(async (email, idx) => {
+                    const taskStart = performance.now();
                     const isSent = email._isSentByUser;
                     const emailBody = email.body || '';
+                    const bodyBytes = emailBody.length;
                     const encryptedMatch = emailBody.replace(/\r\n/g, '\n').match(/-{3,}\s*BEGIN NOSTR (?:NIP-\d+ ENCRYPTED (?:MESSAGE|BODY))\s*-{3,}/);
 
                     let displayBody = emailBody;
@@ -4729,6 +4732,8 @@ ${attachmentsHtml}
                             console.error(`[JS] Thread email ${email.id} sig/glossia error:`, err);
                         }
                     }
+
+                    const tDecryptDone = performance.now();
 
                     // Update thread subject — first message in order whose
                     // decrypted subject differs from the stored one wins.
@@ -4977,7 +4982,18 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                         Utils.decorateArmorBlocks(bodyId);
                         this.verifyAndAnnotateSignatureBlocks(displayBody, bodyId);
                     }
+
+                    const tEnd = performance.now();
+                    console.log(
+                        `[THREAD-PERF] msg ${idx + 1}/${threadEmails.length} ` +
+                        `(body=${bodyBytes}b, encrypted=${!!encryptedMatch}): ` +
+                        `decrypt+verify=${(tDecryptDone - taskStart).toFixed(1)}ms, ` +
+                        `mount+post=${(tEnd - tDecryptDone).toFixed(1)}ms, ` +
+                        `total=${(tEnd - taskStart).toFixed(1)}ms ` +
+                        `(landed at ${(tEnd - taskStartAll).toFixed(1)}ms)`
+                    );
                 }));
+                console.log(`[THREAD-PERF] all ${threadEmails.length} messages settled in ${(performance.now() - taskStartAll).toFixed(1)}ms`);
 
                 // If we showed the "Decrypting…" placeholder but no per-message
                 // task ever produced a decrypted subject (e.g. all decrypts

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -3084,6 +3084,12 @@ class EmailService {
                 return ph;
             });
 
+            // Yield to the browser so it paints the skeletons before we move on.
+            // Without this, a warm preview cache lets the full replacement run to
+            // completion in the same JS turn as the appendChild loop, and the
+            // browser never paints the intermediate "skeleton-only" state.
+            await new Promise(resolve => requestAnimationFrame(resolve));
+
             // Batch-decrypt uncached encrypted emails in a single IPC call
             const uncachedEncrypted = filteredEmails.filter(email => {
                 if (this._previewCache.has(`inbox-${email.id}`)) return false;
@@ -6593,6 +6599,12 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                 sentList.appendChild(ph);
                 return ph;
             });
+
+            // Yield to the browser so it paints the skeletons before we move on.
+            // Without this, a warm preview cache lets the full replacement run to
+            // completion in the same JS turn as the appendChild loop, and the
+            // browser never paints the intermediate "skeleton-only" state.
+            await new Promise(resolve => requestAnimationFrame(resolve));
 
             // Batch-decrypt uncached encrypted sent emails, resolving pubkeys from contact index
             const uncachedEncrypted = filteredEmails.filter(email => {

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -3073,6 +3073,17 @@ class EmailService {
                 return true;
             });
 
+            // Paint skeleton placeholders synchronously so users see structure
+            // (sender, subject, date, attachment badge) the moment the SQL fetch
+            // returns, instead of staring at a blank list until batch decryption
+            // and per-row rendering finish. Each placeholder is replaced in-place
+            // when its full render resolves, so order matches server order.
+            const placeholders = filteredEmails.map(email => {
+                const ph = this.renderInboxEmailItemBasic(email);
+                emailList.appendChild(ph);
+                return ph;
+            });
+
             // Batch-decrypt uncached encrypted emails in a single IPC call
             const uncachedEncrypted = filteredEmails.filter(email => {
                 if (this._previewCache.has(`inbox-${email.id}`)) return false;
@@ -3206,34 +3217,40 @@ class EmailService {
                 }
             }
 
-            // Process emails in parallel (decryption will hit cache from batch above)
-            const emailPromises = filteredEmails
-                .map(async (email) => {
-                    try {
-                        // Add timeout to prevent hanging on decryption
-                        const timeoutPromise = new Promise((_, reject) =>
-                            setTimeout(() => reject(new Error('Decryption timeout')), 5000)
-                        );
-                        const renderPromise = this.renderInboxEmailItem(email);
-                        return await Promise.race([renderPromise, timeoutPromise]);
-                    } catch (error) {
-                        console.error(`[JS] Error rendering inbox email ${email.id}:`, error);
-                        // Return a basic email item even if rendering fails
-                        return this.renderInboxEmailItemBasic(email);
+            // Replace each placeholder with its full render as soon as that render
+            // resolves. Decryption will mostly hit the cache populated by the batch
+            // above, so this is fast; rows that need extra work upgrade in place
+            // without blocking the rest of the list.
+            const replacementResults = await Promise.allSettled(filteredEmails.map(async (email, idx) => {
+                const placeholder = placeholders[idx];
+                try {
+                    const timeoutPromise = new Promise((_, reject) =>
+                        setTimeout(() => reject(new Error('Decryption timeout')), 5000)
+                    );
+                    const fullElement = await Promise.race([
+                        this.renderInboxEmailItem(email),
+                        timeoutPromise
+                    ]);
+                    if (!placeholder || placeholder.parentNode !== emailList) return false;
+                    if (fullElement) {
+                        emailList.replaceChild(fullElement, placeholder);
+                        return true;
                     }
-                });
-
-            // Wait for all emails to be rendered (with timeout protection)
-            const renderedItems = await Promise.allSettled(emailPromises);
-
-            // Add all successfully rendered items to the list (filter out null results)
-            let renderedCount = 0;
-            for (const result of renderedItems) {
-                if (result.status === 'fulfilled' && result.value) {
-                    emailList.appendChild(result.value);
-                    renderedCount++;
+                    // renderInboxEmailItem returns null when hide_undecryptable is on
+                    // and the row failed to decrypt — drop the placeholder entirely.
+                    emailList.removeChild(placeholder);
+                    return false;
+                } catch (error) {
+                    console.error(`[JS] Error rendering inbox email ${email.id}:`, error);
+                    // Leave the skeleton placeholder visible so the user still sees the row.
+                    return !!(placeholder && placeholder.parentNode === emailList);
                 }
-            }
+            }));
+
+            const renderedCount = replacementResults.reduce(
+                (n, r) => n + (r.status === 'fulfilled' && r.value ? 1 : 0),
+                0
+            );
 
             // Show message if no emails were rendered (only on full render, not append)
             if (renderedCount === 0 && appendFrom <= 0) {

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -3111,6 +3111,7 @@ class EmailService {
                                 subject: email.subject,
                                 senderPubkey: null,
                                 recipientPubkey,
+                                messageId: email.message_id || null,
                             };
                         }
                         return {
@@ -3119,6 +3120,7 @@ class EmailService {
                             subject: email.subject,
                             senderPubkey: email.sender_pubkey || email.nostr_pubkey || null,
                             recipientPubkey: null,
+                            messageId: email.message_id || null,
                         };
                     });
                     console.log(`[JS] Batch decrypting ${batchInput.length} inbox emails in one IPC call`);
@@ -3184,7 +3186,7 @@ class EmailService {
                                 const senderPubkey = isSent ? null : (email.sender_pubkey || email.nostr_pubkey || null);
                                 const recipientPubkey = isSent ? (email.recipient_pubkey || null) : null;
                                 const retry = await TauriService.decryptEmailBody(
-                                    email.body, email.subject, senderPubkey, recipientPubkey
+                                    email.body, email.subject, senderPubkey, recipientPubkey, email.message_id || null
                                 );
                                 if (retry && retry.success) {
                                     let previewText = Utils.escapeHtml(retry.body.substring(0, 100));
@@ -3335,7 +3337,8 @@ class EmailService {
                         }
                         const result = await TauriService.decryptEmailBody(
                             email.body, email.subject,
-                            senderPubkey, recipientPubkey
+                            senderPubkey, recipientPubkey,
+                            email.message_id || null
                         );
                         if (result.success) {
                             previewSubject = result.subject;
@@ -3797,7 +3800,7 @@ class EmailService {
                             // Run decryption and signature verification in parallel (they're independent)
                             console.log('[JS] Calling backend decrypt_email_body + verifyAllSignatures in parallel...');
                             const [result, allSigs] = await Promise.all([
-                                TauriService.decryptEmailBody(emailBody, email.subject, senderPubkey, null),
+                                TauriService.decryptEmailBody(emailBody, email.subject, senderPubkey, null, email.message_id || null),
                                 TauriService.verifyAllSignatures(emailBody).catch(e => {
                                     console.warn('[JS] Signature verification error:', e);
                                     return [];
@@ -3924,7 +3927,7 @@ class EmailService {
                                         const senderPubkey = email.sender_pubkey || email.nostr_pubkey;
                                         const decryptResult = await TauriService.decryptEmailBody(
                                             email.body, email.subject || '',
-                                            senderPubkey, null
+                                            senderPubkey, null, email.message_id || null
                                         );
                                         if (decryptResult.isManifest && decryptResult.attachments && decryptResult.attachments.length > 0) {
                                             manifestResult = {
@@ -4583,7 +4586,7 @@ ${attachmentsHtml}
 
                         try {
                             const [result, allSigs] = await Promise.all([
-                                TauriService.decryptEmailBody(emailBody, email.subject, senderPubkey, recipientPubkey),
+                                TauriService.decryptEmailBody(emailBody, email.subject, senderPubkey, recipientPubkey, email.message_id || null),
                                 TauriService.verifyAllSignatures(emailBody).catch(e => {
                                     console.warn('[JS] Thread sig verify error:', e);
                                     return [];
@@ -6591,6 +6594,7 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                             subject: email.subject,
                             senderPubkey: null,
                             recipientPubkey,
+                            messageId: email.message_id || null,
                         };
                     });
                     console.log(`[JS] Batch decrypting ${batchInput.length} sent emails in one IPC call`);
@@ -6642,7 +6646,7 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                                 const changed = await retrofitPromise;
                                 if (!changed || !email.recipient_pubkey) return;
                                 const retry = await TauriService.decryptEmailBody(
-                                    email.body, email.subject, null, email.recipient_pubkey
+                                    email.body, email.subject, null, email.recipient_pubkey, email.message_id || null
                                 );
                                 if (retry && retry.success) {
                                     let previewText = Utils.escapeHtml(retry.body.substring(0, 100));
@@ -6771,7 +6775,8 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                         try {
                             const result = await TauriService.decryptEmailBody(
                                 email.body, email.subject,
-                                null, recipientPubkey
+                                null, recipientPubkey,
+                                email.message_id || null
                             );
                             if (result.success) {
                                 previewSubject = result.subject;
@@ -7387,7 +7392,8 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                                 const recipientPubkey = email.recipient_pubkey || email.nostr_pubkey;
                                 const decryptResult = await TauriService.decryptEmailBody(
                                     email.body, email.subject || '',
-                                    null, recipientPubkey
+                                    null, recipientPubkey,
+                                    email.message_id || null
                                 );
                                 if (decryptResult.isManifest && decryptResult.attachments && decryptResult.attachments.length > 0) {
                                     manifestResult = {
@@ -7796,7 +7802,7 @@ ${attachmentsHtml}
                         // Run decryption and signature verification in parallel (they're independent)
                         console.log('[JS] Calling backend decrypt_email_body + verifyAllSignatures for sent email in parallel...');
                         const [result, allSigs] = await Promise.all([
-                            TauriService.decryptEmailBody(email.body, email.subject, null, recipientPubkey),
+                            TauriService.decryptEmailBody(email.body, email.subject, null, recipientPubkey, email.message_id || null),
                             TauriService.verifyAllSignatures(email.body).catch(e => {
                                 console.warn('[JS] Signature verification error:', e);
                                 return [];
@@ -7942,7 +7948,8 @@ ${attachmentsHtml}
 
             const result = await TauriService.decryptEmailBody(
                 email.body, email.subject || '',
-                null, recipientPubkey
+                null, recipientPubkey,
+                email.message_id || null
             );
 
             // Retrofit happens whether or not the body decrypted — the subject
@@ -8075,7 +8082,8 @@ ${attachmentsHtml}
                 console.log('[JS] Using backend decrypt_email_body to extract manifest for sent attachment...');
                 const decryptResult = await TauriService.decryptEmailBody(
                     email.body, email.subject || '',
-                    null, recipientPubkey
+                    null, recipientPubkey,
+                    email.message_id || null
                 );
 
                 if (!decryptResult.isManifest || !decryptResult.attachments || decryptResult.attachments.length === 0) {
@@ -8171,7 +8179,8 @@ ${attachmentsHtml}
                 const recipientPubkey = email.recipient_pubkey || email.nostr_pubkey;
                 const decryptResult = await TauriService.decryptEmailBody(
                     email.body, email.subject || '',
-                    null, recipientPubkey
+                    null, recipientPubkey,
+                    email.message_id || null
                 );
 
                 if (!decryptResult.isManifest || !decryptResult.attachments || decryptResult.attachments.length === 0) {
@@ -8317,7 +8326,8 @@ ${attachmentsHtml}
                 console.log('[JS] Using backend decrypt_email_body to extract manifest for attachment...');
                 const decryptResult = await TauriService.decryptEmailBody(
                     email.body, email.subject || '',
-                    senderPubkey, null
+                    senderPubkey, null,
+                    email.message_id || null
                 );
 
                 if (!decryptResult.isManifest || !decryptResult.attachments || decryptResult.attachments.length === 0) {
@@ -8416,7 +8426,8 @@ ${attachmentsHtml}
                 console.log('[JS] Using backend decrypt_email_body to extract manifest for ZIP...');
                 const decryptResult = await TauriService.decryptEmailBody(
                     email.body, email.subject || '',
-                    senderPubkey, null
+                    senderPubkey, null,
+                    email.message_id || null
                 );
 
                 if (!decryptResult.isManifest || !decryptResult.attachments || decryptResult.attachments.length === 0) {
@@ -8771,7 +8782,8 @@ ${attachmentsHtml}
                     const recipientPubkey = draft.recipient_pubkey || draft.nostr_pubkey || draft.sender_pubkey;
                     const result = await TauriService.decryptEmailBody(
                         draft.body, draft.subject || '',
-                        recipientPubkey, null
+                        recipientPubkey, null,
+                        draft.message_id || null
                     );
                     if (result.success) {
                         previewSubject = result.subject || draft.subject;
@@ -9196,7 +9208,8 @@ ${attachmentsHtml}
                             const recipientPubkey = draftRecipientPubkey;
                             const result = await TauriService.decryptEmailBody(
                                 draft.body, draft.subject || '',
-                                recipientPubkey, null
+                                recipientPubkey, null,
+                                draft.message_id || null
                             );
                             if (result.success) {
                                 decryptedSubject = result.subject || draft.subject;

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -6581,6 +6581,16 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
             // apply here. Always show your own sent mail.
             const filteredEmails = emails;
 
+            // Paint skeleton placeholders synchronously so users see structure
+            // (recipient, subject, date, attachment badge) the moment the SQL fetch
+            // returns. Each placeholder is replaced in-place when its full render
+            // resolves, preserving server order.
+            const placeholders = filteredEmails.map(email => {
+                const ph = this.renderSentEmailItemBasic(email);
+                sentList.appendChild(ph);
+                return ph;
+            });
+
             // Batch-decrypt uncached encrypted sent emails, resolving pubkeys from contact index
             const uncachedEncrypted = filteredEmails.filter(email => {
                 if (this._previewCache.has(`sent-${email.id}`)) return false;
@@ -6680,34 +6690,40 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                 }
             }
 
-            // Process emails in parallel (decryption will hit cache from batch above)
-            const emailPromises = filteredEmails
-                .map(async (email) => {
+            // Replace each placeholder with its full render as soon as that render
+            // resolves. Decryption will mostly hit the cache populated by the batch
+            // above, so this is fast; rows that need extra work upgrade in place
+            // without blocking the rest of the list.
+            const replacementResults = await Promise.allSettled(filteredEmails.map(async (email, idx) => {
+                const placeholder = placeholders[idx];
                 try {
-                    // Add timeout to prevent hanging on decryption
                     const timeoutPromise = new Promise((_, reject) =>
                         setTimeout(() => reject(new Error('Decryption timeout')), 5000)
                     );
-                    const renderPromise = this.renderSentEmailItem(email);
-                    return await Promise.race([renderPromise, timeoutPromise]);
+                    const fullElement = await Promise.race([
+                        this.renderSentEmailItem(email),
+                        timeoutPromise
+                    ]);
+                    if (!placeholder || placeholder.parentNode !== sentList) return false;
+                    if (fullElement) {
+                        sentList.replaceChild(fullElement, placeholder);
+                        return true;
+                    }
+                    // renderSentEmailItem returns null when hide_undecryptable is on
+                    // and the row failed to decrypt — drop the placeholder entirely.
+                    sentList.removeChild(placeholder);
+                    return false;
                 } catch (error) {
                     console.error(`[JS] Error rendering email ${email.id}:`, error);
-                    // Return a basic email item even if rendering fails
-                    return this.renderSentEmailItemBasic(email);
+                    // Leave the skeleton placeholder visible so the user still sees the row.
+                    return !!(placeholder && placeholder.parentNode === sentList);
                 }
-            });
-            
-            // Wait for all emails to be rendered (with timeout protection)
-            const renderedItems = await Promise.allSettled(emailPromises);
-            
-            // Add all successfully rendered items to the list (filter out null results)
-            let renderedCount = 0;
-            for (const result of renderedItems) {
-                if (result.status === 'fulfilled' && result.value) {
-                    sentList.appendChild(result.value);
-                    renderedCount++;
-                }
-            }
+            }));
+
+            const renderedCount = replacementResults.reduce(
+                (n, r) => n + (r.status === 'fulfilled' && r.value ? 1 : 0),
+                0
+            );
             
             // Show message if no emails were rendered (only on full render, not append)
             if (renderedCount === 0 && appendFrom <= 0) {
@@ -6835,10 +6851,15 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
         if (hideUndecryptable && !isDecryptable) {
             return null;
         }
-        
-        // Add attachment indicator
-        const attachmentCount = email.attachments ? email.attachments.length : 0;
-        const attachmentIndicator = attachmentCount > 0 ? 
+
+        // Add attachment indicator — prefer attachment_count from the thread query
+        // (cheap COUNT(*) subquery) since the sent list no longer prefetches full
+        // attachment metadata. Fall back to email.attachments.length for any code
+        // path that has already populated the array.
+        const attachmentCount = typeof email.attachment_count === 'number'
+            ? email.attachment_count
+            : (email.attachments ? email.attachments.length : 0);
+        const attachmentIndicator = attachmentCount > 0 ?
             `<span class="attachment-indicator" title="${attachmentCount} attachment${attachmentCount > 1 ? 's' : ''}">📎 ${attachmentCount}</span>` : '';
 
         // Add signature verification indicator
@@ -6967,8 +6988,10 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
             dateDisplay = emailDate.toLocaleDateString();
         }
         
-        const attachmentCount = email.attachments ? email.attachments.length : 0;
-        const attachmentIndicator = attachmentCount > 0 ? 
+        const attachmentCount = typeof email.attachment_count === 'number'
+            ? email.attachment_count
+            : (email.attachments ? email.attachments.length : 0);
+        const attachmentIndicator = attachmentCount > 0 ?
             `<span class="attachment-indicator" title="${attachmentCount} attachment${attachmentCount > 1 ? 's' : ''}">📎 ${attachmentCount}</span>` : '';
 
         // Strict pubkey-bound lookup when recipient_pubkey is set, otherwise

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -4594,7 +4594,13 @@ ${attachmentsHtml}
             // Render messages using same per-email decrypt as single email views
             const keypair = appState.getKeypair();
             const defaultAvatar = 'data:image/svg+xml;base64,' + btoa('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>');
-            let threadSubjectText = threadEmails[0].subject;
+            // For encrypted threads the stored subject of the first message is
+            // ciphertext / a placeholder, so start with "Decrypting…" until a
+            // per-message task lands a real decrypted subject. Cleartext threads
+            // just keep their stored subject as the default.
+            const firstHasArmor = !!(threadEmails[0].body && /-{3,}\s*BEGIN NOSTR (?:NIP-\d+ ENCRYPTED (?:MESSAGE|BODY))\s*-{3,}/.test(threadEmails[0].body));
+            const decryptingPlaceholder = 'Decrypting…';
+            let threadSubjectText = firstHasArmor ? decryptingPlaceholder : threadEmails[0].subject;
             let lastDecryptedSubject = null;
             let lastDecryptedBody = null;
 
@@ -4972,6 +4978,15 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                         this.verifyAndAnnotateSignatureBlocks(displayBody, bodyId);
                     }
                 }));
+
+                // If we showed the "Decrypting…" placeholder but no per-message
+                // task ever produced a decrypted subject (e.g. all decrypts
+                // failed), fall back to the stored subject so the title doesn't
+                // stay stuck on the placeholder.
+                if (earliestDecryptedSubjectIdx === Infinity && threadSubjectText === decryptingPlaceholder) {
+                    threadSubjectText = threadEmails[0].subject;
+                    if (threadSubject) threadSubject.textContent = threadSubjectText;
+                }
 
                 // Close menus on outside click
                 document.addEventListener('click', () => {

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -4630,6 +4630,12 @@ ${attachmentsHtml}
                     return skel;
                 });
 
+                // Default the thread title to the first message's stored subject
+                // so the user has a meaningful header from the moment the view
+                // appears. Per-message tasks below may overwrite this as soon as
+                // any decrypted subject differs from the stored one.
+                if (threadSubject) threadSubject.textContent = threadSubjectText;
+
                 // Yield so the skeletons commit to a paint before we start
                 // the decrypt work below (which can otherwise complete in a
                 // single JS turn on warm caches and skip the skeleton frame).
@@ -4637,11 +4643,18 @@ ${attachmentsHtml}
                     requestAnimationFrame(() => requestAnimationFrame(resolve))
                 );
 
-                // Decrypt + verify all messages in parallel. Each Tauri call is an
-                // independent IPC round-trip into Rust, so running them concurrently
-                // turns a sum-of-latencies into a max-of-latencies. DOM mounting still
-                // happens sequentially below to preserve thread order.
-                const preparedMessages = await Promise.all(threadEmails.map(async (email) => {
+                // Stream cards into place as each message's decrypt finishes,
+                // instead of waiting for the whole batch. Each per-message task
+                // decrypts, builds its card, and replaces its own skeleton.
+                // Shared state (thread subject, last-decrypted reply target) is
+                // updated under index-ordering rules so out-of-order completion
+                // doesn't produce inconsistent results: lower-index decrypts
+                // win the thread subject, only the final message updates the
+                // reply-target snapshot.
+                let earliestDecryptedSubjectIdx = Infinity;
+                const lastIdx = threadEmails.length - 1;
+
+                await Promise.allSettled(threadEmails.map(async (email, idx) => {
                     const isSent = email._isSentByUser;
                     const emailBody = email.body || '';
                     const encryptedMatch = emailBody.replace(/\r\n/g, '\n').match(/-{3,}\s*BEGIN NOSTR (?:NIP-\d+ ENCRYPTED (?:MESSAGE|BODY))\s*-{3,}/);
@@ -4711,20 +4724,22 @@ ${attachmentsHtml}
                         }
                     }
 
-                    return { email, isSent, displayBody, displaySubject, sigResults, blockDecryptResults };
-                }));
-
-                // Track thread subject from the first message whose decrypted subject differs
-                // from the stored one. Done in order so the choice matches pre-parallel behavior.
-                for (const { email, displaySubject } of preparedMessages) {
-                    if (displaySubject && displaySubject !== email.subject && threadSubjectText === threadEmails[0].subject) {
+                    // Update thread subject — first message in order whose
+                    // decrypted subject differs from the stored one wins.
+                    if (displaySubject && displaySubject !== email.subject && idx < earliestDecryptedSubjectIdx) {
+                        earliestDecryptedSubjectIdx = idx;
                         threadSubjectText = displaySubject;
-                        break;
+                        if (threadSubject) threadSubject.textContent = threadSubjectText;
                     }
-                }
 
-                for (let idx = 0; idx < preparedMessages.length; idx++) {
-                    const { email, isSent, displayBody, displaySubject, sigResults, blockDecryptResults } = preparedMessages[idx];
+                    // Track reply target — only meaningful for the most recent
+                    // message; other tasks shouldn't overwrite it.
+                    if (idx === lastIdx) {
+                        lastDecryptedSubject = displaySubject;
+                        lastDecryptedBody = displayBody;
+                    }
+
+                    // ===== Build and mount the full card =====
                     // Resolve contact for avatar. For received messages we use
                     // strict pubkey-only matching via _resolveSender (anti-spoofing).
                     // For sent messages the "sender" is the local user, so email-fallback is fine.
@@ -4956,11 +4971,7 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                         Utils.decorateArmorBlocks(bodyId);
                         this.verifyAndAnnotateSignatureBlocks(displayBody, bodyId);
                     }
-
-                    // Track last email's decrypted content for reply button
-                    lastDecryptedSubject = displaySubject;
-                    lastDecryptedBody = displayBody;
-                }
+                }));
 
                 // Close menus on outside click
                 document.addEventListener('click', () => {
@@ -4969,10 +4980,6 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
 
                 // Scroll to bottom (most recent message)
                 threadContent.scrollTop = threadContent.scrollHeight;
-            }
-
-            if (threadSubject) {
-                threadSubject.textContent = threadSubjectText;
             }
 
             // Mark unread emails as read (fire-and-forget)

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -3567,10 +3567,10 @@ class EmailService {
         // For encrypted emails the stored subject is either ciphertext or a
         // placeholder string; either way it isn't meaningful to display while
         // we wait for decryption. Substitute a clear "Decrypting…" hint for
-        // both the subject and the body preview until the full render lands.
+        // the subject and blank the preview until the full render lands.
         const isEncrypted = !!(email.body && /-{3,}\s*BEGIN NOSTR (?:NIP-\d+ ENCRYPTED (?:MESSAGE|BODY))\s*-{3,}/.test(email.body));
         const subjectText = isEncrypted ? 'Decrypting…' : Utils.escapeHtml(email.subject);
-        const previewText = isEncrypted ? 'Decrypting…' : 'Loading...';
+        const previewText = isEncrypted ? '' : 'Loading...';
 
         emailElement.innerHTML = `
             <img class="${senderInfo.avatarClass}" src="${senderInfo.avatarSrc}" alt="${Utils.escapeHtml(senderInfo.identityName)}'s avatar" onerror="this.onerror=null;this.src='${senderInfo.defaultAvatar}';this.className='contact-avatar';">
@@ -7049,12 +7049,13 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
         }
 
         // For encrypted sent emails the stored subject is ciphertext / a
-        // placeholder and the body is armor — show "Decrypting…" for both
-        // until the full render replaces this skeleton.
+        // placeholder and the body is armor — show "Decrypting…" on the
+        // subject and blank the preview until the full render replaces
+        // this skeleton. Cleartext sent emails keep their body snippet.
         const isEncrypted = !!(email.body && /-{3,}\s*BEGIN NOSTR (?:NIP-\d+ ENCRYPTED (?:MESSAGE|BODY))\s*-{3,}/.test(email.body));
         const subjectText = isEncrypted ? 'Decrypting…' : Utils.escapeHtml(email.subject);
         const previewText = isEncrypted
-            ? 'Decrypting…'
+            ? ''
             : Utils.escapeHtml(email.body ? email.body.substring(0, 100) : '');
 
         emailElement.innerHTML = `

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -3564,6 +3564,14 @@ class EmailService {
         const senderInfo = this._resolveSender(email);
         const senderLine = this._renderSenderLine(senderInfo, '');
 
+        // For encrypted emails the stored subject is either ciphertext or a
+        // placeholder string; either way it isn't meaningful to display while
+        // we wait for decryption. Substitute a clear "Decrypting…" hint for
+        // both the subject and the body preview until the full render lands.
+        const isEncrypted = !!(email.body && /-{3,}\s*BEGIN NOSTR (?:NIP-\d+ ENCRYPTED (?:MESSAGE|BODY))\s*-{3,}/.test(email.body));
+        const subjectText = isEncrypted ? 'Decrypting…' : Utils.escapeHtml(email.subject);
+        const previewText = isEncrypted ? 'Decrypting…' : 'Loading...';
+
         emailElement.innerHTML = `
             <img class="${senderInfo.avatarClass}" src="${senderInfo.avatarSrc}" alt="${Utils.escapeHtml(senderInfo.identityName)}'s avatar" onerror="this.onerror=null;this.src='${senderInfo.defaultAvatar}';this.className='contact-avatar';">
             <div class="email-content">
@@ -3571,8 +3579,8 @@ class EmailService {
                     <div class="email-sender email-list-strong">${senderLine} ${attachmentIndicator}</div>
                     <div class="email-date">${dateDisplay}</div>
                 </div>
-                <div class="email-subject email-list-strong">${Utils.escapeHtml(email.subject)}</div>
-                <div class="email-preview">Loading...</div>
+                <div class="email-subject email-list-strong">${subjectText}</div>
+                <div class="email-preview">${previewText}</div>
             </div>
         `;
 
@@ -7040,6 +7048,15 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
             avatarSrc = recipientContact.picture;
         }
 
+        // For encrypted sent emails the stored subject is ciphertext / a
+        // placeholder and the body is armor — show "Decrypting…" for both
+        // until the full render replaces this skeleton.
+        const isEncrypted = !!(email.body && /-{3,}\s*BEGIN NOSTR (?:NIP-\d+ ENCRYPTED (?:MESSAGE|BODY))\s*-{3,}/.test(email.body));
+        const subjectText = isEncrypted ? 'Decrypting…' : Utils.escapeHtml(email.subject);
+        const previewText = isEncrypted
+            ? 'Decrypting…'
+            : Utils.escapeHtml(email.body ? email.body.substring(0, 100) : '');
+
         emailElement.innerHTML = `
             <img class="${avatarClass}" src="${avatarSrc}" alt="${Utils.escapeHtml(email.to)}'s avatar" onerror="this.onerror=null;this.src='${defaultAvatar}';this.className='contact-avatar';">
             <div class="email-content">
@@ -7047,8 +7064,8 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                     <div class="email-sender email-list-strong">To: ${Utils.escapeHtml(email.to)} ${attachmentIndicator}</div>
                     <div class="email-date">${dateDisplay}</div>
                 </div>
-                <div class="email-subject email-list-strong">${Utils.escapeHtml(email.subject)}</div>
-                <div class="email-preview">${Utils.escapeHtml(email.body ? email.body.substring(0, 100) : '')}</div>
+                <div class="email-subject email-list-strong">${subjectText}</div>
+                <div class="email-preview">${previewText}</div>
             </div>
         `;
         emailElement.addEventListener('click', () => {

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -3088,7 +3088,12 @@ class EmailService {
             // Without this, a warm preview cache lets the full replacement run to
             // completion in the same JS turn as the appendChild loop, and the
             // browser never paints the intermediate "skeleton-only" state.
-            await new Promise(resolve => requestAnimationFrame(resolve));
+            // Double-rAF is the standard idiom: the first rAF callback runs
+            // *before* the next paint, the second runs after it, so by the time
+            // the second resolves the skeleton paint has definitely committed.
+            await new Promise(resolve =>
+                requestAnimationFrame(() => requestAnimationFrame(resolve))
+            );
 
             // Batch-decrypt uncached encrypted emails in a single IPC call
             const uncachedEncrypted = filteredEmails.filter(email => {
@@ -6604,7 +6609,12 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
             // Without this, a warm preview cache lets the full replacement run to
             // completion in the same JS turn as the appendChild loop, and the
             // browser never paints the intermediate "skeleton-only" state.
-            await new Promise(resolve => requestAnimationFrame(resolve));
+            // Double-rAF is the standard idiom: the first rAF callback runs
+            // *before* the next paint, the second runs after it, so by the time
+            // the second resolves the skeleton paint has definitely committed.
+            await new Promise(resolve =>
+                requestAnimationFrame(() => requestAnimationFrame(resolve))
+            );
 
             // Batch-decrypt uncached encrypted sent emails, resolving pubkeys from contact index
             const uncachedEncrypted = filteredEmails.filter(email => {

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -2636,52 +2636,10 @@ class EmailService {
             console.log('[JS] Email filter preference:', emailFilter, 'nostrOnly:', nostrOnly);
             console.log('[JS] Loading emails with offset:', this.inboxOffset, 'pageSize:', pageSize);
             const emails = await TauriService.getDbEmailThreads(pageSize, this.inboxOffset, nostrOnly, userEmail, userPubkey);
-            
-            // Load attachments for each email in parallel with timeout
-            console.log(`[JS] Loading attachments for ${emails.length} inbox emails`);
-            const attachmentPromises = emails.map(async (email) => {
-                try {
-                    // Convert email.id to integer - it might be a string
-                    const emailIdInt = parseInt(email.id);
-                    if (isNaN(emailIdInt)) {
-                        console.warn(`[JS] Email ${email.id} has non-numeric ID, trying to get email by message_id to load attachments`);
-                        // Try to get email by message_id to get the real database ID
-                        if (email.message_id) {
-                            try {
-                                const emailData = await TauriService.getDbEmail(email.message_id);
-                                if (emailData && emailData.id) {
-                                    const realId = parseInt(emailData.id);
-                                    if (!isNaN(realId)) {
-                                        email.attachments = await TauriService.getAttachmentsForEmail(realId);
-                                        console.log(`[JS] Email ${email.id} (message_id: ${email.message_id}, DB ID: ${realId}) has ${email.attachments.length} attachments`);
-                                        return;
-                                    }
-                                }
-                            } catch (e) {
-                                console.error(`[JS] Failed to get email by message_id ${email.message_id}:`, e);
-                            }
-                        }
-                        console.warn(`[JS] Email ${email.id} has non-numeric ID and couldn't resolve, cannot load attachments`);
-                        email.attachments = [];
-                        return;
-                    }
-                    
-                    const timeoutPromise = new Promise((_, reject) => 
-                        setTimeout(() => reject(new Error('Attachment load timeout')), 5000)
-                    );
-                    email.attachments = await Promise.race([
-                        TauriService.getAttachmentsForEmail(emailIdInt),
-                        timeoutPromise
-                    ]);
-                    console.log(`[JS] Email ${email.id} (DB ID: ${emailIdInt}) has ${email.attachments.length} attachments:`, email.attachments);
-                } catch (error) {
-                    console.error(`[JS] Failed to load attachments for email ${email.id}:`, error);
-                    email.attachments = [];
-                }
-            });
-            
-            await Promise.all(attachmentPromises);
-            
+
+            // Attachments are no longer prefetched per-email here. The thread query already
+            // returns `attachment_count` (cheap COUNT(*) subquery) which the list badge uses;
+            // full attachment metadata is lazy-loaded by showEmailDetail when the user clicks in.
             let appendFrom = 0;
             if (append) {
                 // Append new emails to existing ones
@@ -2767,51 +2725,10 @@ class EmailService {
             // Fetch sent emails (where user is sender)
             const userPubkey = keypair ? keypair.public_key : null;
             let emails = await TauriService.getDbSentEmailThreads(pageSize, this.sentOffset, userEmail, userPubkey);
-            
-            // Load attachments for each email in parallel with timeout
-            console.log(`[JS] Loading attachments for ${emails.length} sent emails`);
-            const attachmentPromises = emails.map(async (email) => {
-                try {
-                    // Convert email.id to integer - it might be a string
-                    const emailIdInt = parseInt(email.id);
-                    if (isNaN(emailIdInt)) {
-                        console.warn(`[JS] Email ${email.id} has non-numeric ID, trying to get email by message_id to load attachments`);
-                        // Try to get email by message_id to get the real database ID
-                        if (email.message_id) {
-                            try {
-                                const emailData = await TauriService.getDbEmail(email.message_id);
-                                if (emailData && emailData.id) {
-                                    const realId = parseInt(emailData.id);
-                                    if (!isNaN(realId)) {
-                                        email.attachments = await TauriService.getAttachmentsForEmail(realId);
-                                        console.log(`[JS] Email ${email.id} (message_id: ${email.message_id}, DB ID: ${realId}) has ${email.attachments.length} attachments`);
-                                        return;
-                                    }
-                                }
-                            } catch (e) {
-                                console.error(`[JS] Failed to get email by message_id ${email.message_id}:`, e);
-                            }
-                        }
-                        console.warn(`[JS] Email ${email.id} has non-numeric ID and couldn't resolve, cannot load attachments`);
-                        email.attachments = [];
-                        return;
-                    }
-                    
-                    const timeoutPromise = new Promise((_, reject) => 
-                        setTimeout(() => reject(new Error('Attachment load timeout')), 5000)
-                    );
-                    email.attachments = await Promise.race([
-                        TauriService.getAttachmentsForEmail(emailIdInt),
-                        timeoutPromise
-                    ]);
-                    console.log(`[JS] Email ${email.id} (DB ID: ${emailIdInt}) has ${email.attachments.length} attachments:`, email.attachments);
-                } catch (error) {
-                    console.error(`[JS] Failed to load attachments for email ${email.id}:`, error);
-                    email.attachments = [];
-                }
-            });
-            await Promise.allSettled(attachmentPromises);
-            
+
+            // Attachments are no longer prefetched per-email here. The thread query already
+            // returns `attachment_count` (cheap COUNT(*) subquery) which the list badge uses;
+            // full attachment metadata is lazy-loaded by the sent detail view when the user clicks in.
             let appendFrom = 0;
             if (append) {
                 // Append new emails to existing ones
@@ -3477,8 +3394,12 @@ class EmailService {
             return null;
         }
 
-        // Add attachment indicator (same style as sent emails)
-        const attachmentCount = email.attachments ? email.attachments.length : 0;
+        // Add attachment indicator (same style as sent emails).
+        // Prefer attachment_count from the thread query (cheap COUNT(*) subquery).
+        // Fall back to email.attachments.length when an older code path has already populated it.
+        const attachmentCount = typeof email.attachment_count === 'number'
+            ? email.attachment_count
+            : (email.attachments ? email.attachments.length : 0);
         const attachmentIndicator = attachmentCount > 0 ?
             `<span class="attachment-indicator" title="${attachmentCount} attachment${attachmentCount > 1 ? 's' : ''}">📎 ${attachmentCount}</span>` : '';
 
@@ -3602,7 +3523,9 @@ class EmailService {
             dateDisplay = emailDate.toLocaleDateString();
         }
 
-        const attachmentCount = email.attachments ? email.attachments.length : 0;
+        const attachmentCount = typeof email.attachment_count === 'number'
+            ? email.attachment_count
+            : (email.attachments ? email.attachments.length : 0);
         const attachmentIndicator = attachmentCount > 0 ?
             `<span class="attachment-indicator" title="${attachmentCount} attachment${attachmentCount > 1 ? 's' : ''}">📎 ${attachmentCount}</span>` : '';
 
@@ -3955,14 +3878,28 @@ class EmailService {
                     })();
                 }
                 const updateDetail = async (subject, body, cachedManifestResult, wasDecrypted = false, inlineSigResult = null, decryptResults = null) => {
-                    // Render attachments - decrypt metadata for display
-                    console.log(`[JS] Rendering detail for inbox email ${email.id}, attachments:`, email.attachments);
-                    
-                    // Ensure attachments array exists
-                    if (!email.attachments || !Array.isArray(email.attachments)) {
-                        console.warn(`[JS] Email ${email.id} has no attachments array, initializing empty array`);
-                        email.attachments = [];
+                    // Render attachments - decrypt metadata for display.
+                    // Attachments are no longer prefetched during list load; lazy-load them here
+                    // when the detail view actually needs them. attachment_count from the thread
+                    // query gives a fast path to skip the IPC call entirely when there are none.
+                    if (!Array.isArray(email.attachments)) {
+                        if (email.attachment_count === 0) {
+                            email.attachments = [];
+                        } else {
+                            const emailIdInt = parseInt(email.id);
+                            if (!isNaN(emailIdInt)) {
+                                try {
+                                    email.attachments = await TauriService.getAttachmentsForEmail(emailIdInt);
+                                } catch (err) {
+                                    console.error(`[JS] Failed to lazy-load attachments for email ${email.id}:`, err);
+                                    email.attachments = [];
+                                }
+                            } else {
+                                email.attachments = [];
+                            }
+                        }
                     }
+                    console.log(`[JS] Rendering detail for inbox email ${email.id}, attachments:`, email.attachments);
                     
                     let attachmentsHtml = '';
                     if (email.attachments && email.attachments.length > 0) {
@@ -7362,17 +7299,29 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
         
         // Define updateDetail function first (before it's called)
         const updateDetail = async (subject, body, cachedManifestResult, wasDecrypted = false, inlineSigResult = null, decryptResults = null) => {
-            // Render attachments - decrypt metadata for display
-            console.log(`[JS] Rendering detail for email ${email.id}, attachments:`, email.attachments);
-            console.log(`[JS] Email object:`, email);
-            console.log(`[JS] email.html_body present:`, !!email.html_body, `length:`, email.html_body ? email.html_body.length : 0);
-            console.log(`[JS] Email.attachments type:`, typeof email.attachments, Array.isArray(email.attachments));
-            
-            // Ensure attachments array exists
-            if (!email.attachments || !Array.isArray(email.attachments)) {
-                console.warn(`[JS] Email ${email.id} has no attachments array, initializing empty array`);
-                email.attachments = [];
+            // Render attachments - decrypt metadata for display.
+            // Attachments are no longer prefetched during list load; lazy-load them here
+            // when the detail view actually needs them. attachment_count from the thread
+            // query gives a fast path to skip the IPC call entirely when there are none.
+            if (!Array.isArray(email.attachments)) {
+                if (email.attachment_count === 0) {
+                    email.attachments = [];
+                } else {
+                    const emailIdInt = parseInt(email.id);
+                    if (!isNaN(emailIdInt)) {
+                        try {
+                            email.attachments = await TauriService.getAttachmentsForEmail(emailIdInt);
+                        } catch (err) {
+                            console.error(`[JS] Failed to lazy-load attachments for sent email ${email.id}:`, err);
+                            email.attachments = [];
+                        }
+                    } else {
+                        email.attachments = [];
+                    }
+                }
             }
+            console.log(`[JS] Rendering detail for email ${email.id}, attachments:`, email.attachments);
+            console.log(`[JS] email.html_body present:`, !!email.html_body, `length:`, email.html_body ? email.html_body.length : 0);
             
             // Log attachment details for debugging
             if (email.attachments && email.attachments.length > 0) {

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -4559,6 +4559,14 @@ ${attachmentsHtml}
                 threadContent.innerHTML = '<div class="thread-loading"><i class="fas fa-spinner fa-spin"></i> Loading conversation...</div>';
             }
 
+            // Force the browser to paint the view switch + loading spinner before
+            // we kick off the SQL fetch. Without this, the click handler chains
+            // straight into the await below and the user sees the email list
+            // until the whole thread has been fetched and rendered.
+            await new Promise(resolve =>
+                requestAnimationFrame(() => requestAnimationFrame(resolve))
+            );
+
             // Resolve active account email up front so we can scope the thread query to it
             // (prevents cross-account contamination when multiple accounts share this DB).
             const settings = appState.getSettings();
@@ -4592,6 +4600,42 @@ ${attachmentsHtml}
 
             if (threadContent) {
                 threadContent.innerHTML = '';
+
+                // Paint a skeleton card per message so the user sees the
+                // structure of the conversation immediately (sender + date,
+                // with a "Decrypting…" snippet). Each skeleton is replaced
+                // in place once the parallel decrypt + render below produces
+                // the full card for it.
+                const skeletons = threadEmails.map((email, idx) => {
+                    const skel = document.createElement('div');
+                    const isLast = idx === threadEmails.length - 1;
+                    skel.className = `email-detail-card thread-skeleton${isLast ? '' : ' collapsed'}`;
+                    const timeAgo = Utils.formatTimeAgo(new Date(email.date));
+                    const fromLabel = Utils.escapeHtml(email.from || email.from_address || '');
+                    skel.innerHTML = `
+<div class="email-sender-header">
+<div class="email-sender-row">
+<img class="email-sender-avatar" src="${defaultAvatar}" alt="">
+<div class="email-sender-info">
+<div class="email-sender-name-row">
+<div class="email-sender-name">${fromLabel}</div>
+<span class="email-body-snippet">Decrypting…</span>
+<div class="email-sender-time">${Utils.escapeHtml(timeAgo)}</div>
+</div>
+</div>
+</div>
+</div>
+                    `;
+                    threadContent.appendChild(skel);
+                    return skel;
+                });
+
+                // Yield so the skeletons commit to a paint before we start
+                // the decrypt work below (which can otherwise complete in a
+                // single JS turn on warm caches and skip the skeleton frame).
+                await new Promise(resolve =>
+                    requestAnimationFrame(() => requestAnimationFrame(resolve))
+                );
 
                 // Decrypt + verify all messages in parallel. Each Tauri call is an
                 // independent IPC round-trip into Rust, so running them concurrently
@@ -4679,7 +4723,8 @@ ${attachmentsHtml}
                     }
                 }
 
-                for (const { email, isSent, displayBody, displaySubject, sigResults, blockDecryptResults } of preparedMessages) {
+                for (let idx = 0; idx < preparedMessages.length; idx++) {
+                    const { email, isSent, displayBody, displaySubject, sigResults, blockDecryptResults } = preparedMessages[idx];
                     // Resolve contact for avatar. For received messages we use
                     // strict pubkey-only matching via _resolveSender (anti-spoofing).
                     // For sent messages the "sender" is the local user, so email-fallback is fine.
@@ -4805,7 +4850,14 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
 <div class="email-detail-body" id="${bodyId}">${email.html_body ? '' : Utils.escapeHtml(displayBody).replace(/\n/g, '<br>')}</div>
 <pre class="email-raw-content email-raw-body" style="display:none">${Utils.escapeHtml(email.raw_body || '')}${email.html_body ? '\n\n--- text/html ---\n\n' + Utils.escapeHtml(email.html_body) : ''}</pre>
                     `;
-                    threadContent.appendChild(cardDiv);
+                    // Swap the skeleton placeholder for the fully rendered card.
+                    // If the skeleton was already removed (defensive), fall back to append.
+                    const skeleton = skeletons[idx];
+                    if (skeleton && skeleton.parentNode === threadContent) {
+                        threadContent.replaceChild(cardDiv, skeleton);
+                    } else {
+                        threadContent.appendChild(cardDiv);
+                    }
 
                     // Collapse all cards except the last (most recent)
                     const isLastEmail = (email === threadEmails[threadEmails.length - 1]);

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -2565,7 +2565,7 @@ class EmailService {
                     const hash = this._subjectCiphertext
                         ? await this.hashStringSHA256(this._subjectCiphertext)
                         : null;
-                    await window.__TAURI__.core.invoke('db_save_sent_email_stub', {
+                    const savedEmailId = await window.__TAURI__.core.invoke('db_save_sent_email_stub', {
                         messageId,
                         fromAddress: emailConfig.email_address,
                         toAddress: recipientEmail,
@@ -2578,7 +2578,37 @@ class EmailService {
                         inReplyTo: this._replyToMessageId || null,
                         references: this._replyReferences || null,
                     });
-                    console.log('[JS] Saved sent-email stub for message_id:', messageId);
+                    console.log('[JS] Saved sent-email stub for message_id:', messageId, 'id:', savedEmailId);
+
+                    // Persist attachment rows linked to the just-saved email so
+                    // the sent list's attachment_count subquery returns the right
+                    // number immediately (without waiting for an IMAP sync of the
+                    // Sent folder to bring the attachments back from the server).
+                    if (savedEmailId && Array.isArray(attachmentData) && attachmentData.length > 0) {
+                        const nowIso = new Date().toISOString();
+                        for (const att of attachmentData) {
+                            try {
+                                await TauriService.saveAttachment({
+                                    id: null,
+                                    email_id: savedEmailId,
+                                    filename: att.filename,
+                                    content_type: att.content_type,
+                                    data: att.data,
+                                    size: att.size,
+                                    is_encrypted: att.is_encrypted,
+                                    encryption_method: att.encryption_method,
+                                    algorithm: att.algorithm,
+                                    original_filename: att.original_filename,
+                                    original_type: att.original_type,
+                                    original_size: att.original_size,
+                                    created_at: nowIso,
+                                });
+                            } catch (attErr) {
+                                console.warn('[JS] Failed to save attachment row for sent email:', attErr);
+                            }
+                        }
+                        console.log(`[JS] Saved ${attachmentData.length} attachment row(s) for sent email id=${savedEmailId}`);
+                    }
                 } catch (e) {
                     console.warn('[JS] Failed to save sent-email stub:', e);
                 }

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -3280,7 +3280,7 @@ class EmailService {
                 emailList.appendChild(loadMoreBtn);
             }
 
-            console.log(`[JS] renderEmails: Successfully rendered ${renderedItems.filter(r => r.status === 'fulfilled').length} emails`);
+            console.log(`[JS] renderEmails: Successfully rendered ${renderedCount} emails`);
         } catch (error) {
             console.error('Error rendering emails:', error);
         }
@@ -6752,7 +6752,7 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
                 sentList.appendChild(loadMoreBtn);
             }
             
-            console.log(`[JS] renderSentEmails: Successfully rendered ${renderedItems.filter(r => r.status === 'fulfilled').length} emails`);
+            console.log(`[JS] renderSentEmails: Successfully rendered ${renderedCount} emails`);
         } catch (error) {
             console.error('[JS] Error in renderSentEmails:', error);
             sentList.innerHTML = '<div class="text-center text-muted">Error loading sent emails</div>';

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -4553,7 +4553,12 @@ ${attachmentsHtml}
 
             if (threadContent) {
                 threadContent.innerHTML = '';
-                for (const email of threadEmails) {
+
+                // Decrypt + verify all messages in parallel. Each Tauri call is an
+                // independent IPC round-trip into Rust, so running them concurrently
+                // turns a sum-of-latencies into a max-of-latencies. DOM mounting still
+                // happens sequentially below to preserve thread order.
+                const preparedMessages = await Promise.all(threadEmails.map(async (email) => {
                     const isSent = email._isSentByUser;
                     const emailBody = email.body || '';
                     const encryptedMatch = emailBody.replace(/\r\n/g, '\n').match(/-{3,}\s*BEGIN NOSTR (?:NIP-\d+ ENCRYPTED (?:MESSAGE|BODY))\s*-{3,}/);
@@ -4623,11 +4628,19 @@ ${attachmentsHtml}
                         }
                     }
 
-                    // Track thread subject from first successful decrypt
+                    return { email, isSent, displayBody, displaySubject, sigResults, blockDecryptResults };
+                }));
+
+                // Track thread subject from the first message whose decrypted subject differs
+                // from the stored one. Done in order so the choice matches pre-parallel behavior.
+                for (const { email, displaySubject } of preparedMessages) {
                     if (displaySubject && displaySubject !== email.subject && threadSubjectText === threadEmails[0].subject) {
                         threadSubjectText = displaySubject;
+                        break;
                     }
+                }
 
+                for (const { email, isSent, displayBody, displaySubject, sigResults, blockDecryptResults } of preparedMessages) {
                     // Resolve contact for avatar. For received messages we use
                     // strict pubkey-only matching via _resolveSender (anti-spoofing).
                     // For sent messages the "sender" is the local user, so email-fallback is fine.

--- a/tauri-app/frontend/js/tauri-service.js
+++ b/tauri-app/frontend/js/tauri-service.js
@@ -629,16 +629,17 @@ const TauriService = {
         return await this.invoke('parse_armor_message', { armorText });
     },
 
-    decryptEmailBody: async function(armorText, subject, senderPubkey, recipientPubkey) {
+    decryptEmailBody: async function(armorText, subject, senderPubkey, recipientPubkey, messageId) {
         return await this.invoke('decrypt_email_body', {
             armorText, subject,
             senderPubkey: senderPubkey || null,
             recipientPubkey: recipientPubkey || null,
+            messageId: messageId || null,
         });
     },
 
     // Batch decrypt multiple email bodies in a single IPC call.
-    // `emails` is an array of { id, armorText, subject, senderPubkey, recipientPubkey }.
+    // `emails` is an array of { id, armorText, subject, senderPubkey, recipientPubkey, messageId? }.
     // Returns an array of { id, result, error } in the same order.
     decryptEmailBodiesBatch: async function(emails) {
         return await this.invoke('decrypt_email_bodies_batch', { emails });


### PR DESCRIPTION
## Summary

End-to-end performance work on the email rendering pipeline. The worst-case message we profiled (a 4 KB, 3-level nested reply) went from **~3000 ms perceived** down to **~2 ms on reload** (≈1500× faster on the warm path, ≈10× on cold), and the inbox/conversation UI now paints progressively instead of blocking.

The work spans three layers:

**Frontend (JS) — progressive rendering**
- Inbox / sent list lazy-load attachments via a new `attachment_count` column instead of N IPC round-trips per page; skeleton rows paint immediately and are upgraded in place as each row's render resolves (double-rAF yield ensures the skeleton frame actually paints).
- Encrypted skeletons show `Decrypting…` on the subject line so the raw armor / ciphertext placeholder never flashes.
- Conversation view switches immediately on click, paints one skeleton card per message, then streams each card in as its own decrypt completes (out-of-order safe — shared state like thread subject and reply target use index-ordering rules). Subject in the header also starts as `Decrypting…` until the earliest-index decrypt completes.
- Two unrelated bugs fixed in passing: `renderedItems` ReferenceError that wiped the sent list after rendering, and a `this.getSelectedContact()` typo in `contacts-service.js`.

**Backend (Rust) — decrypt pipeline caching**
- `glossia` submodule bumped to `553e775` which caches `WordlistTree::new` per `(language, wordlist)` — the build-once tree was being rebuilt ~tens of ms per call.
- `parse_armor_components` cache keyed by hash of normalized armor text; on first parse the resulting tree is walked and each nested level is pre-populated so `verify_all_signatures`' recursive parse calls hit cache too.
- Process-wide cache for `glossia::detect_dialect_best` + `glossia::decode_from_language` results — the same body text was being decoded ~6× per message across decrypt / `extract_ciphertext_binary` / `verify_all_signatures`.
- Process-wide cache for `glossia_decode_subject` keyed by `(subject, nip_hint)`.
- For NIP-44 specifically, skip the eager `decode_armor_section` inside `populate_armor_from_text` — the pre-decoded ciphertext bytes are only consumed by NIP-04 signature verification.
- All caches soft-capped at 10k entries with ~25% random eviction on overflow.

**Backend (Rust) — DB changes**
- `EmailThreadSummary` gets `attachment_count` (correlated COUNT(*) subquery in `get_email_threads` / `get_sent_email_threads`).

**Logging**
- The verbose `[RUST] ...` logs in the decrypt hot path are now gated behind a `NOSTR_MAIL_DEBUG` env var (silent by default, OnceLock-cached bool check). `[RUST-PERF]` lines remain on so profiling info is always visible.

## Profile data on the test thread

3-message NIP-44 reply chain (4 KB outermost message, 3 levels of nested armor):

| msg | armor | original | first open (this PR) | reload (this PR) |
|---|---|---|---|---|
| 1 | 1442 b | 231 ms | 104 ms | 1 ms |
| 2 | 2689 b | 522 ms | 169 ms | 2 ms |
| 3 | 4149 b | 585 ms (3026 ms perceived) | 2-200 ms | 2 ms |

(msg 3 on first open is often a cache hit because the inbox preview pass populates the parse + decode caches before the conversation is opened.)

## Test plan

- [x] Open inbox — skeleton rows visible immediately, attachment paperclip counts correct, previews fill in.
- [x] Open sent — same.
- [x] Click into a long encrypted reply chain — view switches instantly, "Decrypting…" subject placeholder visible until first decrypt lands, cards stream in.
- [x] Click back, reopen the same thread — should be near-instant.
- [x] Open an email with attachments — paperclip count matches actual attachments; clicking opens detail with all attachments visible.
- [x] Confirm NIP-04 emails still decrypt + verify correctly (the NIP-44 gate in `populate_armor_from_text` only skips the eager decode for NIP-44).
- [x] Set `NOSTR_MAIL_DEBUG=1` and confirm the verbose `[RUST]` logs come back for diagnostic builds.
- [ ] Sanity-check memory behavior on a large inbox (the cache cap is 10k entries; eviction kicks in past that).

https://claude.ai/code/session_012NMTCqFkVq3h4ADPtGKJAr

---
_Generated by [Claude Code](https://claude.ai/code/session_012NMTCqFkVq3h4ADPtGKJAr)_