### PR TITLE
Honor the "Require Signatures" setting in the decrypt pipeline

### DIFF
--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -2800,6 +2800,12 @@ fn decrypt_armor_tree(
     user_pubkey_hex: &str,
     fallback_pubkey: &str,
     raw_headers: Option<&str>,
+    // When false (user disabled "Require Signatures"), NIP-04 signature
+    // verification failures no longer block decryption — the body is decrypted
+    // anyway and the UI still surfaces the invalid/missing-signature indicator
+    // via the separate verify path. When true (default), an unverified NIP-04
+    // message is rejected before decryption (the signature is NIP-04's only MAC).
+    require_signature: bool,
     depth: usize,
 ) -> (Vec<crate::types::DecryptedBlock>, Option<JsonManifest>) {
     let perf_level = std::time::Instant::now();
@@ -2823,7 +2829,7 @@ fn decrypt_armor_tree(
         // slice of that signed data, so the header sig would never verify against
         // them — pass None so inner levels rely solely on their inline signatures.
         let perf_inner = std::time::Instant::now();
-        let (inner_results, _) = decrypt_armor_tree(quoted, private_key, user_pubkey_hex, inner_fallback, None, depth + 1);
+        let (inner_results, _) = decrypt_armor_tree(quoted, private_key, user_pubkey_hex, inner_fallback, None, require_signature, depth + 1);
         inner_ms = perf_inner.elapsed().as_millis();
         results.extend(inner_results);
     }
@@ -2835,7 +2841,12 @@ fn decrypt_armor_tree(
     let perf_sig = std::time::Instant::now();
     let mut sig_verify_ran = false;
     let mut sig_verify_bytes_len: usize = 0;
-    if parsed.encryption_nip.as_deref() == Some("nip04") {
+    // Only enforce (and even compute) NIP-04 signature verification when the user
+    // requires signatures. With "Require Signatures" off, the user has opted into
+    // reading unauthenticated mail, so we skip the gate entirely and let decryption
+    // proceed; the missing/invalid signature still shows in the UI via the separate
+    // verify_all_signatures path.
+    if require_signature && parsed.encryption_nip.as_deref() == Some("nip04") {
         sig_verify_ran = true;
         // Compute the canonical signed bytes once: this level's raw decoded body
         // concatenated with all nested quoted body bytes. Both the inline
@@ -2987,6 +2998,10 @@ pub fn decrypt_email_body_pipeline(
     sender_pubkey: Option<&str>,
     recipient_pubkey: Option<&str>,
     raw_headers: Option<&str>,
+    // When false (user disabled "Require Signatures"), skip the NIP-04 signature
+    // gate so unauthenticated mail still decrypts. When true (default), an
+    // unverified NIP-04 message is rejected before decryption.
+    require_signature: bool,
     // When true, decrypt only the most recent (outermost) message and skip the
     // quoted thread history. DM conversation rendering uses this: the inline body
     // shows just the latest message (the full thread is reachable via the
@@ -3048,7 +3063,7 @@ pub fn decrypt_email_body_pipeline(
 
     // Walk the armor tree, decrypt each level
     let perf_tree = std::time::Instant::now();
-    let (block_results, manifest) = decrypt_armor_tree(&parsed, private_key, &user_pubkey_hex, fallback, raw_headers, 0);
+    let (block_results, manifest) = decrypt_armor_tree(&parsed, private_key, &user_pubkey_hex, fallback, raw_headers, require_signature, 0);
     let tree_ms = perf_tree.elapsed().as_millis();
 
     // Extract outermost decrypted body (last element in innermost-first array)
@@ -6154,7 +6169,7 @@ fn lookup_sync_cutoff_days(db: &Database, pubkey: &str) -> i64 {
 }
 
 /// Read `require_signature` for the active pubkey, defaulting to true.
-fn lookup_require_signature(db: &Database, pubkey: &str) -> bool {
+pub(crate) fn lookup_require_signature(db: &Database, pubkey: &str) -> bool {
     if let Ok(Some(value)) = db.get_setting(pubkey, "require_signature") {
         return value == "true";
     }

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -80,6 +80,17 @@ fn active_user_npub(state: &AppState) -> Option<String> {
         .and_then(|k| k.public_key().to_bech32().ok())
 }
 
+/// Read the active account's "Require Signatures" setting (defaults to true).
+/// Threaded into the decrypt pipeline so NIP-04 signature enforcement honors the
+/// user's choice instead of rejecting unverified mail unconditionally. Keyed by
+/// the same npub the inbox-sync filter uses (see email::lookup_require_signature).
+fn active_require_signature(state: &AppState) -> bool {
+    match (active_user_npub(state), state.get_database().ok()) {
+        (Some(pk), Some(db)) => email::lookup_require_signature(&db, &pk),
+        _ => true,
+    }
+}
+
 /// Best-effort: after saving a DM, fill in any matching email row's NULL
 /// pubkey fields using the DM's counterparty. Failures are logged, not
 /// surfaced — backfill is a recovery hint, not a critical write.
@@ -4239,6 +4250,7 @@ fn decrypt_email_body(
         sender_pubkey.as_deref(),
         recipient_pubkey.as_deref(),
         raw_headers.as_deref(),
+        active_require_signature(&state),
         false, // full thread: the email detail view may show quoted history
     )
 }
@@ -4253,6 +4265,8 @@ fn decrypt_email_bodies_batch(
     // Open DB once for the whole batch so each item can look up its raw_headers
     // by message_id for NIP-04 header-sig fallback verification.
     let db_opt = state.get_database().ok();
+    // One setting read for the whole batch — same value applies to every row.
+    let require_signature = active_require_signature(&state);
     let results = emails
         .into_iter()
         .map(|e| {
@@ -4269,6 +4283,7 @@ fn decrypt_email_bodies_batch(
                 e.sender_pubkey.as_deref(),
                 e.recipient_pubkey.as_deref(),
                 raw_headers.as_deref(),
+                require_signature,
                 false, // batch decrypt feeds the email list/detail; keep full thread
             ) {
                 Ok(result) => types::BatchDecryptResultItem {
@@ -6742,6 +6757,7 @@ fn db_get_matching_email_body(dm_event_id: String, private_key: Option<String>, 
     
     // Use the unified decrypt pipeline (handles glossia, NIP-04/44, manifest, nested blocks)
     // Try each candidate pubkey until one succeeds
+    let require_signature = active_require_signature(&state);
     for pubkey in &pubkeys_to_try {
         let sender_pk = if user_received_email { Some(pubkey.as_str()) } else { None };
         let recipient_pk = if user_sent_email { Some(pubkey.as_str()) } else { Some(pubkey.as_str()) };
@@ -6749,7 +6765,7 @@ fn db_get_matching_email_body(dm_event_id: String, private_key: Option<String>, 
         // inline (the full thread is one click away via the envelope icon), so we
         // skip decrypting quoted history the view never shows. See the pipeline's
         // `shallow` param — it's a no-op for NIP-04.
-        match email::decrypt_email_body_pipeline(&private_key, &email.body, &email.subject, sender_pk, recipient_pk, email.raw_headers.as_deref(), true) {
+        match email::decrypt_email_body_pipeline(&private_key, &email.body, &email.subject, sender_pk, recipient_pk, email.raw_headers.as_deref(), require_signature, true) {
             Ok(result) if result.success => {
                 println!("[RUST] decrypt_email_body_pipeline succeeded with pubkey: {}", pubkey);
                 return Ok(Some(types::MatchingEmailBodyResult {

--- a/tauri-app/backend/tests/email_integration.rs
+++ b/tauri-app/backend/tests/email_integration.rs
@@ -594,6 +594,7 @@ async fn nip04_header_sig_fallback_unlocks_decrypt() {
         Some(&alice_npub),
         Some(&bob_npub),
         None,
+        true,
         false,
     )
     .expect("pipeline returns Ok even on signature rejection");
@@ -620,6 +621,7 @@ async fn nip04_header_sig_fallback_unlocks_decrypt() {
         Some(&alice_npub),
         Some(&bob_npub),
         Some(&raw_headers),
+        true,
         false,
     )
     .expect("pipeline returns Ok when header sig verifies");
@@ -632,6 +634,31 @@ async fn nip04_header_sig_fallback_unlocks_decrypt() {
         with_headers.body.trim(),
         plaintext,
         "decrypted plaintext must round-trip"
+    );
+
+    // require_signature = false: the user opted into reading unauthenticated
+    // mail, so the same unsigned NIP-04 message decrypts even with no header sig
+    // available. This is the "Require Signatures" off path.
+    let unsigned_allowed = email::decrypt_email_body_pipeline(
+        &bob_nsec,
+        &delivered.body,
+        &delivered.subject,
+        Some(&alice_npub),
+        Some(&bob_npub),
+        None,
+        false, // require_signature off
+        false,
+    )
+    .expect("pipeline returns Ok with require_signature off");
+    assert!(
+        unsigned_allowed.success,
+        "unsigned NIP-04 must decrypt when Require Signatures is off, error={:?}",
+        unsigned_allowed.error
+    );
+    assert_eq!(
+        unsigned_allowed.body.trim(),
+        plaintext,
+        "decrypted plaintext must round-trip on the require_signature-off path"
     );
 }
 
@@ -946,6 +973,7 @@ async fn sent_mail_decrypts_via_recipient_header_without_dm() {
         None,
         Some(&recipient_from_header),
         None,
+        true,
         false,
     )
     .expect("decrypt_email_body_pipeline");
@@ -1037,6 +1065,7 @@ async fn sent_mail_undecryptable_without_any_counterparty_hint() {
         None,
         None,
         None,
+        true,
         false,
     )
     .expect("decrypt_email_body_pipeline returns Ok even when content can't be decrypted");
@@ -2229,6 +2258,7 @@ async fn nip44_reply_preserves_nested_encrypted_armor() {
         Some(&bob_npub),
         Some(&alice_npub),
         None,
+        true,
         false,
     )
     .expect("decrypt_email_body_pipeline");
@@ -2449,6 +2479,7 @@ async fn nip44_three_level_reply_chain() {
         Some(&alice_npub),
         Some(&bob_npub),
         None,
+        true,
         false,
     )
     .expect("decrypt pipeline");


### PR DESCRIPTION
## Summary

Follow-up to #69 (which merged at `eaf34ca`). This commit landed on the branch just after that merge, so it missed #69. Single commit, clean apply on current `staging`.

## Honor the "Require Signatures" setting in the decrypt pipeline (`d29fa07`)

The "Require Signatures" toggle already existed in the UI (default on) and was persisted, but the backend ignored it — unverified NIP-04 messages were always rejected before decryption (the signature is NIP-04's only MAC). This threads the setting through so the user's choice is honored:

- **off** → skip the NIP-04 signature gate; unauthenticated mail still decrypts (the missing/invalid signature still surfaces via the verify path + the Unsigned/Invalid badge).
- **on** (default) → keep the existing reject-before-decrypt behavior.

**Changes**
- `email.rs`: add `require_signature: bool` to `decrypt_armor_tree` and `decrypt_email_body_pipeline`.
- `lib.rs`: `active_require_signature(state)` reads the active account's setting via `email::lookup_require_signature` (defaults true); wired into `decrypt_email_body`, `decrypt_email_bodies_batch` (one read per batch), and `db_get_matching_email_body`.
- `email_integration.rs`: assert the `require_signature=false` path decrypts and round-trips an otherwise-unverified NIP-04 message.

Backend/frontend agree on the setting string (`"true"`/`"false"`, default true).

## Testing

`cargo test --test email_integration`: **21/21 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
