### PR TITLE
DM/email decode performance + glossia integration cleanup

### DIFF
--- a/tauri-app/backend/src/database.rs
+++ b/tauri-app/backend/src/database.rs
@@ -92,6 +92,18 @@ pub struct DbConversation {
     pub cached_at: DateTime<Utc>,
 }
 
+/// One-row-per-contact summary for the DM contact list. Carries just the
+/// latest message (still encrypted) plus a total count, so the contact list
+/// can render without fetching+decrypting every message of every conversation.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DmConversationPreview {
+    pub contact_pubkey: String,
+    pub last_event_id: String,
+    pub last_content: String,
+    pub last_created_at: DateTime<Utc>,
+    pub message_count: i64,
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct UserSettings {
@@ -2569,6 +2581,136 @@ impl Database {
         })?;
 
         rows.collect()
+    }
+
+    /// Paginated fetch of a conversation, newest-first internally but returned
+    /// oldest→newest (ASC) so callers can append a page directly.
+    ///
+    /// Fetches at most `limit` messages. When `before` is `Some((created_at, id))`
+    /// only messages strictly older than that cursor are returned — the cursor is
+    /// the oldest message currently held by the caller. The `(created_at, id)` pair
+    /// is used as a compound key so messages sharing a `created_at` (second-
+    /// granularity) page cleanly without gaps or duplicates.
+    pub fn get_dms_for_conversation_page(
+        &self,
+        user_pubkey: &str,
+        contact_pubkey: &str,
+        limit: i64,
+        before: Option<(DateTime<Utc>, i64)>,
+    ) -> Result<Vec<DirectMessage>> {
+        let conn = self.conn.lock().unwrap();
+        let map_row = |row: &rusqlite::Row| -> rusqlite::Result<DirectMessage> {
+            Ok(DirectMessage {
+                id: Some(row.get(0)?),
+                event_id: row.get(1)?,
+                sender_pubkey: row.get(2)?,
+                recipient_pubkey: row.get(3)?,
+                content: row.get(4)?,
+                created_at: row.get(5)?,
+                received_at: row.get(6)?,
+                email_message_id: row.get(7)?,
+                received_from_relay: row.get(8)?,
+            })
+        };
+
+        let mut messages: Vec<DirectMessage> = match before {
+            None => {
+                let mut stmt = conn.prepare(
+                    "SELECT id, event_id, sender_pubkey, recipient_pubkey, content, created_at, received_at, email_message_id, received_from_relay
+                     FROM direct_messages
+                     WHERE (sender_pubkey = ?1 AND recipient_pubkey = ?2) OR (sender_pubkey = ?2 AND recipient_pubkey = ?1)
+                     ORDER BY created_at DESC, id DESC
+                     LIMIT ?3"
+                )?;
+                let rows = stmt.query_map(params![user_pubkey, contact_pubkey, limit], map_row)?;
+                rows.collect::<Result<Vec<_>>>()?
+            }
+            Some((cursor_created_at, cursor_id)) => {
+                let mut stmt = conn.prepare(
+                    "SELECT id, event_id, sender_pubkey, recipient_pubkey, content, created_at, received_at, email_message_id, received_from_relay
+                     FROM direct_messages
+                     WHERE ((sender_pubkey = ?1 AND recipient_pubkey = ?2) OR (sender_pubkey = ?2 AND recipient_pubkey = ?1))
+                       AND (created_at < ?3 OR (created_at = ?3 AND id < ?4))
+                     ORDER BY created_at DESC, id DESC
+                     LIMIT ?5"
+                )?;
+                let rows = stmt.query_map(
+                    params![user_pubkey, contact_pubkey, cursor_created_at, cursor_id, limit],
+                    map_row,
+                )?;
+                rows.collect::<Result<Vec<_>>>()?
+            }
+        };
+
+        // Query is newest-first for the LIMIT to grab the most recent page;
+        // flip to chronological order for rendering.
+        messages.reverse();
+        Ok(messages)
+    }
+
+    /// One row per contact: the latest message (still encrypted) and a total
+    /// message count, ordered most-recent-conversation first. Lets the contact
+    /// list render without fetching+decrypting entire conversations.
+    pub fn get_dm_conversation_previews(&self, user_pubkey: &str) -> Result<Vec<DmConversationPreview>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT contact_pubkey, event_id, content, created_at, msg_count FROM (
+               SELECT
+                 CASE WHEN sender_pubkey = ?1 THEN recipient_pubkey ELSE sender_pubkey END AS contact_pubkey,
+                 event_id, content, created_at, id,
+                 COUNT(*) OVER (
+                   PARTITION BY CASE WHEN sender_pubkey = ?1 THEN recipient_pubkey ELSE sender_pubkey END
+                 ) AS msg_count,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY CASE WHEN sender_pubkey = ?1 THEN recipient_pubkey ELSE sender_pubkey END
+                   ORDER BY created_at DESC, id DESC
+                 ) AS rn
+               FROM direct_messages
+               WHERE sender_pubkey = ?1 OR recipient_pubkey = ?1
+             )
+             WHERE rn = 1 AND contact_pubkey != ''
+             ORDER BY created_at DESC"
+        )?;
+        let rows = stmt.query_map(params![user_pubkey], |row| {
+            Ok(DmConversationPreview {
+                contact_pubkey: row.get(0)?,
+                last_event_id: row.get(1)?,
+                last_content: row.get(2)?,
+                last_created_at: row.get(3)?,
+                message_count: row.get(4)?,
+            })
+        })?;
+        rows.collect()
+    }
+
+    /// Contacts whose conversation contains at least one DM that matches a stored
+    /// email. Mirrors `db_check_dm_matches_email_encrypted`: a match is either a
+    /// NIP-17 message-id link (dm.email_message_id ↔ emails.message_id) or the
+    /// content-hash fallback (dm.content_hash ↔ emails.subject_hash). Computed in
+    /// one query so the contact list doesn't probe every message individually.
+    pub fn get_dm_pubkeys_with_email_match(&self, user_pubkey: &str) -> Result<Vec<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT contact_pubkey FROM (
+               SELECT CASE WHEN dm.sender_pubkey = ?1 THEN dm.recipient_pubkey ELSE dm.sender_pubkey END AS contact_pubkey
+               FROM direct_messages dm
+               WHERE (dm.sender_pubkey = ?1 OR dm.recipient_pubkey = ?1)
+                 AND (
+                   (dm.email_message_id IS NOT NULL AND dm.email_message_id != ''
+                    AND EXISTS (SELECT 1 FROM emails e WHERE e.message_id = dm.email_message_id))
+                   OR
+                   (dm.content_hash IS NOT NULL
+                    AND EXISTS (SELECT 1 FROM emails e WHERE e.subject_hash = dm.content_hash AND e.is_nostr_encrypted = 1))
+                 )
+             )
+             WHERE contact_pubkey != ''"
+        )?;
+        let rows = stmt.query_map(params![user_pubkey], |row| row.get(0))?;
+        let mut pubkeys = Vec::new();
+        for row in rows {
+            pubkeys.push(row?);
+        }
+        Ok(pubkeys)
     }
 
     // Returns the latest created_at timestamp from direct_messages, or None if no messages exist

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -16,8 +16,9 @@ use std::net::TcpStream;
 
 // Verbose [RUST] logs in the decrypt hot path are silent by default — set the
 // NOSTR_MAIL_DEBUG environment variable to any value to re-enable them for
-// diagnostics. [RUST-PERF] lines (regular println!) remain on so profiling
-// info is always available.
+// diagnostics. [RUST-PERF] profiling lines are gated behind the same variable
+// (via debug_log!), so they're off in normal use and only printed when
+// NOSTR_MAIL_DEBUG is set.
 fn debug_log_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var("NOSTR_MAIL_DEBUG").is_ok())
@@ -1767,7 +1768,7 @@ pub fn parse_armor_components(armor_text: &str) -> Option<crate::types::ParsedAr
 
     let cache_map = PARSE_ARMOR_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
     if let Some(cached) = cache_map.lock().unwrap().get(&cache_key) {
-        println!("[RUST-PERF] parse_armor cache HIT key={:x} (in={}b, has_quoted={})",
+        debug_log!("[RUST-PERF] parse_armor cache HIT key={:x} (in={}b, has_quoted={})",
             cache_key, armor_text.len(), cached.quoted.is_some());
         return Some(cached.clone());
     }
@@ -1798,7 +1799,7 @@ pub fn parse_armor_components(armor_text: &str) -> Option<crate::types::ParsedAr
     debug_log!("[RUST] parse_armor_components: success body_type={} nip={:?} has_sig={} has_seal={} has_quoted={}",
         result.body_type, result.encryption_nip, result.signature_hex.is_some(),
         result.seal_pubkey_hex.is_some(), result.quoted.is_some());
-    println!("[RUST-PERF] parse_armor cache MISS key={:x} compute={}ms (in={}b, has_quoted={})",
+    debug_log!("[RUST-PERF] parse_armor cache MISS key={:x} compute={}ms (in={}b, has_quoted={})",
         cache_key, perf.elapsed().as_millis(), armor_text.len(), result.quoted.is_some());
 
     // Insert outer + each nested level under its own hash key so
@@ -2261,7 +2262,7 @@ fn glossia_detect_and_decode_cached(text: &str) -> Option<GlossiaDecodeCached> {
     let cache = GLOSSIA_DECODE_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
     if let Some(entry) = cache.lock().unwrap().get(&key) {
-        println!("[RUST-PERF] glossia cache HIT key={:x} (in={}b, dialect={}/{}, out={}b)",
+        debug_log!("[RUST-PERF] glossia cache HIT key={:x} (in={}b, dialect={}/{}, out={}b)",
             key, text.len(), entry.language, entry.wordlist, entry.decoded.len());
         return Some(entry.clone());
     }
@@ -2294,7 +2295,7 @@ fn glossia_detect_and_decode_cached(text: &str) -> Option<GlossiaDecodeCached> {
         decoded,
         hit_rate: best.hit_rate,
     };
-    println!("[RUST-PERF] glossia cache MISS key={:x} compute={}ms (in={}b, words={}, dialect={}/{}, out={}b, hit_rate={:.3})",
+    debug_log!("[RUST-PERF] glossia cache MISS key={:x} compute={}ms (in={}b, words={}, dialect={}/{}, out={}b, hit_rate={:.3})",
         key, perf.elapsed().as_millis(), text.len(), words.len(),
         entry.language, entry.wordlist, entry.decoded.len(), entry.hit_rate);
     {
@@ -2421,7 +2422,7 @@ fn glossia_decode_subject(subject: &str, nip_hint: &str) -> Option<String> {
     let key = hash_subject(subject, nip_hint);
     let cache = GLOSSIA_SUBJECT_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
     if let Some(cached) = cache.lock().unwrap().get(&key) {
-        println!("[RUST-PERF] glossia subject cache HIT key={:x} (in={}b, nip={})",
+        debug_log!("[RUST-PERF] glossia subject cache HIT key={:x} (in={}b, nip={})",
             key, subject.len(), nip_hint);
         return cached.clone();
     }
@@ -2689,7 +2690,7 @@ fn decrypt_single_block(
         }
     };
     let nip_decrypt_ms = perf_nip.elapsed().as_millis();
-    println!("[RUST-PERF] decrypt_single_block: nip={} glossia={}ms (ct={}b) nip_decrypt={}ms (out={}b)",
+    debug_log!("[RUST-PERF] decrypt_single_block: nip={} glossia={}ms (ct={}b) nip_decrypt={}ms (out={}b)",
         nip, glossia_ms, ciphertext_len, nip_decrypt_ms, decrypted.len());
 
     // Step 4: Detect manifest vs legacy
@@ -2902,7 +2903,7 @@ fn decrypt_armor_tree(
                 body_type: "encrypted".to_string(),
             });
             let sig_ms_reject = perf_sig.elapsed().as_millis();
-            println!("[RUST-PERF] decrypt_armor_tree depth={} body_len={}b nip={:?} inner={}ms sig_verify={}ms (verify_bytes={}b) decrypt_block=SKIPPED(sig fail) total={}ms",
+            debug_log!("[RUST-PERF] decrypt_armor_tree depth={} body_len={}b nip={:?} inner={}ms sig_verify={}ms (verify_bytes={}b) decrypt_block=SKIPPED(sig fail) total={}ms",
                 depth, parsed.body_text.len(), parsed.encryption_nip.as_deref(),
                 inner_ms, sig_ms_reject, sig_verify_bytes_len,
                 perf_level.elapsed().as_millis());
@@ -2930,7 +2931,7 @@ fn decrypt_armor_tree(
     }
     results.push(block);
 
-    println!("[RUST-PERF] decrypt_armor_tree depth={} body_len={}b nip={:?} inner={}ms sig_verify={}ms (verify_bytes={}b) decrypt_block={}ms total={}ms",
+    debug_log!("[RUST-PERF] decrypt_armor_tree depth={} body_len={}b nip={:?} inner={}ms sig_verify={}ms (verify_bytes={}b) decrypt_block={}ms total={}ms",
         depth, parsed.body_text.len(), parsed.encryption_nip.as_deref(),
         inner_ms, sig_verify_ms, sig_verify_bytes_len, block_ms,
         perf_level.elapsed().as_millis());
@@ -3072,7 +3073,7 @@ pub fn decrypt_email_body_pipeline(
     debug_log!("[RUST] decrypt_email_body: success={} is_manifest={} blocks={} attachments={} armor_sender_pubkey={:?}",
         success, is_manifest, block_results.len(), attachments.len(),
         armor_sender_pubkey.as_deref().map(|s: &str| &s[..std::cmp::min(s.len(), 20)]));
-    println!("[RUST-PERF] decrypt_email_body_pipeline: total={}ms parse={}ms derive_pk={}ms tree={}ms subject={}ms sender_extract={}ms (armor_len={}b, levels={})",
+    debug_log!("[RUST-PERF] decrypt_email_body_pipeline: total={}ms parse={}ms derive_pk={}ms tree={}ms subject={}ms sender_extract={}ms (armor_len={}b, levels={})",
         perf_total.elapsed().as_millis(), parse_ms, derive_pk_ms, tree_ms, subject_ms, sender_extract_ms,
         armor_text.len(), block_results.len());
 

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -1356,26 +1356,42 @@ fn extract_armor_body_content(body: &str) -> Option<&str> {
 /// `decode_from_language` path used by `try_glossia_decode_to_bytes`
 /// assumes a leading bitpack header word and is wrong for raw fixed
 /// payloads (it round-trips by luck for high-entropy inputs).
-fn try_decode_raw_base_n_fixed(text: &str, expected_bytes: usize) -> Option<Vec<u8>> {
-    use std::collections::HashSet;
+/// The only (language, wordlist) pairs nostr-mail ever emits as `bitpack_fixed`
+/// raw payloads — Latin and English-BIP39 (see `glossia_roundtrip_to_bytes`'s
+/// encoding map and the per-field `glossia_encoding_*` settings). `detect_dialect`
+/// will otherwise also propose large *cover-word* vocabularies (e.g.
+/// `english/lemmas`, `english/ngram` — 2^17 words each) because the Latin payload
+/// words incidentally overlap them, but those are never valid payload encodings
+/// here. Probing them cost a ~50ms cold `WordlistTree` build each (the "190ms
+/// decode_sig_and_pubkey" outlier) for a tree no nostr-mail payload is encoded
+/// against. We feed this allowlist to `glossia::detect_dialect_with`, which drops
+/// non-allowed wordlists *before* its binary searches (glossia #14).
+const PAYLOAD_WORDLISTS: &[(&str, &str)] = &[("latin", "default"), ("english", "bip39")];
 
+fn try_decode_raw_base_n_fixed(text: &str, expected_bytes: usize) -> Option<Vec<u8>> {
     let words: Vec<String> = text.split_whitespace().map(|w| w.to_lowercase()).collect();
     if words.is_empty() {
         return None;
     }
 
-    let candidates = glossia::detect_dialect(&words);
+    let mut filter = glossia::DialectFilter::new();
+    for (language, wordlist) in PAYLOAD_WORDLISTS {
+        filter = filter.allow_wordlist(*language, *wordlist);
+    }
+    let candidates = glossia::detect_dialect_with(&words, &filter);
     if candidates.is_empty() {
         return None;
     }
 
     for cand in candidates {
-        let payload_words = match glossia::load_payload_words_for_wordlist(&cand.language, &cand.wordlist) {
-            Ok(w) => w,
+        // Shared, process-wide-cached tree (glossia #12) — built at most once per
+        // dialect across glossia's encode pipeline and our decode path. Its
+        // internal index is already lowercased, so `contains()` IS the membership
+        // check; no separate payload set is needed.
+        let payload_tree = match glossia::cached_payload_tree(&cand.language, &cand.wordlist) {
+            Ok(t) => t,
             Err(_) => continue,
         };
-        let payload_tree = glossia::WordlistTree::new(payload_words.clone());
-        let payload_set: HashSet<String> = payload_words.iter().map(|w| w.to_lowercase()).collect();
 
         // Normalize every input token the same way (lowercase, strip leading/trailing
         // non-alphanumerics, drop empties), then split into kept-vs-dropped against
@@ -1387,7 +1403,7 @@ fn try_decode_raw_base_n_fixed(text: &str, expected_bytes: usize) -> Option<Vec<
             .collect();
         let extracted: Vec<String> = all_tokens
             .iter()
-            .filter(|w| payload_set.contains(w.as_str()))
+            .filter(|w| payload_tree.contains(w.as_str()))
             .cloned()
             .collect();
 
@@ -1779,15 +1795,19 @@ pub fn parse_armor_components(armor_text: &str) -> Option<crate::types::ParsedAr
     let perf = std::time::Instant::now();
 
     // Build the capnp ArmorMessage — this is the parsing target
+    let perf_populate = std::time::Instant::now();
     let mut capnp_msg = ::capnp::message::Builder::new_default();
     let (prefix_text, raw_quoted_text) = {
         let armor_builder = capnp_msg.init_root::<nostr_mail_capnp::armor_message::Builder>();
         populate_armor_from_text(armor_builder, &normalized)?
     };
+    let populate_ms = perf_populate.elapsed().as_millis();
 
     // Read the capnp message → serde struct (all fields derived from capnp)
+    let perf_serde = std::time::Instant::now();
     let reader = capnp_msg.get_root_as_reader::<nostr_mail_capnp::armor_message::Reader>().ok()?;
     let mut result = armor_message_to_serde(reader);
+    let serde_ms = perf_serde.elapsed().as_millis();
     result.prefix_text = prefix_text;
     // Override quoted_armor_text with the verbatim text from the input (the capnp
     // encoded_content field only stores the inner body text, losing delimiters,
@@ -1804,12 +1824,23 @@ pub fn parse_armor_components(armor_text: &str) -> Option<crate::types::ParsedAr
 
     // Insert outer + each nested level under its own hash key so
     // verify_all_signatures' recursive parse calls hit cache as well.
+    let perf_subtree = std::time::Instant::now();
     {
         let mut guard = cache_map.lock().unwrap();
         maybe_evict(&mut guard);
         guard.insert(cache_key, result.clone());
         populate_parse_subtree_cache(&result, &mut guard);
     }
+    let subtree_ms = perf_subtree.elapsed().as_millis();
+
+    // Sub-phase breakdown of the parse_armor cache-miss path. Lets us localize the
+    // ~500ms baseline: populate = text state machine + capnp build, serde =
+    // capnp→struct conversion (incl. NIP-04 glossia decode, deferred for NIP-44),
+    // subtree_cache = recursive clone of nested levels into the parse cache.
+    debug_log!("[RUST-PERF] parse_armor breakdown key={:x} total={}ms = populate={}ms + serde={}ms + subtree_cache={}ms (in={}b, normalized={}b, body={}b, nip={:?}, has_quoted={})",
+        cache_key, perf.elapsed().as_millis(), populate_ms, serde_ms, subtree_ms,
+        armor_text.len(), normalized.len(), result.body_text.len(),
+        result.encryption_nip, result.quoted.is_some());
 
     Some(result)
 }
@@ -1999,7 +2030,15 @@ fn populate_armor_from_text(
         let all_content = content_lines.join("\n").trim().to_string();
         if !all_content.is_empty() {
             sig_builder.set_encoded_sig_pubkey(&all_content);
-            if let Some((sig_hex, pubkey_hex)) = decode_sig_and_pubkey(&all_content) {
+            // Time the signature-block decode in isolation. Suspected to dominate
+            // the parse "populate" phase: decode_sig_and_pubkey can build a fresh
+            // 32k-word WordlistTree per attempt (try_decode_as_pubkey /
+            // try_decode_as_signature / try_decode_raw_base_n_fixed) with no cache.
+            let perf_sig_decode = std::time::Instant::now();
+            let decoded_sig = decode_sig_and_pubkey(&all_content);
+            debug_log!("[RUST-PERF] populate: decode_sig_and_pubkey={}ms (sig_content={}b, lines={})",
+                perf_sig_decode.elapsed().as_millis(), all_content.len(), content_lines.len());
+            if let Some((sig_hex, pubkey_hex)) = decoded_sig {
                 if let Ok(sig_bytes) = hex::decode(&sig_hex) {
                     sig_builder.set_signature(&sig_bytes);
                 }
@@ -2948,6 +2987,13 @@ pub fn decrypt_email_body_pipeline(
     sender_pubkey: Option<&str>,
     recipient_pubkey: Option<&str>,
     raw_headers: Option<&str>,
+    // When true, decrypt only the most recent (outermost) message and skip the
+    // quoted thread history. DM conversation rendering uses this: the inline body
+    // shows just the latest message (the full thread is reachable via the
+    // envelope icon), so decrypting nested quoted levels is wasted work the UI
+    // discards. No-op for NIP-04, whose signature is computed over the outer body
+    // PLUS all nested quoted bytes — see the gate where `parsed.quoted` is cleared.
+    shallow: bool,
 ) -> Result<crate::types::DecryptEmailResult, String> {
     let perf_total = std::time::Instant::now();
     debug_log!("[RUST] decrypt_email_body: armor_len={} subject_len={}", armor_text.len(), subject.len());
@@ -2957,7 +3003,7 @@ pub fn decrypt_email_body_pipeline(
 
     // Parse armor into capnp ArmorMessage → serde struct
     let perf_parse = std::time::Instant::now();
-    let parsed = match parse_armor_components(&normalized) {
+    let mut parsed = match parse_armor_components(&normalized) {
         Some(p) => p,
         None => {
             debug_log!("[RUST] decrypt_email_body: no armor found");
@@ -2975,6 +3021,15 @@ pub fn decrypt_email_body_pipeline(
         }
     };
     let parse_ms = perf_parse.elapsed().as_millis();
+
+    // Shallow mode: discard the quoted subtree so decrypt_armor_tree won't
+    // recurse into thread history the caller won't display. Skipped for NIP-04,
+    // where the signature is verified over the outer body PLUS all nested quoted
+    // bytes (see decrypt_armor_tree's collect_quoted_bytes) — dropping them there
+    // would fail verification and block decryption.
+    if shallow && parsed.encryption_nip.as_deref() != Some("nip04") {
+        parsed.quoted = None;
+    }
 
     // Derive user's pubkey hex from private key
     let perf_derive = std::time::Instant::now();
@@ -6170,4 +6225,80 @@ fn discover_sent_mailbox(session: &mut imap::Session<impl std::io::Read + std::i
     
     debug_log!("[RUST] discover_sent_mailbox: No sent mailbox found");
     Ok(None)
+}
+
+#[cfg(test)]
+mod decode_perf_bench {
+    //! Opt-level isolation harness for the glossia signature-block decode path.
+    //!
+    //! Times `decode_sig_and_pubkey` — the function profiled as the dominant cost
+    //! in `parse_armor` (the `[RUST-PERF] populate: decode_sig_and_pubkey` line).
+    //! Run under a speed profile to tell whether residual decode cost is
+    //! algorithmic or just opt-level=0 codegen overhead:
+    //!
+    //! ```sh
+    //! CARGO_PROFILE_RELEASE_OPT_LEVEL=3 CARGO_PROFILE_RELEASE_LTO=false \
+    //!   cargo test --release --lib decode_sig_and_pubkey_timing -- --ignored --nocapture
+    //! ```
+    //!
+    //! `--lib` (no backend bins) sidesteps the glossia cdylib+rlib output-filename
+    //! collision (cargo #6313) that breaks `cargo test --release` on the bin graph.
+    //! `#[ignore]` keeps it out of normal test sweeps.
+
+    /// Encode raw bytes into bare Latin payload words via the same bitpack_fixed
+    /// codec the app's `glossia_encode_raw_base_n` (lib.rs) uses on the encode side.
+    fn encode_latin(bytes: &[u8]) -> String {
+        let wordlist = glossia::generator::data::default_wordlist("latin");
+        let payload_words = glossia::generator::data::load_payload_words_for_wordlist("latin", wordlist)
+            .expect("load latin payload wordlist");
+        let tree = glossia::WordlistTree::new(payload_words);
+        let words = glossia::codec::encode_base_n(bytes, &tree, "bitpack_fixed")
+            .expect("encode_base_n");
+        words.join(" ")
+    }
+
+    fn percentile(sorted_us: &[u128], p: f64) -> u128 {
+        if sorted_us.is_empty() { return 0; }
+        let idx = ((sorted_us.len() as f64 - 1.0) * p).round() as usize;
+        sorted_us[idx]
+    }
+
+    #[test]
+    #[ignore]
+    fn decode_sig_and_pubkey_timing() {
+        // Deterministic 64-byte signature + 32-byte pubkey (no RNG needed).
+        let sig_bytes: Vec<u8> = (0..64u16).map(|i| (i.wrapping_mul(37) ^ 0xA5) as u8).collect();
+        let pubkey_bytes: Vec<u8> = (0..32u16).map(|i| (i.wrapping_mul(53) ^ 0x3C) as u8).collect();
+
+        // Canonical two-line SIGNATURE block: glossia sig line(s) then pubkey line.
+        let content = format!("{}\n{}", encode_latin(&sig_bytes), encode_latin(&pubkey_bytes));
+        let sig_hex = hex::encode(&sig_bytes);
+        let pubkey_hex = hex::encode(&pubkey_bytes);
+
+        // Cold call — first decode for this dialect builds the cached WordlistTree
+        // + payload HashSet (the ~497ms cold build in the debug-profile profiling).
+        let t0 = std::time::Instant::now();
+        let cold = super::decode_sig_and_pubkey(&content);
+        let cold_us = t0.elapsed().as_micros();
+        assert_eq!(cold, Some((sig_hex.clone(), pubkey_hex.clone())),
+            "decode must round-trip the encoded sig+pubkey (else we're timing an early bail, not real work)");
+
+        // Warm calls — steady state with the cache populated.
+        const N: usize = 100;
+        let mut warm_us: Vec<u128> = Vec::with_capacity(N);
+        for _ in 0..N {
+            let t = std::time::Instant::now();
+            let r = super::decode_sig_and_pubkey(&content);
+            warm_us.push(t.elapsed().as_micros());
+            assert!(r.is_some());
+        }
+        warm_us.sort_unstable();
+        let sum: u128 = warm_us.iter().sum();
+
+        println!("[BENCH] decode_sig_and_pubkey  cold={}us ({:.2}ms)", cold_us, cold_us as f64 / 1000.0);
+        println!("[BENCH] decode_sig_and_pubkey  warm n={} min={}us p50={}us p90={}us p99={}us mean={:.1}us ({:.3}ms)",
+            N, warm_us[0], percentile(&warm_us, 0.50), percentile(&warm_us, 0.90),
+            percentile(&warm_us, 0.99), sum as f64 / N as f64, (sum as f64 / N as f64) / 1000.0);
+        println!("[BENCH] sig block: {} chars, {} words", content.len(), content.split_whitespace().count());
+    }
 }

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -57,6 +57,14 @@ macro_rules! debug_log {
     };
 }
 
+/// Expose the NOSTR_MAIL_DEBUG gate to the frontend so JS-side diagnostics can
+/// honor the same env var as the backend `debug_log!` macro. Returns whether
+/// gated logging is enabled; carries no sensitive data.
+#[tauri::command]
+fn get_debug_log_enabled() -> bool {
+    debug_log_enabled()
+}
+
 /// Resolve a private key: prefer an explicit key if provided, fall back to AppState.
 fn resolve_private_key(explicit: Option<String>, state: &AppState) -> Result<String, String> {
     if let Some(key) = explicit.filter(|k| !k.is_empty()) {
@@ -4231,6 +4239,7 @@ fn decrypt_email_body(
         sender_pubkey.as_deref(),
         recipient_pubkey.as_deref(),
         raw_headers.as_deref(),
+        false, // full thread: the email detail view may show quoted history
     )
 }
 
@@ -4260,6 +4269,7 @@ fn decrypt_email_bodies_batch(
                 e.sender_pubkey.as_deref(),
                 e.recipient_pubkey.as_deref(),
                 raw_headers.as_deref(),
+                false, // batch decrypt feeds the email list/detail; keep full thread
             ) {
                 Ok(result) => types::BatchDecryptResultItem {
                     id,
@@ -4335,7 +4345,8 @@ fn encode_bip39(ciphertext: String, language: String, wordlist: String, mode: St
     let payload_words = glossia::generator::data::load_payload_words_for_wordlist(&language, &wordlist)
         .map_err(|e| format!("Failed to load wordlist: {}", e))?;
     let wordlist_set: HashSet<String> = payload_words.iter().map(|w| w.to_lowercase()).collect();
-    let tree = glossia::WordlistTree::new(payload_words);
+    let tree = glossia::cached_payload_tree(&language, &wordlist)
+        .map_err(|e| format!("Failed to build wordlist tree: {}", e))?;
     let encoded_words = glossia::codec::encode_base_n(&raw_bytes, &tree, "bip39")
         .map_err(|e| format!("BIP39 encoding failed: {:?}", e))?;
 
@@ -4388,7 +4399,8 @@ fn decode_bip39(text: String, language: String, wordlist: String, algorithm: Str
     let payload_words = glossia::generator::data::load_payload_words_for_wordlist(&language, &wordlist)
         .map_err(|e| format!("Failed to load wordlist: {}", e))?;
     let wordlist_set: HashSet<String> = payload_words.iter().map(|w| w.to_lowercase()).collect();
-    let tree = glossia::WordlistTree::new(payload_words);
+    let tree = glossia::cached_payload_tree(&language, &wordlist)
+        .map_err(|e| format!("Failed to build wordlist tree: {}", e))?;
 
     // 2. Filter text to extract only payload words (preserving order)
     let extracted: Vec<String> = text.split_whitespace()
@@ -4601,7 +4613,8 @@ fn glossia_encode_raw_base_n(input: String, language: String, wordlist: String, 
         // 2. Load payload wordlist and build WordlistTree
         let payload_words = glossia::generator::data::load_payload_words_for_wordlist(&language, &wordlist)
             .map_err(|e| format!("Failed to load wordlist: {}", e))?;
-        let payload_tree = glossia::WordlistTree::new(payload_words.clone());
+        let payload_tree = glossia::cached_payload_tree(&language, &wordlist)
+            .map_err(|e| format!("Failed to build wordlist tree: {}", e))?;
 
         // 3. Encode bytes to payload words via bitpack_fixed codec
         let byte_count = bytes.len();
@@ -4729,7 +4742,8 @@ fn glossia_decode_raw_base_n(text: String, language: String, wordlist: String, e
         // 1. Load payload wordlist
         let payload_words = glossia::generator::data::load_payload_words_for_wordlist(&language, &wordlist)
             .map_err(|e| format!("Failed to load wordlist: {}", e))?;
-        let payload_tree = glossia::WordlistTree::new(payload_words.clone());
+        let payload_tree = glossia::cached_payload_tree(&language, &wordlist)
+            .map_err(|e| format!("Failed to build wordlist tree: {}", e))?;
 
         // 2. Build payload set for filtering
         let payload_set: HashSet<String> = payload_words.iter().map(|w| w.to_lowercase()).collect();
@@ -6731,7 +6745,11 @@ fn db_get_matching_email_body(dm_event_id: String, private_key: Option<String>, 
     for pubkey in &pubkeys_to_try {
         let sender_pk = if user_received_email { Some(pubkey.as_str()) } else { None };
         let recipient_pk = if user_sent_email { Some(pubkey.as_str()) } else { Some(pubkey.as_str()) };
-        match email::decrypt_email_body_pipeline(&private_key, &email.body, &email.subject, sender_pk, recipient_pk, email.raw_headers.as_deref()) {
+        // shallow=true: the DM conversation renders only the most recent message
+        // inline (the full thread is one click away via the envelope icon), so we
+        // skip decrypting quoted history the view never shows. See the pipeline's
+        // `shallow` param — it's a no-op for NIP-04.
+        match email::decrypt_email_body_pipeline(&private_key, &email.body, &email.subject, sender_pk, recipient_pk, email.raw_headers.as_deref(), true) {
             Ok(result) if result.success => {
                 println!("[RUST] decrypt_email_body_pipeline succeeded with pubkey: {}", pubkey);
                 return Ok(Some(types::MatchingEmailBodyResult {
@@ -6807,6 +6825,7 @@ pub fn run() {
     
     let builder = builder.invoke_handler(tauri::generate_handler![
         greet,
+        get_debug_log_enabled,
         should_clear_localstorage_cache,
         generate_keypair,
         keychain_add_account,

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -19,7 +19,7 @@ use types::*;
 pub use state::{AppState, Relay};
 pub use types::{KeyPair, EmailConfig};
 use storage::{Storage, Contact, UserProfile, AppSettings, EmailDraft};
-use database::{Contact as DbContact, Email as DbEmail, DirectMessage as DbDirectMessage, DbRelay, DbConversation};
+use database::{Contact as DbContact, Email as DbEmail, DirectMessage as DbDirectMessage, DbRelay, DbConversation, DmConversationPreview};
 use crate::types::{EmailMessage, EmailThreadSummary, RelayStatus, RelayConnectionStatus};
 
 use nostr_sdk::Metadata;
@@ -3434,6 +3434,44 @@ fn db_get_dms_for_conversation(user_pubkey: String, contact_pubkey: String, stat
     println!("[RUST] db_get_dms_for_conversation called");
     let db = state.get_database()?;
     db.get_dms_for_conversation(&user_pubkey, &contact_pubkey).map_err(|e| e.to_string())
+}
+
+/// Paginated conversation fetch. Returns at most `limit` messages, oldest→newest.
+/// When `before_created_at` + `before_id` are both supplied they form the cursor
+/// (the oldest message the caller already holds); only older messages are returned.
+#[tauri::command]
+fn db_get_dms_for_conversation_page(
+    user_pubkey: String,
+    contact_pubkey: String,
+    limit: i64,
+    before_created_at: Option<DateTime<Utc>>,
+    before_id: Option<i64>,
+    state: tauri::State<AppState>,
+) -> Result<Vec<DbDirectMessage>, String> {
+    let db = state.get_database()?;
+    let before = match (before_created_at, before_id) {
+        (Some(ts), Some(id)) => Some((ts, id)),
+        _ => None,
+    };
+    db.get_dms_for_conversation_page(&user_pubkey, &contact_pubkey, limit, before)
+        .map_err(|e| e.to_string())
+}
+
+/// One-row-per-contact previews (latest still-encrypted message + count) for the
+/// DM contact list. Avoids fetching+decrypting whole conversations just to render
+/// the list.
+#[tauri::command]
+fn db_get_dm_conversation_previews(user_pubkey: String, state: tauri::State<AppState>) -> Result<Vec<DmConversationPreview>, String> {
+    let db = state.get_database()?;
+    db.get_dm_conversation_previews(&user_pubkey).map_err(|e| e.to_string())
+}
+
+/// Contacts whose conversation contains at least one email-matched DM, for the
+/// envelope indicator in the contact list.
+#[tauri::command]
+fn db_get_dm_pubkeys_with_email_match(user_pubkey: String, state: tauri::State<AppState>) -> Result<Vec<String>, String> {
+    let db = state.get_database()?;
+    db.get_dm_pubkeys_with_email_match(&user_pubkey).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -6857,6 +6895,9 @@ pub fn run() {
         db_get_all_sent_message_ids,
         db_save_dm,
         db_get_dms_for_conversation,
+        db_get_dms_for_conversation_page,
+        db_get_dm_conversation_previews,
+        db_get_dm_pubkeys_with_email_match,
         db_get_decrypted_dms_for_conversation,
         db_save_conversation,
         db_get_conversations,

--- a/tauri-app/backend/tests/email_integration.rs
+++ b/tauri-app/backend/tests/email_integration.rs
@@ -594,6 +594,7 @@ async fn nip04_header_sig_fallback_unlocks_decrypt() {
         Some(&alice_npub),
         Some(&bob_npub),
         None,
+        false,
     )
     .expect("pipeline returns Ok even on signature rejection");
     assert!(
@@ -619,6 +620,7 @@ async fn nip04_header_sig_fallback_unlocks_decrypt() {
         Some(&alice_npub),
         Some(&bob_npub),
         Some(&raw_headers),
+        false,
     )
     .expect("pipeline returns Ok when header sig verifies");
     assert!(
@@ -944,6 +946,7 @@ async fn sent_mail_decrypts_via_recipient_header_without_dm() {
         None,
         Some(&recipient_from_header),
         None,
+        false,
     )
     .expect("decrypt_email_body_pipeline");
 
@@ -1034,6 +1037,7 @@ async fn sent_mail_undecryptable_without_any_counterparty_hint() {
         None,
         None,
         None,
+        false,
     )
     .expect("decrypt_email_body_pipeline returns Ok even when content can't be decrypted");
 
@@ -2225,6 +2229,7 @@ async fn nip44_reply_preserves_nested_encrypted_armor() {
         Some(&bob_npub),
         Some(&alice_npub),
         None,
+        false,
     )
     .expect("decrypt_email_body_pipeline");
     assert!(decrypt.success, "decrypt must succeed: {:?}", decrypt.error);
@@ -2444,6 +2449,7 @@ async fn nip44_three_level_reply_chain() {
         Some(&alice_npub),
         Some(&bob_npub),
         None,
+        false,
     )
     .expect("decrypt pipeline");
     assert!(decrypt.success, "decrypt failed: {:?}", decrypt.error);

--- a/tauri-app/frontend/js/dm-service.js
+++ b/tauri-app/frontend/js/dm-service.js
@@ -509,7 +509,18 @@ class DMService {
         }, { passive: true });
     }
 
-    // Load profiles for DM contacts
+    // Enrich DM contacts with relay-fetched kind:0 profiles (names/avatars).
+    //
+    // INTENTIONALLY NOT CALLED. This is a deliberate anti-spoofing measure, not
+    // dead code. The DM list resolves names/avatars ONLY from saved contacts
+    // (DatabaseService.getContact). If we pulled relay profiles for unsaved
+    // pubkeys, a non-contact could copy a known contact's display name and
+    // avatar and appear identical to them in the list — letting the user mistake
+    // an impostor for someone they trust. Unsaved senders therefore stay shown as
+    // a truncated pubkey with no avatar, visually distinct from real contacts.
+    //
+    // Do NOT wire this into loadDmContacts() to "fix" missing names — that would
+    // reintroduce the impersonation vector. (See git history / issue discussion.)
     async loadDmContactProfiles() {
         // Only process contacts that don't already have profiles loaded
         const dmContacts = window.appState.getDmContacts();

--- a/tauri-app/frontend/js/dm-service.js
+++ b/tauri-app/frontend/js/dm-service.js
@@ -16,6 +16,20 @@ class DMService {
         this.swipeStartY = null;
         this.swipeThreshold = 50; // Minimum distance for swipe
         this.loadingMessages = new Map(); // Track ongoing loadDmMessages calls to prevent race conditions
+        // Pagination: conversations load the newest PAGE_SIZE messages, then fetch
+        // older pages on scroll-up. Per-contact state tracks whether more history
+        // exists and whether an older-page fetch is in flight.
+        this.PAGE_SIZE = 30;
+        this.pagination = new Map(); // contactPubkey -> { hasMore: bool, loadingOlder: bool }
+    }
+
+    _getPagination(contactPubkey) {
+        return this.pagination.get(contactPubkey) || { hasMore: false, loadingOlder: false };
+    }
+
+    _setPagination(contactPubkey, patch) {
+        const current = this._getPagination(contactPubkey);
+        this.pagination.set(contactPubkey, { ...current, ...patch });
     }
 
     // Decrypt a single DM content string via NIP-44/NIP-04.
@@ -227,28 +241,85 @@ class DMService {
         }
     }
 
-    // Fetch raw DMs from DB and decrypt in the frontend (supports glossia).
-    async _fetchAndDecryptDms(contactPubkey) {
-        const myPubkey = window.appState.getKeypair().public_key;
-
-        const rawMessages = await window.__TAURI__.core.invoke('db_get_dms_for_conversation', {
-            userPubkey: myPubkey,
-            contactPubkey: contactPubkey
-        });
-
-        if (!rawMessages || rawMessages.length === 0) return [];
-
-        // Decrypt each message — use the other party's pubkey for the shared secret.
-        // Preserve the original ciphertext on `raw_content` so the debug-info modal
-        // can show what's actually stored in the DB. Decryption calls are independent,
-        // so run them in parallel to avoid serializing N IPC round trips.
+    // Decrypt a batch of raw DB messages in place. Uses the other party's pubkey
+    // for the shared secret. Preserves the original ciphertext on `raw_content` so
+    // the debug-info modal can show what's actually stored. Decryptions are
+    // independent, so run them in parallel to avoid serializing N IPC round trips.
+    async _decryptDmsInPlace(rawMessages, myPubkey) {
         await Promise.all(rawMessages.map(async (msg) => {
             const otherPubkey = (msg.sender_pubkey === myPubkey) ? msg.recipient_pubkey : msg.sender_pubkey;
             msg.raw_content = msg.content;
             msg.content = await this._decryptDmContent(msg.content, otherPubkey);
         }));
-
         return rawMessages;
+    }
+
+    // Fetch+decrypt a single page of a conversation (newest-first window).
+    // `before` is the oldest message already held: { created_at, id }, or null
+    // for the most recent page. Returns messages oldest→newest.
+    async _fetchAndDecryptDmsPage(contactPubkey, before) {
+        const myPubkey = window.appState.getKeypair().public_key;
+
+        const rawMessages = await window.__TAURI__.core.invoke('db_get_dms_for_conversation_page', {
+            userPubkey: myPubkey,
+            contactPubkey: contactPubkey,
+            limit: this.PAGE_SIZE,
+            beforeCreatedAt: before ? before.created_at : null,
+            beforeId: before ? before.id : null
+        });
+
+        if (!rawMessages || rawMessages.length === 0) return [];
+        return this._decryptDmsInPlace(rawMessages, myPubkey);
+    }
+
+    // Normalize a decrypted raw DB message into the shape the renderer/debug modal
+    // expect. `matchMap` is a Map<event_id, bool> of email-match results.
+    _formatDmMessage(msg, myPubkey, matchMap) {
+        return {
+            id: msg.id,
+            event_id: msg.event_id || null,
+            content: msg.content || '',
+            created_at: msg.created_at || msg.timestamp,
+            sender_pubkey: msg.sender_pubkey,
+            // Preserve the rest of the DirectMessage shape so the debug modal can
+            // show the full record. These fields don't affect rendering but are
+            // essential for diagnosing send/receive issues from the inspector.
+            recipient_pubkey: msg.recipient_pubkey ?? null,
+            received_at: msg.received_at ?? null,
+            email_message_id: msg.email_message_id ?? null,
+            received_from_relay: msg.received_from_relay ?? null,
+            raw_content: msg.raw_content ?? null,
+            is_sent: msg.sender_pubkey === myPubkey,
+            confirmed: true, // All DB messages are confirmed
+            hasEmailMatch: msg.event_id ? (matchMap.get(msg.event_id) === true) : false
+        };
+    }
+
+    // created_at may arrive as an ISO string (DB serialization) or an epoch-seconds
+    // number; normalize to epoch milliseconds for ordering.
+    _createdAtMs(message) {
+        const c = message?.created_at;
+        if (typeof c === 'number') return c * 1000;
+        const parsed = Date.parse(c);
+        return Number.isNaN(parsed) ? 0 : parsed;
+    }
+
+    // Merge two formatted-message lists, deduping by event_id (falling back to db
+    // id), and return them sorted oldest→newest. Used to fold a freshly-fetched
+    // newest page into already-loaded history without losing older pages. Existing
+    // entries win on a tie so already-computed fields (e.g. hasEmailMatch) survive.
+    _mergeDmMessages(existing, incoming) {
+        const seen = new Set();
+        const keyOf = (m) => m.event_id || (m.id != null ? `id:${m.id}` : null);
+        const out = [];
+        for (const m of [...existing, ...incoming]) {
+            const key = keyOf(m);
+            if (key && seen.has(key)) continue;
+            if (key) seen.add(key);
+            out.push(m);
+        }
+        out.sort((a, b) => this._createdAtMs(a) - this._createdAtMs(b));
+        return out;
     }
 
     // Load DM contacts from backend and network
@@ -261,48 +332,42 @@ class DMService {
 
             const myPubkey = window.appState.getKeypair().public_key;
 
-            // 1. Get sorted list of DM pubkeys scoped to the active profile
-            const pubkeys = await window.__TAURI__.core.invoke('db_get_all_dm_pubkeys_sorted', {
+            // 1. One-row-per-contact previews: latest (still-encrypted) message +
+            //    total count, ordered most-recent-conversation first. This replaces
+            //    the old per-contact "fetch + decrypt the ENTIRE conversation" loop —
+            //    the contact list now decrypts a single message per contact.
+            const previews = await window.__TAURI__.core.invoke('db_get_dm_conversation_previews', {
                 userPubkey: myPubkey
             });
 
-            if (!pubkeys || pubkeys.length === 0) {
+            if (!previews || previews.length === 0) {
                 window.appState.setDmContacts([]);
                 this.renderDmContacts();
                 return;
             }
 
+            // 2. Which conversations contain an email-matched DM — one batched query
+            //    instead of probing every message of every conversation.
+            let emailMatchSet = new Set();
+            try {
+                const matchPubkeys = await window.__TAURI__.core.invoke('db_get_dm_pubkeys_with_email_match', {
+                    userPubkey: myPubkey
+                });
+                emailMatchSet = new Set(matchPubkeys || []);
+            } catch (error) {
+                console.error('[LOAD_CONTACTS] email-match lookup failed:', error);
+            }
+
             const dmContacts = [];
 
-            for (const contactPubkey of pubkeys) {
+            // 3. Decrypt just the latest message per contact (one decryption each)
+            //    and attach DB-backed profile info. Independent per contact, so run
+            //    them in parallel.
+            await Promise.all(previews.map(async (preview) => {
+                const contactPubkey = preview.contact_pubkey;
                 try {
-                    // 1. Fetch and decrypt messages for this conversation (frontend decryption with glossia support)
-                    const messages = await this._fetchAndDecryptDms(contactPubkey);
-                    // LOG: Show how many messages were returned
-                    if (!messages || messages.length === 0) {
-                        continue;
-                    }
+                    const lastMessage = await this._decryptDmContent(preview.last_content, contactPubkey);
 
-                    // 2. Find the most recent message
-                    const lastMessageObj = messages[messages.length - 1];
-                    const lastMessage = lastMessageObj.content;
-                    const lastMessageTime = new Date(lastMessageObj.created_at);
-
-                    // 3. Check if any messages have email matches
-                    let hasEmailMatch = false;
-                    for (const msg of messages) {
-                        const emailMatch = await window.__TAURI__.core.invoke('db_check_dm_matches_email_encrypted', {
-                            dmEventId: msg.event_id,
-                            userPubkey: myPubkey,
-                            contactPubkey: contactPubkey
-                        });
-                        if (emailMatch) {
-                            hasEmailMatch = true;
-                            break;
-                        }
-                    }
-
-                    // 4. Always fetch contact info from the database
                     const profile = await window.DatabaseService.getContact(contactPubkey);
                     const name = profile?.name || contactPubkey.substring(0, 16) + '...';
                     // Use picture_data_url for avatars, fallback to picture_url or picture
@@ -310,52 +375,28 @@ class DMService {
                     const picture = profile?.picture_url || profile?.picture || '';
                     const profileLoaded = !!profile;
 
-                    const contactData = {
+                    dmContacts.push({
                         pubkey: contactPubkey,
                         name,
                         lastMessage,
-                        lastMessageTime,
-                        messageCount: messages.length,
+                        lastMessageTime: new Date(preview.last_created_at),
+                        messageCount: preview.message_count,
                         picture_data_url,
                         picture, // ensure this is set for avatar fallback
                         profileLoaded,
-                        hasEmailMatch // New field to track if this conversation has email matches
-                    };
-                    dmContacts.push(contactData);
-
-                    // 5. Cache decrypted messages in appState
-                    // CRITICAL FIX: Don't overwrite messages if we're currently viewing this conversation
-                    // and have newer messages loaded. This prevents race conditions where loadDmContacts()
-                    // overwrites messages that loadDmMessages() just loaded and rendered.
-                    const currentContact = window.appState.getSelectedDmContact();
-                    const isCurrentlyViewing = currentContact && currentContact.pubkey === contactPubkey;
-                    const existingMessages = window.appState.getDmMessages(contactPubkey) || [];
-                    
-                    if (isCurrentlyViewing && existingMessages.length > 0) {
-                        // Check if existing messages are newer (more recent) than what we're about to cache
-                        const existingLatestTime = existingMessages.length > 0 
-                            ? new Date(existingMessages[existingMessages.length - 1].created_at).getTime()
-                            : 0;
-                        const newLatestTime = messages.length > 0
-                            ? new Date(messages[messages.length - 1].created_at).getTime()
-                            : 0;
-                        
-                        // Only overwrite if the new messages are actually newer
-                        if (newLatestTime > existingLatestTime) {
-                            window.appState.setDmMessages(contactPubkey, messages);
-                        }
-                        // Otherwise, keep the existing messages (they're already rendered and up-to-date)
-                    } else {
-                        // Not currently viewing this conversation, safe to cache
-                        window.appState.setDmMessages(contactPubkey, messages);
-                    }
+                        hasEmailMatch: emailMatchSet.has(contactPubkey)
+                    });
                 } catch (error) {
                     console.error(`[LOAD_CONTACTS] Error processing contact ${contactPubkey}:`, error);
                     console.error(`[LOAD_CONTACTS] Error stack:`, error.stack);
-                    // Continue with next contact instead of failing entirely
-                    continue;
+                    // Skip this contact instead of failing the whole list.
                 }
-            }
+            }));
+
+            // Promise.all may resolve out of order; restore the recency order the
+            // previews query returned.
+            const order = new Map(previews.map((p, i) => [p.contact_pubkey, i]));
+            dmContacts.sort((a, b) => (order.get(a.pubkey) ?? 0) - (order.get(b.pubkey) ?? 0));
 
         // 6. Set and render contacts
         window.appState.setDmContacts(dmContacts);
@@ -874,8 +915,9 @@ class DMService {
         }
 
         try {
-            // Fetch and decrypt messages in the frontend (supports glossia-encoded DMs)
-            const messages = await this._fetchAndDecryptDms(contactPubkey);
+            // Fetch+decrypt only the newest page (supports glossia-encoded DMs).
+            // Older history is pulled in on scroll-up via loadOlderMessages().
+            const messages = await this._fetchAndDecryptDmsPage(contactPubkey, null);
 
             if (!messages || !Array.isArray(messages)) {
                 console.error('[JS] Invalid messages response:', messages);
@@ -883,46 +925,92 @@ class DMService {
                 return;
             }
 
-            // Check for email matches for all messages in a single batched call.
+            // A full page implies there's probably older history to fetch.
+            const hasMore = messages.length >= this.PAGE_SIZE;
+
+            // Check for email matches for this page in a single batched call.
             const matchMap = await this._fetchEmailMatchMap(
                 messages.filter((m) => m.event_id).map((m) => m.event_id)
             );
 
-            const formattedMessages = messages.map((msg) => ({
-                id: msg.id,
-                event_id: msg.event_id || null,
-                content: msg.content || '',
-                created_at: msg.created_at || msg.timestamp,
-                sender_pubkey: msg.sender_pubkey,
-                // Preserve the rest of the DirectMessage shape so the debug
-                // modal can show the full record. These fields don't affect
-                // rendering but are essential for diagnosing send/receive
-                // issues from the in-app inspector.
-                recipient_pubkey: msg.recipient_pubkey ?? null,
-                received_at: msg.received_at ?? null,
-                email_message_id: msg.email_message_id ?? null,
-                received_from_relay: msg.received_from_relay ?? null,
-                raw_content: msg.raw_content ?? null,
-                is_sent: msg.sender_pubkey === myPubkey,
-                confirmed: true, // All DB messages are confirmed
-                hasEmailMatch: msg.event_id ? (matchMap.get(msg.event_id) === true) : false
-            }));
-            
-            window.appState.setDmMessages(contactPubkey, formattedMessages);
-            const renderStart = Date.now();
+            const formattedMessages = messages.map((msg) => this._formatDmMessage(msg, myPubkey, matchMap));
+
+            if (forceRefresh && cachedMessages && cachedMessages.length > 0) {
+                // Live-refresh: fold the newest page into already-loaded history so
+                // scrolled-back pages aren't lost and a just-arrived message appears.
+                const merged = this._mergeDmMessages(cachedMessages, formattedMessages);
+                const prior = this.pagination.get(contactPubkey);
+                this._setPagination(contactPubkey, {
+                    hasMore: prior ? prior.hasMore : hasMore,
+                    loadingOlder: false
+                });
+                window.appState.setDmMessages(contactPubkey, merged);
+            } else {
+                this._setPagination(contactPubkey, { hasMore, loadingOlder: false });
+                window.appState.setDmMessages(contactPubkey, formattedMessages);
+            }
+
             this.renderDmMessages(contactPubkey);
-            const renderEnd = Date.now();
-            
-            console.log(`✅ Loaded ${formattedMessages.length} messages from DB`);
+
+            const count = (window.appState.getDmMessages(contactPubkey) || []).length;
+            console.log(`✅ Loaded ${count} messages from DB (page of ${formattedMessages.length}, hasMore=${this._getPagination(contactPubkey).hasMore})`);
         } catch (error) {
             console.error('Failed to load DM messages:', error);
             window.notificationService.showError('Failed to load messages');
         }
     }
 
-    // Render DM messages
-    renderDmMessages(contactPubkey) {
-        
+    // Fetch the next older page and prepend it to the current conversation view,
+    // preserving the user's scroll position. Triggered by scrolling near the top.
+    async loadOlderMessages(contactPubkey) {
+        const state = this._getPagination(contactPubkey);
+        if (!state.hasMore || state.loadingOlder) return;
+
+        const existing = window.appState.getDmMessages(contactPubkey) || [];
+        if (existing.length === 0) return;
+
+        // Cursor = oldest message currently held (list is kept oldest→newest).
+        const oldest = existing[0];
+        const before = { created_at: oldest.created_at, id: oldest.id };
+
+        // Capture scroll metrics from the live container BEFORE we rebuild it, so
+        // we can restore the viewport to the same messages after prepending.
+        const dmMessages = window.domManager.get('dmMessages');
+        const container = dmMessages?.querySelector('.messages-container');
+        const prevScrollHeight = container ? container.scrollHeight : 0;
+        const prevScrollTop = container ? container.scrollTop : 0;
+
+        this._setPagination(contactPubkey, { loadingOlder: true });
+        try {
+            const myPubkey = window.appState.getKeypair().public_key;
+            const olderRaw = await this._fetchAndDecryptDmsPage(contactPubkey, before);
+
+            // Fewer than a full page back means we've reached the start of history.
+            const hasMore = olderRaw.length >= this.PAGE_SIZE;
+
+            const matchMap = await this._fetchEmailMatchMap(
+                olderRaw.filter((m) => m.event_id).map((m) => m.event_id)
+            );
+            const olderFormatted = olderRaw.map((msg) => this._formatDmMessage(msg, myPubkey, matchMap));
+
+            const merged = this._mergeDmMessages(olderFormatted, existing);
+            window.appState.setDmMessages(contactPubkey, merged);
+            this._setPagination(contactPubkey, { hasMore, loadingOlder: false });
+
+            // Re-render and restore scroll so the previously-visible message stays put.
+            this.renderDmMessages(contactPubkey, { preserveScroll: true, prevScrollHeight, prevScrollTop });
+        } catch (error) {
+            console.error('Failed to load older DM messages:', error);
+            this._setPagination(contactPubkey, { loadingOlder: false });
+        }
+    }
+
+    // Render DM messages.
+    // `options.preserveScroll` (with prevScrollHeight/prevScrollTop) keeps the
+    // viewport anchored after prepending older messages; otherwise we scroll to
+    // the newest message at the bottom.
+    renderDmMessages(contactPubkey, options = {}) {
+
         const dmMessages = window.domManager.get('dmMessages');
         if (!dmMessages) {
             console.error('[RENDER] dmMessages element not found!');
@@ -1126,11 +1214,25 @@ class DMService {
                 // Create messages container
                 const messagesContainer = document.createElement('div');
                 messagesContainer.className = 'messages-container';
-                
-                // Sort messages from oldest to newest (top to bottom)
-                const sortedMessages = [...messages].sort((a, b) => a.created_at - b.created_at);
-                
-                
+
+                // Sort messages from oldest to newest (top to bottom). created_at is
+                // an ISO string, so compare normalized timestamps rather than doing
+                // numeric subtraction on strings.
+                const sortedMessages = [...messages].sort((a, b) => this._createdAtMs(a) - this._createdAtMs(b));
+
+                // When older history remains, show a thin top affordance and wire
+                // scroll-up to fetch the next page.
+                const paginationState = this._getPagination(contactPubkey);
+                if (paginationState.hasMore) {
+                    const loadOlderEl = document.createElement('div');
+                    loadOlderEl.className = 'dm-load-older';
+                    loadOlderEl.style.cssText = 'text-align:center; padding:8px; font-size:12px; opacity:0.6;';
+                    loadOlderEl.innerHTML = paginationState.loadingOlder
+                        ? '<i class="fas fa-spinner fa-spin"></i> Loading earlier messages…'
+                        : '<i class="fas fa-clock-rotate-left"></i> Scroll up for earlier messages';
+                    messagesContainer.appendChild(loadOlderEl);
+                }
+
                 const myPubkey = window.appState.getKeypair()?.public_key;
                 sortedMessages.forEach((message, index) => {
                     const isMe = message.sender_pubkey === myPubkey;
@@ -1349,11 +1451,30 @@ class DMService {
                 });
                 
                 dmMessages.appendChild(messagesContainer);
-                
-                // Scroll to bottom to show the newest messages
-                setTimeout(() => {
-                    messagesContainer.scrollTop = messagesContainer.scrollHeight;
-                }, 0);
+
+                if (options.preserveScroll && options.prevScrollHeight != null) {
+                    // Older messages were prepended — keep the previously-visible
+                    // message anchored by offsetting scrollTop by the added height.
+                    const delta = messagesContainer.scrollHeight - options.prevScrollHeight;
+                    messagesContainer.scrollTop = (options.prevScrollTop || 0) + delta;
+                } else {
+                    // Scroll to bottom to show the newest messages
+                    setTimeout(() => {
+                        messagesContainer.scrollTop = messagesContainer.scrollHeight;
+                    }, 0);
+                }
+
+                // Infinite scroll-up: fetch the next older page when the user nears
+                // the top. The loadingOlder guard inside loadOlderMessages prevents
+                // overlapping fetches.
+                messagesContainer.addEventListener('scroll', () => {
+                    if (messagesContainer.scrollTop <= 80) {
+                        const st = this._getPagination(contactPubkey);
+                        if (st.hasMore && !st.loadingOlder) {
+                            this.loadOlderMessages(contactPubkey);
+                        }
+                    }
+                });
             }
             
             // Add message input box at the bottom of conversation panel (not inside scrollable messages)

--- a/tauri-app/frontend/js/dm-service.js
+++ b/tauri-app/frontend/js/dm-service.js
@@ -32,6 +32,28 @@ class DMService {
         this.pagination.set(contactPubkey, { ...current, ...patch });
     }
 
+    // Diagnostic logging gated on the backend NOSTR_MAIL_DEBUG env var, resolved
+    // once via the `get_debug_log_enabled` Tauri command and cached. Mirrors the
+    // Rust `debug_log!` macro so JS-side diagnostics honor the same switch and
+    // stay silent in normal runs. Reusable pattern for future JS gating — call
+    // `await this._debugLog(...)` anywhere a gated console line is wanted.
+    async _isDebugLogEnabled() {
+        if (this._debugLogEnabled === undefined) {
+            try {
+                this._debugLogEnabled = await window.__TAURI__.core.invoke('get_debug_log_enabled');
+            } catch (_) {
+                this._debugLogEnabled = false;
+            }
+        }
+        return this._debugLogEnabled;
+    }
+
+    async _debugLog(...args) {
+        if (await this._isDebugLogEnabled()) {
+            console.log('[JS-DEBUG]', ...args);
+        }
+    }
+
     // Decrypt a single DM content string via NIP-44/NIP-04.
     /// Sniff the format of a stored DM content string. Mirrors the backend's
     /// `crypto::detect_encryption_format` heuristic so the debug modal can
@@ -1315,6 +1337,15 @@ class DMService {
                     if (message.hasEmailMatch) {
                         // Email-match messages: always show subject + body inline.
                         // Quoted reply chains are hidden — envelope icon opens the full email.
+                        //
+                        // Rendering the full email body inline is intentional and a core
+                        // feature: it lets nostr-mail carry effectively *unbounded* message
+                        // content that plain nostr clients can't, since the body rides along
+                        // via the linked email rather than the DM event itself — sidestepping
+                        // the per-event size limits relay policies impose. The DM event stays
+                        // small; the body comes from the email. Only the most recent message
+                        // is shown here (the backend decrypts shallowly, skipping quoted
+                        // history); the full thread is one click away via the envelope icon.
                         messageElement.innerHTML = `
                             <div class="message-content">
                                 <div class="email-match-subject">${window.Utils.escapeHtml(message.content)}</div>

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -1171,6 +1171,15 @@ class EmailService {
                 email.sender_pubkey = fresh.sender_pubkey;
                 changed = true;
             }
+            // (B) A newly-anchored pubkey can flip an earlier "could not decrypt"
+            // into a success. Drop any cached preview for this row so the next
+            // render re-decrypts with the fresh anchor instead of showing a stale
+            // miss. _previewCache is never otherwise cleared, so without this the
+            // failure would stick for the whole session.
+            if (changed && email.id != null) {
+                this._previewCache.delete(`inbox-${email.id}`);
+                this._previewCache.delete(`sent-${email.id}`);
+            }
             return changed;
         } catch (e) {
             console.warn('[JS] subject_hash retrofit/backfill failed:', e);
@@ -3525,14 +3534,14 @@ class EmailService {
                                 previewSubject: item.result.subject,
                                 showSubject: true,
                             });
-                        } else {
-                            // Cache the failure too so we don't re-attempt
-                            this._previewCache.set(`inbox-${item.id}`, {
-                                previewText: 'Your private key could not decrypt this message. The email may not have been encrypted for your keypair.',
-                                previewSubject: email ? email.subject : '',
-                                showSubject: false,
-                            });
                         }
+                        // (A) Deliberately do NOT cache decrypt failures. A miss
+                        // here is often transient — the retrofit/backfill below can
+                        // anchor a sender/recipient pubkey that makes the very next
+                        // render succeed. Caching the failure (which is never
+                        // invalidated) is what made the inbox show a permanent
+                        // "could not decrypt" for messages that decrypt fine on
+                        // click. The per-row renderInboxEmailItem pass re-attempts.
                         // Side effects fire regardless of full-decrypt success:
                         // subject_ciphertext is produced as long as glossia decode
                         // worked, which is enough to self-heal recipient_pubkey for
@@ -3762,8 +3771,21 @@ class EmailService {
                 showSubject = true;
             }
 
-            // Cache the result for future re-renders
-            this._previewCache.set(cacheKey, { previewText, previewSubject, showSubject });
+            // Cache the result for future re-renders — but (A) never cache a
+            // decrypt failure. A miss here is often transient: the row's
+            // sender/recipient pubkey gets backfilled after this attempt and the
+            // next render succeeds. Caching the failure (never invalidated) is
+            // what pinned a permanent "could not decrypt" on messages that
+            // decrypt fine on click. The failure strings mirror the isDecryptable
+            // check below — note showSubject is initialized differently across the
+            // inbox/sent renderers, so we classify on previewText, not showSubject.
+            const decryptFailed =
+                previewText.includes('Unable to decrypt') ||
+                previewText.includes('could not decrypt') ||
+                previewText.includes('Could not decrypt');
+            if (!decryptFailed) {
+                this._previewCache.set(cacheKey, { previewText, previewSubject, showSubject });
+            }
         }
 
         // Check if email is decryptable (for filtering)
@@ -3797,6 +3819,9 @@ class EmailService {
             signatureIndicator = `<span class="signature-indicator verified" title="Verified Nostr signature${sigSource}"><i class="fas fa-pen"></i> Signature Verified</span>`;
         } else if (email.signature_valid === false) {
             signatureIndicator = `<span class="signature-indicator invalid" data-message-id="${Utils.escapeHtml(email.message_id || email.id)}" title="Invalid Nostr signature"><i class="fas fa-pen"></i> Signature Invalid</span>`;
+        } else {
+            // No signature at all — softer "Unsigned" warning, distinct from invalid.
+            signatureIndicator = `<span class="signature-indicator missing" title="No Nostr signature"><i class="fas fa-exclamation-triangle"></i> Unsigned</span>`;
         }
 
         // Add transport authentication indicator
@@ -4457,6 +4482,11 @@ class EmailService {
                     } else if (email.signature_valid === false) {
                         signatureIcon = `<span class="signature-indicator invalid" data-message-id="${Utils.escapeHtml(email.message_id || email.id)}" title="Signature Invalid"><i class="fas fa-times-circle"></i></span>`;
                         securityRows += `<div class="security-row invalid"><i class="fas fa-times-circle"></i> Signature Invalid</div>`;
+                    } else {
+                        // No signature at all (signature_valid null/undefined, no inline sig).
+                        // Softer "Unsigned" warning — distinct from a present-but-bad signature.
+                        signatureIcon = `<span class="signature-indicator missing" title="No signature"><i class="fas fa-exclamation-triangle"></i></span>`;
+                        securityRows += `<div class="security-row missing"><i class="fas fa-exclamation-triangle"></i> Unsigned</div>`;
                     }
                     if (email.transport_auth_verified === true) {
                         securityRows += `<div class="security-row verified"><i class="fas fa-envelope"></i> Email Transport Verified</div>`;
@@ -5170,6 +5200,10 @@ ${attachmentsHtml}
                     } else if (email.signature_valid === false) {
                         signatureIcon = `<span class="signature-indicator invalid" title="Signature Invalid"><i class="fas fa-times-circle"></i></span>`;
                         securityRows += `<div class="security-row invalid"><i class="fas fa-times-circle"></i> Signature Invalid</div>`;
+                    } else {
+                        // No signature at all — softer "Unsigned" warning (see detail card).
+                        signatureIcon = `<span class="signature-indicator missing" title="No signature"><i class="fas fa-exclamation-triangle"></i></span>`;
+                        securityRows += `<div class="security-row missing"><i class="fas fa-exclamation-triangle"></i> Unsigned</div>`;
                     }
 
                     // Suppress green inline sig icon for unknown signers; the
@@ -7148,13 +7182,12 @@ ${attachmentsHtml}
                                 this._saveRecipientPubkeyToDb(email, email.recipient_pubkey)
                                     .catch(e => console.warn('[JS] Failed to backfill recipient_pubkey:', e));
                             }
-                        } else {
-                            this._previewCache.set(`sent-${item.id}`, {
-                                previewText: 'Could not decrypt',
-                                previewSubject: email ? email.subject : '',
-                                showSubject: true,
-                            });
                         }
+                        // (A) Do NOT cache decrypt failures — the retrofit below
+                        // may anchor recipient_pubkey and make the next render
+                        // succeed. A cached miss is never invalidated, so it would
+                        // otherwise pin a permanent "Could not decrypt" on a row
+                        // that decrypts fine once backfilled.
                         // Retrofit subject_hash whenever the backend produced a
                         // glossia-decoded ciphertext — even on full-decrypt failure.
                         // This breaks the catch-22 where missing recipient_pubkey
@@ -7331,8 +7364,21 @@ ${attachmentsHtml}
                 showSubject = true;
             }
 
-            // Cache the result for future re-renders
-            this._previewCache.set(cacheKey, { previewText, previewSubject, showSubject });
+            // Cache the result for future re-renders — but (A) never cache a
+            // decrypt failure. A miss here is often transient: the row's
+            // sender/recipient pubkey gets backfilled after this attempt and the
+            // next render succeeds. Caching the failure (never invalidated) is
+            // what pinned a permanent "could not decrypt" on messages that
+            // decrypt fine on click. The failure strings mirror the isDecryptable
+            // check below — note showSubject is initialized differently across the
+            // inbox/sent renderers, so we classify on previewText, not showSubject.
+            const decryptFailed =
+                previewText.includes('Unable to decrypt') ||
+                previewText.includes('could not decrypt') ||
+                previewText.includes('Could not decrypt');
+            if (!decryptFailed) {
+                this._previewCache.set(cacheKey, { previewText, previewSubject, showSubject });
+            }
         }
 
         // Check if email is decryptable (for filtering)

--- a/tauri-app/frontend/styles/email.css
+++ b/tauri-app/frontend/styles/email.css
@@ -107,12 +107,22 @@ body.dark-mode .email-list {
     opacity: 0.7;
 }
 
+/* Missing signature — softer warning than the red "invalid": the message
+   simply wasn't signed (vs. a signature that's present but failed). */
+.signature-indicator.missing {
+    color: #f59e0b;
+}
+
 body.dark-mode .signature-indicator.verified {
     color: #4ade80;
 }
 
 body.dark-mode .signature-indicator.invalid {
     color: #f87171;
+}
+
+body.dark-mode .signature-indicator.missing {
+    color: #fbbf24;
 }
 
 /* Secondary From: address shown next to a cryptographically-bound identity.
@@ -629,6 +639,10 @@ body.dark-mode .email-sender-time {
     color: #ef4444;
 }
 
+.email-security-info .security-row.missing {
+    color: #f59e0b;
+}
+
 body.dark-mode .email-metadata-summary {
     color: #9ca3af;
 }
@@ -653,6 +667,10 @@ body.dark-mode .email-security-info .security-row.verified {
 
 body.dark-mode .email-security-info .security-row.invalid {
     color: #f87171;
+}
+
+body.dark-mode .email-security-info .security-row.missing {
+    color: #fbbf24;
 }
 
 /* Subject row styling removed - subject is now in page header */


### PR DESCRIPTION
## Summary

DM/email decode and conversation-load performance, plus a glossia integration cleanup. Bundles this branch's commits over `staging`.

## Changes

**Glossia decode hot path** (`749ec29`)
- Bump `glossia` submodule `553e775 → e472a5b` (upstream PRs #15/#16/#17: public `cached_payload_tree`, `DialectFilter`/`detect_dialect_with`, workspace split).
- Restrict raw_base_n decode candidates to the payload wordlists nostr-mail actually emits (`latin/default`, `english/bip39`) via `detect_dialect_with` + `DialectFilter`. `detect_dialect` previously also proposed 2¹⁷-word cover-word lists (`english/lemmas`, `english/ngram`) for Latin content; probing them cost a ~50ms cold `WordlistTree` build each — the entire ~190ms (opt-z) `decode_sig_and_pubkey` outlier on the first signature block per launch.
- Drop nostr-mail's local `WordlistTree`+set cache entirely; the tree now comes from `glossia::cached_payload_tree` (shared with glossia's encode pipeline), and membership uses the tree's own lowercased `contains()`.
- Use `cached_payload_tree` in all four encode/decode command paths (`lib.rs`) instead of rebuilding per call.
- Shallow-decrypt DM conversation rendering: skip decrypting quoted thread history the inline view never shows (no-op for NIP-04). New `shallow` param on `decrypt_email_body_pipeline`.

**DM conversation loading** (`a044297`)
- Paginate conversation loading; lighten contact-list previews.

**Honor the "Require Signatures" setting** (`d29fa07`)
- The "Require Signatures" toggle existed in the UI (default on) and was persisted, but the backend ignored it — unverified NIP-04 messages were always rejected before decryption. Thread `require_signature` through `decrypt_armor_tree` / `decrypt_email_body_pipeline` so the user's choice is honored: **off** decrypts unauthenticated mail anyway (the Unsigned/Invalid badge still shows); **on** (default) keeps reject-before-decrypt.
- `active_require_signature(state)` reads the setting (`email::lookup_require_signature`, defaults true), wired into `decrypt_email_body`, `decrypt_email_bodies_batch`, and `db_get_matching_email_body`. Test asserts the `require_signature=false` path round-trips an unverified NIP-04 message.

**"Unsigned" signature badge** (`eaf34ca`)
- Email signature badges only distinguished verified (green) vs invalid (red); a message with **no** signature (`signature_valid` null/absent) rendered nothing — the `if/else-if` chains had no terminal `else`. Add a softer amber **"Unsigned"** warning so missing is visibly distinct from a present-but-bad signature.
- Applied at all three render sites (detail card security panel, preview/headers modal, inbox list item) + `.signature-indicator.missing` / `.security-row.missing` CSS (amber, light + dark).

**Diagnostics** (`d159a2c`, plus this work)
- Gate `[RUST-PERF]` profiling logs behind `NOSTR_MAIL_DEBUG`.
- `get_debug_log_enabled` command + `dm-service.js` helper so JS gates on the same switch as the Rust `debug_log!` macro.
- `#[ignore]` `decode_sig_and_pubkey` timing bench (lib unit test).

## Performance (measured)

| | debug (opt-0) | release (opt-z, shipping) |
|---|---|---|
| per-message decode (median) | 226–574ms | ~41ms |
| reopened conversation | — | 0ms (cache hit) |
| worst sig-block outlier | 404ms | 190ms → ~15ms after the candidate-restriction fix |

opt-z is fine — bumping `opt-level` is not warranted.

## Testing

- `cargo test --test email_integration`: **21/21 pass** (debug).
- Decode bench confirms correctness through the shared-tree path.
- Note: `cargo test --release` (full bin graph) remains broken by glossia's `cdylib`+`rlib` cargo #6313 collision (pre-existing, tracked upstream at glossia#13); use debug or `--lib`.

## Upstream

Filed and merged the three glossia issues this surfaced: #12 (cached tree getter), #13 (#6313 packaging), #14 (detect_dialect candidate filtering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
