### PR TITLE
Cosmetic improvements (#62)

### DIFF
--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -6099,8 +6099,8 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
         let msgs = session.uid_fetch(&uid_list, "(UID ENVELOPE)")?;
         for msg in msgs.iter() {
             let uid = match msg.uid { Some(u) => u, None => continue };
-            let mid = match msg.envelope().and_then(|e| e.message_id) {
-                Some(bytes) => std::str::from_utf8(bytes).unwrap_or("").to_string(),
+            let mid = match msg.envelope().and_then(|e| e.message_id.clone()) {
+                Some(bytes) => std::str::from_utf8(&bytes).unwrap_or("").to_string(),
                 None => { missing.push(uid); continue; }
             };
             let mid = mid.trim().trim_start_matches('<').trim_end_matches('>').trim().to_string();

--- a/tauri-app/frontend/index.html
+++ b/tauri-app/frontend/index.html
@@ -679,7 +679,7 @@
                                             <input type="checkbox" id="require-signature-preference" checked>
                                         </label>
                                     </div>
-                                    <small class="form-text text-muted">Only accept emails with valid Nostr signatures. Emails without signatures will be ignored.</small>
+                                    <small class="form-text text-muted">Permanently reject incoming emails that claim a Nostr pubkey but whose signature fails to verify (likely forged or tampered). These are never saved to your inbox. Plain emails with no Nostr signature are still accepted.</small>
                                 </li>
                                 
                                 <li class="toggle-settings-item">
@@ -719,7 +719,7 @@
                                             <input type="checkbox" id="hide-unsigned-messages-preference" checked>
                                         </label>
                                     </div>
-                                    <small class="form-text text-muted">Hide messages with missing or unverified signatures.</small>
+                                    <small class="form-text text-muted">Hide messages from the inbox view unless they have a valid Nostr signature — this includes both unsigned messages and those that fail verification. Messages stay in your inbox and reappear if you turn this off.</small>
                                 </li>
 
                                 <li class="toggle-settings-item">

--- a/tauri-app/frontend/js/contacts-service.js
+++ b/tauri-app/frontend/js/contacts-service.js
@@ -2382,9 +2382,8 @@ class ContactsService {
                 window.notificationService.hideLoading(loadingNotification);
                 if (unfollowedPubkeys.length > 0) {
                     window.notificationService.showInfo(`${unfollowedPubkeys.length} contacts converted to private (no longer in public follow list)`);
-                } else {
-                    window.notificationService.showInfo('No new contacts found in your follow list');
                 }
+                // No toast when there are simply no new contacts to add (issue #62).
             }
         } catch (error) {
             console.error('Failed to load contacts from network:', error);

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -2523,9 +2523,18 @@ class EmailService {
         // encrypted, show it decrypted first with an unlock icon and let the user
         // toggle back to the ciphertext — mirroring the body decrypt toggle.
         const rawSubject = domManager.getValue('subject') || '';
-        if (window.Utils && window.Utils.isLikelyEncryptedContent(rawSubject)) {
-            (async () => {
-                try {
+        (async () => {
+            try {
+                // The subject may be raw NIP ciphertext OR glossia-encoded prose
+                // (default encoding is glossia latin, which looks like plain words
+                // and is indistinguishable from a real subject without decoding).
+                // isLikelyEncryptedContent only recognizes the base64 layer, so we
+                // also attempt a glossia decode — mirroring the sent-mail detection
+                // at _loadSentEmailDetail. The backend decrypt_subject re-decodes
+                // glossia internally, so rawSubject can be passed through as-is.
+                const looksEncrypted = (window.Utils && window.Utils.isLikelyEncryptedContent(rawSubject))
+                    || !!(await this.decodeGlossiaSubject(rawSubject));
+                if (looksEncrypted) {
                     const pubkey = this.selectedNostrContact?.pubkey;
                     if (!pubkey || !appState.hasKeypair()) return;
                     const bodyForDecrypt = plainBody || this._plainBody || domManager.getValue('messageBody') || '';
@@ -2547,11 +2556,11 @@ class EmailService {
                         lock.title = isDecrypted ? 'Click to show encrypted' : 'Click to decrypt';
                     });
                     span.insertAdjacentElement('afterend', lock);
-                } catch (e) {
-                    console.warn('[JS] Preview subject decrypt toggle failed:', e);
                 }
-            })();
-        }
+            } catch (e) {
+                console.warn('[JS] Preview subject decrypt toggle failed:', e);
+            }
+        })();
     }
 
     async sendEncryptedEmail(emailConfig, contact, subject, body, messageId, toAddress) {

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -5212,6 +5212,7 @@ ${attachmentsHtml}
                         isUnknownSigner = senderInfo.isUnknownSigner;
                         unknownSignerPubkey = senderInfo.senderPubkey;
                         if (senderInfo.hasSignature
+                            && !senderInfo.contact
                             && senderInfo.fromAddress
                             && senderInfo.identityName !== senderInfo.fromAddress) {
                             fromAddressLabelThread = `<span class="email-sender-secondary">&lt;${Utils.escapeHtml(senderInfo.fromAddress)}&gt;</span>`;

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -5285,6 +5285,14 @@ ${attachmentsHtml}
                     const attachmentsHtml = await this._buildThreadCardAttachmentsHtml(
                         email, manifestAttachmentsForCard, source
                     );
+                    // When the card is collapsed we hide the full download section and
+                    // surface just a paperclip indicator in the header instead (issue #62).
+                    const threadAttachmentCount = typeof email.attachment_count === 'number'
+                        ? email.attachment_count
+                        : (email.attachments ? email.attachments.length : 0);
+                    const collapsedAttachmentIndicator = attachmentsHtml
+                        ? `<span class="thread-attachment-indicator" title="Has attachments">📎${threadAttachmentCount > 0 ? ' ' + threadAttachmentCount : ''}</span>`
+                        : '';
 
                     const cardDiv = document.createElement('div');
                     cardDiv.className = 'email-detail-card';
@@ -5299,6 +5307,7 @@ ${signatureIcon}
 ${unknownBadgeThread}
 ${fromAddressLabelThread}
 ${transportAuthIcon}
+${collapsedAttachmentIndicator}
 <span class="email-body-snippet">${snippet}</span>
 <div class="email-sender-time">${Utils.escapeHtml(timeAgo)}</div>
 </div>

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -214,7 +214,11 @@ class EmailService {
         const from = Utils.escapeHtml(senderInfo.fromAddress);
         const unknownBadge = this._renderUnknownContactBadge(senderInfo);
         if (senderInfo.hasSignature) {
-            const showSecondary = senderInfo.fromAddress
+            // For known contacts show only the nostr identity name — not the email
+            // address (issue #62). Unknown signers still surface the From: address,
+            // but there identityName already equals fromAddress so nothing is duplicated.
+            const showSecondary = !senderInfo.contact
+                && senderInfo.fromAddress
                 && senderInfo.identityName !== senderInfo.fromAddress;
             const secondary = showSecondary
                 ? ` <span class="email-sender-secondary">&lt;${from}&gt;</span>`
@@ -303,19 +307,24 @@ class EmailService {
                             <div class="attachment-meta" style="font-size:0.9em;color:#666;">${sizeFormatted}</div>
                         </div>
                     </div>
-                    <button class="btn btn-sm btn-outline-primary" onclick="${downloadCall}">
-                        <i class="fas fa-download"></i> Download
+                    <button class="btn btn-sm btn-outline-primary" onclick="${downloadCall}" title="Download ${Utils.escapeHtml(displayName)}" aria-label="Download ${Utils.escapeHtml(displayName)}">
+                        <i class="fas fa-download"></i>
                     </button>
                 </div>`;
         }).join('');
 
+        // Only offer "Download All" when there's more than one attachment —
+        // with a single file the per-item download button already covers it (issue #62).
+        const downloadAllHtml = items.length > 1
+            ? `<button class="btn btn-sm btn-outline-success" onclick="window.emailService.${downloadAllFn}(${email.id})" title="Download all attachments as ZIP">
+                        <i class="fas fa-download"></i> Download All
+                    </button>`
+            : '';
         return `
             <div class="email-attachments" style="margin:15px 0;">
                 <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
                     <h4 style="margin:0;">Attachments (${items.length})</h4>
-                    <button class="btn btn-sm btn-outline-success" onclick="window.emailService.${downloadAllFn}(${email.id})" title="Download all attachments as ZIP">
-                        <i class="fas fa-download"></i> Download All
-                    </button>
+                    ${downloadAllHtml}
                 </div>
                 <div class="attachment-list">${itemsHtml}</div>
             </div>`;
@@ -2401,7 +2410,7 @@ class EmailService {
             <div style="margin-bottom:1em;font-size:0.95em;line-height:1.8;">
                 <div><strong>From:</strong> ${fromAddr} ${headerBadge}</div>
                 <div><strong>To:</strong> ${toAddr}</div>
-                <div><strong>Subject:</strong> ${subject}</div>
+                <div><strong>Subject:</strong> <span id="preview-subject-text">${subject}</span></div>
             </div>
             <hr style="border:none;border-top:1px solid #ccc;margin:0 0 1em;">`;
 
@@ -2492,7 +2501,7 @@ class EmailService {
                 } catch (e) {
                     console.warn('[JS] Preview pre-decrypt failed:', e);
                 }
-                Utils.renderHtmlBodyInIframe('preview-html-body', htmlToRender, { decryptedTexts: decryptResults });
+                Utils.renderHtmlBodyInIframe('preview-html-body', htmlToRender, { decryptedTexts: decryptResults, startDecrypted: true });
             };
             renderHtmlWithSigBadge();
         } else if (hasHtml) {
@@ -2509,6 +2518,40 @@ class EmailService {
                 modal.querySelector(`.preview-tab-panel[data-panel="${tab.dataset.tab}"]`).classList.add('active');
             });
         });
+
+        // Subject lock/unlock toggle (issue #62): when the composed subject is
+        // encrypted, show it decrypted first with an unlock icon and let the user
+        // toggle back to the ciphertext — mirroring the body decrypt toggle.
+        const rawSubject = domManager.getValue('subject') || '';
+        if (window.Utils && window.Utils.isLikelyEncryptedContent(rawSubject)) {
+            (async () => {
+                try {
+                    const pubkey = this.selectedNostrContact?.pubkey;
+                    if (!pubkey || !appState.hasKeypair()) return;
+                    const bodyForDecrypt = plainBody || this._plainBody || domManager.getValue('messageBody') || '';
+                    const res = await TauriService.decryptEmailBody(bodyForDecrypt, rawSubject, pubkey, null);
+                    const decryptedSubject = res && res.subject;
+                    if (!decryptedSubject || decryptedSubject === rawSubject) return;
+                    const span = document.getElementById('preview-subject-text');
+                    if (!span) return;
+                    const lock = document.createElement('i');
+                    lock.className = 'fas fa-lock-open';
+                    lock.style.cssText = 'cursor:pointer;margin-left:0.5em;opacity:0.7;';
+                    lock.title = 'Click to show encrypted';
+                    let isDecrypted = true;
+                    span.textContent = decryptedSubject; // decrypted view first (issue #62)
+                    lock.addEventListener('click', () => {
+                        isDecrypted = !isDecrypted;
+                        span.textContent = isDecrypted ? decryptedSubject : rawSubject;
+                        lock.className = isDecrypted ? 'fas fa-lock-open' : 'fas fa-lock';
+                        lock.title = isDecrypted ? 'Click to show encrypted' : 'Click to decrypt';
+                    });
+                    span.insertAdjacentElement('afterend', lock);
+                } catch (e) {
+                    console.warn('[JS] Preview subject decrypt toggle failed:', e);
+                }
+            })();
+        }
     }
 
     async sendEncryptedEmail(emailConfig, contact, subject, body, messageId, toAddress) {
@@ -4498,6 +4541,7 @@ class EmailService {
                     const defaultAvatar = senderInfo.defaultAvatar;
                     const senderName = senderInfo.identityName;
                     const fromAddressLabel = senderInfo.hasSignature
+                        && !senderInfo.contact
                         && senderInfo.fromAddress
                         && senderInfo.identityName !== senderInfo.fromAddress
                         ? `<span class="email-sender-secondary">&lt;${Utils.escapeHtml(senderInfo.fromAddress)}&gt;</span>`
@@ -7326,10 +7370,12 @@ ${attachmentsHtml}
                 const keypair = appState.getKeypair();
                 if (!keypair) {
                     previewText = 'Unable to decrypt: no keypair';
+                    showSubject = false; // don't show the encrypted subject (issue #62)
                 } else {
                     const recipientPubkey = email.recipient_pubkey || email.nostr_pubkey;
                     if (!recipientPubkey) {
                         previewText = 'Could not decrypt';
+                        showSubject = false; // don't show the encrypted subject (issue #62)
                     } else {
                         try {
                             const result = await TauriService.decryptEmailBody(
@@ -7344,11 +7390,13 @@ ${attachmentsHtml}
                                 showSubject = true;
                             } else {
                                 previewText = 'Could not decrypt';
+                                showSubject = false; // don't show the encrypted subject (issue #62)
                             }
                             this._retrofitSubjectHashAndBackfill(email, result.subjectCiphertext);
                         } catch (e) {
                             console.error('[JS] Backend decrypt failed for sent preview:', e);
                             previewText = 'Could not decrypt';
+                            showSubject = false; // don't show the encrypted subject (issue #62)
                         }
                     }
                 }

--- a/tauri-app/frontend/js/utils.js
+++ b/tauri-app/frontend/js/utils.js
@@ -46,14 +46,7 @@ class Utils {
                    background: ${isDark ? '#232946' : '#fff'}; }
             img { max-width: 100%; height: auto; }
             a { color: ${isDark ? '#93c5fd' : '#2563eb'}; }
-            blockquote { cursor: default; position: relative; }
-            blockquote::before {
-                content: '';
-                position: absolute;
-                left: 0; top: 0; bottom: 0;
-                width: 12px;
-                cursor: pointer;
-            }
+            blockquote { cursor: pointer; position: relative; }
             blockquote.collapsed > *:not(.collapse-hint) { display: none; }
             .collapse-hint {
                 font-size: 0.8em; color: ${isDark ? '#9ca3af' : '#6b7280'};
@@ -94,9 +87,11 @@ class Utils {
                 bq.insertBefore(hint, bq.firstChild);
                 if (startCollapsed) bq.classList.add('collapsed');
                 bq.addEventListener('click', (e) => {
-                    // Only toggle when clicking on the left quote bar (within 12px of left edge)
-                    const rect = bq.getBoundingClientRect();
-                    if (e.clientX - rect.left > 12) return;
+                    // Clicking anywhere on the quoted row toggles it (issue #62).
+                    // Skip links, and let the innermost blockquote handle nested
+                    // clicks so an outer quote doesn't also toggle.
+                    if (e.target.closest('a')) return;
+                    if (e.target.closest('blockquote') !== bq) return;
                     e.stopPropagation();
                     const collapsed = bq.classList.toggle('collapsed');
                     hint.style.display = collapsed ? '' : 'none';

--- a/tauri-app/frontend/styles/email.css
+++ b/tauri-app/frontend/styles/email.css
@@ -1374,9 +1374,27 @@ body.dark-mode .email-body-snippet {
 .email-detail-card.collapsed .thread-card-actions,
 .email-detail-card.collapsed .email-detail-body,
 .email-detail-card.collapsed .email-raw-content,
+.email-detail-card.collapsed .email-attachments,
 .email-detail-card.collapsed .signature-indicator,
 .email-detail-card.collapsed .transport-auth-indicator {
     display: none;
+}
+
+/* Attachment paperclip shown in the collapsed card header in place of the
+   full download section (issue #62). Hidden once the card is expanded. */
+.thread-attachment-indicator {
+    display: none;
+    font-size: 0.8125rem;
+    color: #6b7280;
+    white-space: nowrap;
+}
+
+body.dark-mode .thread-attachment-indicator {
+    color: #9ca3af;
+}
+
+.email-detail-card.collapsed .thread-attachment-indicator {
+    display: inline;
 }
 
 .email-detail-card.collapsed {

--- a/tauri-app/frontend/styles/responsive.css
+++ b/tauri-app/frontend/styles/responsive.css
@@ -238,6 +238,7 @@
     }
 
     .email-detail-header,
+    .email-detail-subject,
     .thread-subject-header {
         padding-left: var(--spacing-md);
         padding-right: var(--spacing-md);


### PR DESCRIPTION
Addresses #62 — a batch of cosmetic UI improvements.

## Checklist

**Preview**
- [x] Show the decrypted view first, with an unlock icon
- [x] Show a lock/unlock indicator for the subject line

**Email view cards**
- [x] Don't show the "Download all" button when there's only one attachment
- [x] Use a download icon only (drop the text label)
- [x] Don't show the email address in the label line for contacts — show only the nostr identity name
- [x] Fix subject title being flush with the left edge of the screen on mobile
- [x] Make clicking anywhere on the quoted row expand it (not just the left vertical line)

**Inbox / Sent mail list**
- [x] Don't show the encrypted subject when it can't be decrypted

**Alerts**
- [x] Don't alert "No new contacts found in your follow list" when that's the case

## Notes on implementation

- **Preview** (`showHeadersModal`): the body now renders with `startDecrypted: true`; the subject gets a lock/unlock icon (`fa-lock-open` ↔ `fa-lock`) that toggles ciphertext/plaintext, defaulting to decrypted. Only appears when the composed subject is actually encrypted.
- **Attachments** (`_buildThreadCardAttachmentsHtml`): per-item buttons are now icon-only with an accessible `title`/`aria-label`; "Download All" is hidden when there's a single attachment.
- **Sender label**: `_renderSenderLine` and the detail-view `fromAddressLabel` now suppress the `<email>` secondary when the sender is a known contact.
- **Mobile**: added `.email-detail-subject` to the mobile left/right padding rule (the single-email detail subject lived in a container that drops side padding on mobile; the thread view's `.thread-subject-header` was already handled).
- **Quoted rows** (`renderHtmlBodyInIframe`): blockquote is now fully clickable (`cursor: pointer`); the click handler toggles on any click except links, and the innermost blockquote handles nested clicks.
- **Sent list**: the sent-mail preview now sets `showSubject = false` on every decrypt-failure branch, matching the inbox renderer.
- **Contacts sync**: removed the "No new contacts found" info toast.

Frontend is static JS with no build/lint step; `node --check` passes on all edited files. Visual changes haven't been exercised in a running app yet.

---
Closes #62