### PR TITLE
Move emails to custom IMAP folders + automated spam rescue

### DIFF
--- a/WorkLog.md
+++ b/WorkLog.md
@@ -1,3 +1,5 @@
+* inbox doesn't show emails when no email is set up, but sent mail does - should we display any emails that matched from the db? messages does.
+* preview is inverted from conversation view - can't decrypt when convo does and vice versa. sent seems to be displaying emails from the wrong user
 * adding mock data relays
 
 Workflow for android

--- a/docs/nostr-mail-spec.md
+++ b/docs/nostr-mail-spec.md
@@ -352,6 +352,40 @@ Since email clients strip `<style>` tags and external stylesheets, all styling M
    - For NIP-44: signature verification is recommended but not required (NIP-44 provides its own authentication via HMAC)
 8. **Decrypt** if encrypted, using recipient's private key and sender's pubkey
 
-## 9. Versioning
+## 9. Spam Rescue & Folder Handling
+
+Providers routinely misclassify Nostr-encrypted mail as spam (opaque bodies, armor blocks). Spam rescue is a client behavior that recovers it. Spam/junk/bulk folders are **never** part of the inbox folder selection; how their contents are handled is decided per sync by the `spam_rescue` setting (default ON):
+
+| `spam_rescue` | Spam folders scanned? | Behavior |
+|---------------|-----------------------|----------|
+| **ON** | No | Authenticated Nostr mail is **moved** out of spam into the rescue target folder (default `nostr-mail`), which is part of the synced set, so it surfaces in the inbox. Spam stays out of the inbox's read-state (`\Seen`) bookkeeping. |
+| **OFF** | Yes | Spam folders are scanned so misfiled Nostr mail still **appears** in the inbox, but nothing is moved — it stays in spam and is eventually auto-purged by the provider. |
+
+### 9.1 Rescue eligibility (stateless)
+
+A message in a spam folder is rescued **⟺** it is `UNSEEN` **AND** is authenticated Nostr mail — it carries a Nostr marker (`X-Nostr-Pubkey`/`X-Nostr-Sig` header, or a `BEGIN NOSTR …` armor block) **and** passes transport authentication (SPF/DKIM/alignment). Transport-failing mail is left in spam, matching the inbox's existing enforcement.
+
+The rescue decision is derived entirely from server state on every sync, so all devices compute the same answer. There is **no rescue-once ledger.**
+
+### 9.2 `\Seen` as the "leave it in spam" signal
+
+Intent is carried by the `\Seen` flag, which the IMAP server replicates to every client. The `UNSEEN` guard means a message the user has read **and deliberately filed into spam** is left alone. This is trustworthy because nothing automated ever sets `\Seen` on spam mail:
+
+- All IMAP fetches use `BODY.PEEK[]`, so reading a body never sets `\Seen`.
+- Read-state sync (`mark_inbox_email_seen_on_server`) only sets `\Seen` in non-spam inbox folders.
+- The **only** code path that sets `\Seen` within a spam folder is a deliberate move-to-spam (`move_message_to_folder`), which marks the message `\Seen` *before* moving it.
+
+### 9.3 On-enable catch-up
+
+When the user first switches spam rescue ON, a one-time catch-up (`rescue_spam_now`) runs the rescue with the `UNSEEN` guard **dropped**, so already-read Nostr mail sitting in spam — which the per-sync rescue intentionally skips — is swept out too. The user is told how many messages were moved.
+
+### 9.4 Future work: a first-class "mark as spam" action
+
+There is currently **no dedicated "mark as spam" UI.** A message can only reach a spam folder via the generic *Move to folder* picker, which already routes through `move_message_to_folder` and therefore sets `\Seen` on a spam target. When a dedicated mark-as-spam action is added:
+
+- Route it through the same `move_message_to_folder` → spam-folder path so it sets `\Seen`; the per-sync rescue (§9.2) will then automatically respect it as a "leave it" signal with no further changes.
+- Reconsider the on-enable catch-up (§9.3): with a real spam-filing action, the catch-up's `unseen_only = false` would *undo* a deliberate spam-filing. At that point the catch-up should likely honor `\Seen` (keep `unseen_only = true`) so it only sweeps provider-misclassified mail, not user-filed spam.
+
+## 10. Versioning
 
 This specification may be extended with additional block types in future versions. Decoders SHOULD ignore unrecognized block types rather than failing.

--- a/tauri-app/backend/src/database.rs
+++ b/tauri-app/backend/src/database.rs
@@ -517,10 +517,6 @@ impl Database {
         // pagination ("fetch older from server").
         Self::migrate_add_min_seen_uid_column(&conn)?;
 
-        // Migrate: Add rescued_message_ids table so spam rescue moves each
-        // message at most once (respects a user's deliberate move-to-spam).
-        Self::migrate_add_rescued_message_ids_table(&conn)?;
-
         // Migrate: One-shot cleanup of duplicate DM rows that slipped past the
         // old outer-wrap-id dedup. Safe to run on every startup (idempotent).
         Self::migrate_collapse_dm_rumor_duplicates(&conn)?;
@@ -1032,67 +1028,6 @@ impl Database {
                 [],
             )?;
         }
-        Ok(())
-    }
-
-    /// Migration: Add rescued_message_ids table.
-    /// Records which messages spam rescue has already moved out of Spam, keyed
-    /// by (pubkey, normalized message_id), so a message is rescued at most once
-    /// and a later deliberate move-to-spam by the user is respected.
-    fn migrate_add_rescued_message_ids_table(conn: &Connection) -> Result<()> {
-        let table_exists = {
-            let mut stmt = conn.prepare(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='rescued_message_ids'"
-            )?;
-            let mut rows = stmt.query([])?;
-            rows.next()?.is_some()
-        };
-
-        if !table_exists {
-            println!("[DB] Creating rescued_message_ids table");
-            conn.execute(
-                "CREATE TABLE rescued_message_ids (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    pubkey TEXT NOT NULL,
-                    message_id TEXT NOT NULL,
-                    rescued_at DATETIME NOT NULL,
-                    UNIQUE(pubkey, message_id)
-                )",
-                [],
-            )?;
-            conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_rescued_message_ids_pubkey ON rescued_message_ids(pubkey)",
-                [],
-            )?;
-        }
-        Ok(())
-    }
-
-    /// True if spam rescue has already moved this message for this account.
-    pub fn is_message_id_rescued(&self, pubkey: &str, message_id: &str) -> Result<bool> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT 1 FROM rescued_message_ids WHERE pubkey = ? AND message_id = ? LIMIT 1",
-        )?;
-        let mut rows = stmt.query(params![
-            pubkey.trim().to_lowercase(),
-            Self::normalize_message_id(message_id),
-        ])?;
-        Ok(rows.next()?.is_some())
-    }
-
-    /// Record that spam rescue moved this message (idempotent).
-    pub fn add_rescued_message_id(&self, pubkey: &str, message_id: &str) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT OR IGNORE INTO rescued_message_ids (pubkey, message_id, rescued_at)
-             VALUES (?, ?, ?)",
-            params![
-                pubkey.trim().to_lowercase(),
-                Self::normalize_message_id(message_id),
-                Utc::now(),
-            ],
-        )?;
         Ok(())
     }
 

--- a/tauri-app/backend/src/database.rs
+++ b/tauri-app/backend/src/database.rs
@@ -517,6 +517,10 @@ impl Database {
         // pagination ("fetch older from server").
         Self::migrate_add_min_seen_uid_column(&conn)?;
 
+        // Migrate: Add rescued_message_ids table so spam rescue moves each
+        // message at most once (respects a user's deliberate move-to-spam).
+        Self::migrate_add_rescued_message_ids_table(&conn)?;
+
         // Migrate: One-shot cleanup of duplicate DM rows that slipped past the
         // old outer-wrap-id dedup. Safe to run on every startup (idempotent).
         Self::migrate_collapse_dm_rumor_duplicates(&conn)?;
@@ -1028,6 +1032,67 @@ impl Database {
                 [],
             )?;
         }
+        Ok(())
+    }
+
+    /// Migration: Add rescued_message_ids table.
+    /// Records which messages spam rescue has already moved out of Spam, keyed
+    /// by (pubkey, normalized message_id), so a message is rescued at most once
+    /// and a later deliberate move-to-spam by the user is respected.
+    fn migrate_add_rescued_message_ids_table(conn: &Connection) -> Result<()> {
+        let table_exists = {
+            let mut stmt = conn.prepare(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='rescued_message_ids'"
+            )?;
+            let mut rows = stmt.query([])?;
+            rows.next()?.is_some()
+        };
+
+        if !table_exists {
+            println!("[DB] Creating rescued_message_ids table");
+            conn.execute(
+                "CREATE TABLE rescued_message_ids (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    pubkey TEXT NOT NULL,
+                    message_id TEXT NOT NULL,
+                    rescued_at DATETIME NOT NULL,
+                    UNIQUE(pubkey, message_id)
+                )",
+                [],
+            )?;
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_rescued_message_ids_pubkey ON rescued_message_ids(pubkey)",
+                [],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// True if spam rescue has already moved this message for this account.
+    pub fn is_message_id_rescued(&self, pubkey: &str, message_id: &str) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT 1 FROM rescued_message_ids WHERE pubkey = ? AND message_id = ? LIMIT 1",
+        )?;
+        let mut rows = stmt.query(params![
+            pubkey.trim().to_lowercase(),
+            Self::normalize_message_id(message_id),
+        ])?;
+        Ok(rows.next()?.is_some())
+    }
+
+    /// Record that spam rescue moved this message (idempotent).
+    pub fn add_rescued_message_id(&self, pubkey: &str, message_id: &str) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO rescued_message_ids (pubkey, message_id, rescued_at)
+             VALUES (?, ?, ?)",
+            params![
+                pubkey.trim().to_lowercase(),
+                Self::normalize_message_id(message_id),
+                Utc::now(),
+            ],
+        )?;
         Ok(())
     }
 

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -6381,18 +6381,34 @@ fn list_spam_folders(
         .collect()
 }
 
-/// Lenient nostr-message detector for the rescue path: a message qualifies if it
-/// carries the `X-Nostr-Pubkey` header OR an inline encryption armor marker.
-/// Deliberately does NOT require transport authentication (DKIM/SPF) — messages
-/// often land in spam precisely because that check failed, so demanding it here
-/// would refuse to rescue the very mail this feature targets.
-fn body_is_nostr_message(raw_body: &[u8]) -> bool {
+/// Decide whether a message sitting in a spam folder should be rescued.
+///
+/// A message qualifies when BOTH hold:
+/// 1. It carries a nostr marker — an `X-Nostr-Pubkey` or `X-Nostr-Sig` header,
+///    or an inline `BEGIN NOSTR ...` armor block (encrypted body, signed body,
+///    signature, or seal).
+/// 2. It passes transport authentication (SPF/DKIM/alignment).
+///
+/// Transport auth is required because the rest of the inbox enforces it: a
+/// message that fails it would be moved out of spam yet still get filtered from
+/// the inbox, stranding it where the user can't see it. Mail that fails SPF/DKIM
+/// is therefore deliberately left in spam — only authenticated nostr mail that
+/// the provider misfiled gets rescued.
+fn should_rescue_message(raw_body: &[u8]) -> bool {
     let text = String::from_utf8_lossy(raw_body);
-    text.contains("X-Nostr-Pubkey:")
-        || text.contains("BEGIN NOSTR NIP-04 ENCRYPTED MESSAGE")
-        || text.contains("BEGIN NOSTR NIP-44 ENCRYPTED MESSAGE")
-        || text.contains("BEGIN NOSTR NIP-04 ENCRYPTED BODY")
-        || text.contains("BEGIN NOSTR NIP-44 ENCRYPTED BODY")
+    let has_nostr_marker = text.contains("X-Nostr-Pubkey:")
+        || text.contains("X-Nostr-Sig:")
+        || text.contains("BEGIN NOSTR NIP-")
+        || text.contains("BEGIN NOSTR SIGNED")
+        || text.contains("BEGIN NOSTR SIGNATURE")
+        || text.contains("BEGIN NOSTR SEAL");
+    if !has_nostr_marker {
+        return false;
+    }
+    match verify_transport_authentication(Some(raw_body), None) {
+        Ok(verdict) => verdict.transport_verified,
+        Err(_) => false,
+    }
 }
 
 /// Move a UID set into `target_folder`, creating the folder if needed. Uses the
@@ -6444,13 +6460,18 @@ fn rescue_nostr_emails_from_spam(
         }
 
         // Cheap server-side narrowing to candidate UIDs: header-marked messages
-        // plus anything whose body carries an armor marker. BODY search support
-        // varies by server, so we re-confirm each candidate by fetching it.
+        // (X-Nostr-Pubkey / X-Nostr-Sig) plus anything whose body carries a nostr
+        // armor block (encrypted, signed, signature, or seal). BODY search support
+        // varies by server, so we re-confirm each candidate by fetching it and
+        // checking the transport auth gate.
         let mut candidates: std::collections::HashSet<u32> = std::collections::HashSet::new();
         for query in &[
             "HEADER X-Nostr-Pubkey \"\"",
-            "BODY \"BEGIN NOSTR NIP-04 ENCRYPTED\"",
-            "BODY \"BEGIN NOSTR NIP-44 ENCRYPTED\"",
+            "HEADER X-Nostr-Sig \"\"",
+            "BODY \"BEGIN NOSTR NIP-\"",
+            "BODY \"BEGIN NOSTR SIGNED\"",
+            "BODY \"BEGIN NOSTR SIGNATURE\"",
+            "BODY \"BEGIN NOSTR SEAL\"",
         ] {
             if let Ok(found) = session.uid_search(*query) {
                 candidates.extend(found);
@@ -6473,7 +6494,7 @@ fn rescue_nostr_emails_from_spam(
             };
             for msg in messages.iter() {
                 if let (Some(uid), Some(body)) = (msg.uid, msg.body()) {
-                    if body_is_nostr_message(body) {
+                    if should_rescue_message(body) {
                         confirmed.push(uid);
                     }
                 }

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -5141,6 +5141,8 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
     let account_key = config.email_address.trim().to_lowercase();
     let sync_cutoff_days = lookup_sync_cutoff_days(db, active_pubkey);
     let require_signature = lookup_require_signature(db, active_pubkey);
+    let spam_rescue = lookup_spam_rescue(db, active_pubkey);
+    let rescue_target = lookup_spam_rescue_target(db, active_pubkey);
 
     // Folders to scan. Default (empty/None) = provider-aware list from
     // `default_inbox_folders`, with any *spam*-named server folder appended
@@ -5169,6 +5171,12 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
     };
     let mut folders = folders;
 
+    // With spam rescue on, ensure the rescue target is in the scan set so moved
+    // messages land in the local DB during this same pass.
+    if spam_rescue && !folders.iter().any(|f| f.eq_ignore_ascii_case(&rescue_target)) {
+        folders.push(rescue_target.clone());
+    }
+
     println!(
         "[RUST] sync_nostr_emails_to_db: account={}, folders={:?}, sync_cutoff_days={} (bootstrap only)",
         account_key, folders, sync_cutoff_days
@@ -5193,6 +5201,12 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
         let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
         if expand_spam {
             extend_with_spam_folders(&mut session, &mut folders);
+        }
+        if spam_rescue {
+            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target);
+            if moved > 0 {
+                println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
+            }
         }
         println!("[RUST] sync_nostr_emails_to_db: folders after spam expansion: {:?}", folders);
         for f in &folders {
@@ -5225,6 +5239,12 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
         let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
         if expand_spam {
             extend_with_spam_folders(&mut session, &mut folders);
+        }
+        if spam_rescue {
+            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target);
+            if moved > 0 {
+                println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
+            }
         }
         println!("[RUST] sync_nostr_emails_to_db: folders after spam expansion: {:?}", folders);
         for f in &folders {
@@ -6310,6 +6330,26 @@ pub(crate) fn lookup_require_signature(db: &Database, pubkey: &str) -> bool {
     true
 }
 
+/// Read `spam_rescue` for the active pubkey, defaulting to false (opt-in).
+pub(crate) fn lookup_spam_rescue(db: &Database, pubkey: &str) -> bool {
+    if let Ok(Some(value)) = db.get_setting(pubkey, "spam_rescue") {
+        return value == "true";
+    }
+    false
+}
+
+/// Read the folder spam-rescued nostr mail should be moved into, defaulting to
+/// `nostr-mail`. Blank/whitespace settings fall back to the default.
+pub(crate) fn lookup_spam_rescue_target(db: &Database, pubkey: &str) -> String {
+    if let Ok(Some(value)) = db.get_setting(pubkey, "spam_rescue_target") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    "nostr-mail".to_string()
+}
+
 /// Discover sent mailbox name using IMAP LIST command
 /// Returns the actual mailbox name found, or None if no sent mailbox exists
 /// Append any server mailbox whose name contains "spam", "junk", or "bulk"
@@ -6319,6 +6359,143 @@ pub(crate) fn lookup_require_signature(db: &Database, pubkey: &str) -> bool {
 /// `Junk Email`, Fastmail's `Junk`, Yahoo's `Bulk Mail`, etc. Failures during
 /// LIST are non-fatal — the sync will just proceed with the pre-expansion
 /// folder set.
+/// Return every server mailbox whose name contains "spam", "junk", or "bulk"
+/// (case-insensitive). Failures during LIST are non-fatal — returns empty.
+fn list_spam_folders(
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+) -> Vec<String> {
+    let mailboxes = match session.list(Some(""), Some("*")) {
+        Ok(m) => m,
+        Err(e) => {
+            debug_log!("[RUST] list_spam_folders: LIST failed: {}", e);
+            return Vec::new();
+        }
+    };
+    mailboxes
+        .iter()
+        .map(|mb| mb.name().to_string())
+        .filter(|name| {
+            let lower = name.to_lowercase();
+            lower.contains("spam") || lower.contains("junk") || lower.contains("bulk")
+        })
+        .collect()
+}
+
+/// Lenient nostr-message detector for the rescue path: a message qualifies if it
+/// carries the `X-Nostr-Pubkey` header OR an inline encryption armor marker.
+/// Deliberately does NOT require transport authentication (DKIM/SPF) — messages
+/// often land in spam precisely because that check failed, so demanding it here
+/// would refuse to rescue the very mail this feature targets.
+fn body_is_nostr_message(raw_body: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(raw_body);
+    text.contains("X-Nostr-Pubkey:")
+        || text.contains("BEGIN NOSTR NIP-04 ENCRYPTED MESSAGE")
+        || text.contains("BEGIN NOSTR NIP-44 ENCRYPTED MESSAGE")
+        || text.contains("BEGIN NOSTR NIP-04 ENCRYPTED BODY")
+        || text.contains("BEGIN NOSTR NIP-44 ENCRYPTED BODY")
+}
+
+/// Move a UID set into `target_folder`, creating the folder if needed. Uses the
+/// IMAP UID MOVE command, falling back to UID COPY + flag-deleted + EXPUNGE on
+/// servers without MOVE. UID-based so source sequence renumbering during the
+/// operation can't misaddress messages.
+fn move_uids_to_folder(
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+    uid_set: &str,
+    target_folder: &str,
+) -> Result<()> {
+    if session.uid_mv(uid_set, target_folder).is_ok() {
+        return Ok(());
+    }
+    // Target may not exist yet — create and retry.
+    if session.create(target_folder).is_ok() && session.uid_mv(uid_set, target_folder).is_ok() {
+        return Ok(());
+    }
+    if session.uid_copy(uid_set, target_folder).is_ok() {
+        session.uid_store(uid_set, "+FLAGS (\\Deleted)")?;
+        session.expunge()?;
+        return Ok(());
+    }
+    Err(anyhow::anyhow!("Failed to move UIDs {} to folder {}", uid_set, target_folder))
+}
+
+/// Scan every spam/junk/bulk folder and move nostr messages out of them into
+/// `target_folder`, so providers' misclassified encrypted mail stays reachable.
+/// Returns the number of messages moved. Per-folder failures are logged and
+/// skipped — rescue is best-effort and never aborts the surrounding sync.
+fn rescue_nostr_emails_from_spam(
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+    target_folder: &str,
+) -> usize {
+    let spam_folders = list_spam_folders(session);
+    if spam_folders.is_empty() {
+        return 0;
+    }
+    // Make sure the destination exists before we start moving into it.
+    let _ = session.create(target_folder);
+
+    let mut moved_total = 0usize;
+    for folder in spam_folders {
+        if folder.eq_ignore_ascii_case(target_folder) {
+            continue;
+        }
+        if session.select(&folder).is_err() {
+            continue;
+        }
+
+        // Cheap server-side narrowing to candidate UIDs: header-marked messages
+        // plus anything whose body carries an armor marker. BODY search support
+        // varies by server, so we re-confirm each candidate by fetching it.
+        let mut candidates: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        for query in &[
+            "HEADER X-Nostr-Pubkey \"\"",
+            "BODY \"BEGIN NOSTR NIP-04 ENCRYPTED\"",
+            "BODY \"BEGIN NOSTR NIP-44 ENCRYPTED\"",
+        ] {
+            if let Ok(found) = session.uid_search(*query) {
+                candidates.extend(found);
+            }
+        }
+        if candidates.is_empty() {
+            continue;
+        }
+
+        let mut confirmed: Vec<u32> = Vec::new();
+        let uids: Vec<u32> = candidates.into_iter().collect();
+        for chunk in uids.chunks(500) {
+            let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
+            let messages = match session.uid_fetch(&uid_list, "(UID RFC822)") {
+                Ok(m) => m,
+                Err(e) => {
+                    debug_log!("[RUST] rescue_nostr_emails_from_spam: fetch in '{}' failed: {}", folder, e);
+                    continue;
+                }
+            };
+            for msg in messages.iter() {
+                if let (Some(uid), Some(body)) = (msg.uid, msg.body()) {
+                    if body_is_nostr_message(body) {
+                        confirmed.push(uid);
+                    }
+                }
+            }
+        }
+
+        if confirmed.is_empty() {
+            continue;
+        }
+        let uid_set = confirmed.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
+        match move_uids_to_folder(session, &uid_set, target_folder) {
+            Ok(_) => {
+                debug_log!("[RUST] rescue_nostr_emails_from_spam: moved {} message(s) from '{}' to '{}'",
+                    confirmed.len(), folder, target_folder);
+                moved_total += confirmed.len();
+            }
+            Err(e) => debug_log!("[RUST] rescue_nostr_emails_from_spam: move from '{}' failed: {}", folder, e),
+        }
+    }
+    moved_total
+}
+
 fn extend_with_spam_folders(
     session: &mut imap::Session<impl std::io::Read + std::io::Write>,
     folders: &mut Vec<String>,

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -1087,6 +1087,17 @@ fn move_message_to_folder(
 
     debug_log!("[RUST] move_message_to_folder: Moving message {} to {}", message_seq, target_folder);
 
+    // When the user deliberately files a message INTO a spam folder, mark it
+    // \Seen first. Spam rescue only pulls UNSEEN mail out of spam, so a read
+    // message sitting in spam is the user's "leave it here" signal — and because
+    // it's a server flag it's the same answer on every device. Our sync uses
+    // BODY.PEEK[] everywhere, so nothing automated ever sets \Seen; this is the
+    // only path that does, and that flag must not be auto-cleared on spam mail.
+    // IMAP COPY/MOVE preserve flags, so setting it before the move is enough.
+    if is_spam_folder_name(target_folder) {
+        let _ = session.store(&seq_str, "+FLAGS (\\Seen)");
+    }
+
     // Try MOVE first.
     if session.mv(&seq_str, target_folder).is_ok() {
         debug_log!("[RUST] move_message_to_folder: Successfully moved via MOVE command");
@@ -5143,6 +5154,7 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
     let require_signature = lookup_require_signature(db, active_pubkey);
     let spam_rescue = lookup_spam_rescue(db, active_pubkey);
     let rescue_target = lookup_spam_rescue_target(db, active_pubkey);
+    debug_log!("[RUST] sync: spam_rescue={}, rescue_target='{}'", spam_rescue, rescue_target);
 
     // Folders to scan. Default (empty/None) = provider-aware list from
     // `default_inbox_folders`, with any *spam*-named server folder appended
@@ -5203,7 +5215,7 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
             extend_with_spam_folders(&mut session, &mut folders);
         }
         if spam_rescue {
-            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target, db, active_pubkey);
+            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target);
             if moved > 0 {
                 println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
             }
@@ -5241,7 +5253,7 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
             extend_with_spam_folders(&mut session, &mut folders);
         }
         if spam_rescue {
-            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target, db, active_pubkey);
+            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target);
             if moved > 0 {
                 println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
             }
@@ -6019,7 +6031,10 @@ fn uid_sync_folder<S: std::io::Read + std::io::Write>(
     let mut max_uid: u32 = 0;
     for chunk in uids.chunks(FETCH_BATCH) {
         let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
-        let messages = session.uid_fetch(&uid_list, "(UID RFC822)")?;
+        // BODY.PEEK[] (not RFC822) so background sync never sets \Seen — read
+        // state is tracked in our own DB, not the server flag. Response key is
+        // still BODY[], so msg.body() works unchanged.
+        let messages = session.uid_fetch(&uid_list, "(UID BODY.PEEK[])")?;
         for msg in messages.iter() {
             if let Some(uid) = msg.uid {
                 if uid > max_uid {
@@ -6159,7 +6174,8 @@ fn fetch_older_in_folder<S: std::io::Read + std::io::Write>(
         let batch = &uids[start..end];
 
         let uid_list = batch.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
-        let msgs = session.uid_fetch(&uid_list, "(UID RFC822)")?;
+        // BODY.PEEK[] so paging older mail doesn't mark it \Seen on the server.
+        let msgs = session.uid_fetch(&uid_list, "(UID BODY.PEEK[])")?;
         for msg in msgs.iter() {
             if let Some(uid) = msg.uid {
                 if uid < lowest_scanned { lowest_scanned = uid; }
@@ -6296,7 +6312,8 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
     let mut emails: Vec<RawNostrEmail> = Vec::new();
     for chunk in missing.chunks(FETCH_BATCH) {
         let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
-        let msgs = session.uid_fetch(&uid_list, "(UID RFC822)")?;
+        // BODY.PEEK[] so gap-fill backfill doesn't mark messages \Seen.
+        let msgs = session.uid_fetch(&uid_list, "(UID BODY.PEEK[])")?;
         for msg in msgs.iter() {
             if let Some(body) = msg.body() {
                 if let Some(parsed) = parse_fn(body, config) {
@@ -6330,12 +6347,13 @@ pub(crate) fn lookup_require_signature(db: &Database, pubkey: &str) -> bool {
     true
 }
 
-/// Read `spam_rescue` for the active pubkey, defaulting to false (opt-in).
+/// Read `spam_rescue` for the active pubkey, defaulting to true (on by default).
+/// Only an explicit "false" disables it; absent/blank settings stay on.
 pub(crate) fn lookup_spam_rescue(db: &Database, pubkey: &str) -> bool {
     if let Ok(Some(value)) = db.get_setting(pubkey, "spam_rescue") {
-        return value == "true";
+        return value != "false";
     }
-    false
+    true
 }
 
 /// Read the folder spam-rescued nostr mail should be moved into, defaulting to
@@ -6361,6 +6379,12 @@ pub(crate) fn lookup_spam_rescue_target(db: &Database, pubkey: &str) -> String {
 /// folder set.
 /// Return every server mailbox whose name contains "spam", "junk", or "bulk"
 /// (case-insensitive). Failures during LIST are non-fatal — returns empty.
+/// True if a mailbox name looks like a provider spam/junk/bulk folder.
+fn is_spam_folder_name(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower.contains("spam") || lower.contains("junk") || lower.contains("bulk")
+}
+
 fn list_spam_folders(
     session: &mut imap::Session<impl std::io::Read + std::io::Write>,
 ) -> Vec<String> {
@@ -6374,10 +6398,7 @@ fn list_spam_folders(
     mailboxes
         .iter()
         .map(|mb| mb.name().to_string())
-        .filter(|name| {
-            let lower = name.to_lowercase();
-            lower.contains("spam") || lower.contains("junk") || lower.contains("bulk")
-        })
+        .filter(|name| is_spam_folder_name(name))
         .collect()
 }
 
@@ -6403,11 +6424,20 @@ fn should_rescue_message(raw_body: &[u8]) -> bool {
         || text.contains("BEGIN NOSTR SIGNATURE")
         || text.contains("BEGIN NOSTR SEAL");
     if !has_nostr_marker {
+        debug_log!("[RUST] rescue: should_rescue_message=false (no nostr marker)");
         return false;
     }
     match verify_transport_authentication(Some(raw_body), None) {
-        Ok(verdict) => verdict.transport_verified,
-        Err(_) => false,
+        Ok(verdict) => {
+            if !verdict.transport_verified {
+                debug_log!("[RUST] rescue: should_rescue_message=false (has marker, transport auth NOT verified)");
+            }
+            verdict.transport_verified
+        }
+        Err(e) => {
+            debug_log!("[RUST] rescue: should_rescue_message=false (transport auth check errored: {})", e);
+            false
+        }
     }
 }
 
@@ -6439,13 +6469,18 @@ fn move_uids_to_folder(
 /// `target_folder`, so providers' misclassified encrypted mail stays reachable.
 /// Returns the number of messages moved. Per-folder failures are logged and
 /// skipped — rescue is best-effort and never aborts the surrounding sync.
+///
+/// Rescue is stateless: a message is moved out whenever it's UNSEEN in spam and
+/// looks like authenticated nostr mail. There is no rescue-once ledger — to keep
+/// a message in spam, the user (via the app's move-to-spam) marks it \Seen, which
+/// the server replicates to every device. The UNSEEN guard alone therefore
+/// encodes intent, identically on all clients.
 fn rescue_nostr_emails_from_spam(
     session: &mut imap::Session<impl std::io::Read + std::io::Write>,
     target_folder: &str,
-    db: &Database,
-    active_pubkey: &str,
 ) -> usize {
     let spam_folders = list_spam_folders(session);
+    debug_log!("[RUST] rescue: spam folders found = {:?}, target = '{}'", spam_folders, target_folder);
     if spam_folders.is_empty() {
         return 0;
     }
@@ -6480,18 +6515,22 @@ fn rescue_nostr_emails_from_spam(
                 candidates.extend(found);
             }
         }
+        debug_log!("[RUST] rescue: folder '{}' UNSEEN nostr candidate UIDs = {}", folder, candidates.len());
         if candidates.is_empty() {
             continue;
         }
 
-        // (uid, message_id) pairs that pass all checks and haven't been rescued
-        // before. Skipping already-rescued message-ids means that if the user
-        // later moves a rescued message back into spam, we respect that choice.
-        let mut to_move: Vec<(u32, String)> = Vec::new();
+        // UIDs that pass the eligibility gate. No ledger: a deliberate
+        // move-to-spam is respected because the app marks such mail \Seen, so it
+        // never appears in the UNSEEN candidate set above.
+        let mut to_move: Vec<u32> = Vec::new();
         let uids: Vec<u32> = candidates.into_iter().collect();
         for chunk in uids.chunks(500) {
             let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
-            let messages = match session.uid_fetch(&uid_list, "(UID RFC822)") {
+            // BODY.PEEK[] (not RFC822) so confirming a candidate doesn't set the
+            // \Seen flag — rescued messages must stay unread on the server. The
+            // response key is still BODY[], so msg.body() works unchanged.
+            let messages = match session.uid_fetch(&uid_list, "(UID BODY.PEEK[])") {
                 Ok(m) => m,
                 Err(e) => {
                     debug_log!("[RUST] rescue_nostr_emails_from_spam: fetch in '{}' failed: {}", folder, e);
@@ -6500,17 +6539,11 @@ fn rescue_nostr_emails_from_spam(
             };
             for msg in messages.iter() {
                 if let (Some(uid), Some(body)) = (msg.uid, msg.body()) {
-                    if !should_rescue_message(body) {
-                        continue;
+                    if should_rescue_message(body) {
+                        to_move.push(uid);
+                    } else {
+                        debug_log!("[RUST] rescue: uid {} in '{}' not eligible (missing nostr marker or transport auth failed)", uid, folder);
                     }
-                    let message_id = match extract_message_id_from_raw(body) {
-                        Some(id) => id,
-                        None => continue,
-                    };
-                    if db.is_message_id_rescued(active_pubkey, &message_id).unwrap_or(false) {
-                        continue;
-                    }
-                    to_move.push((uid, message_id));
                 }
             }
         }
@@ -6518,34 +6551,17 @@ fn rescue_nostr_emails_from_spam(
         if to_move.is_empty() {
             continue;
         }
-        let uid_set = to_move.iter().map(|(u, _)| u.to_string()).collect::<Vec<_>>().join(",");
+        let uid_set = to_move.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
         match move_uids_to_folder(session, &uid_set, target_folder) {
             Ok(_) => {
                 debug_log!("[RUST] rescue_nostr_emails_from_spam: moved {} message(s) from '{}' to '{}'",
                     to_move.len(), folder, target_folder);
-                for (_, message_id) in &to_move {
-                    if let Err(e) = db.add_rescued_message_id(active_pubkey, message_id) {
-                        debug_log!("[RUST] rescue_nostr_emails_from_spam: failed to record rescued id {}: {}", message_id, e);
-                    }
-                }
                 moved_total += to_move.len();
             }
             Err(e) => debug_log!("[RUST] rescue_nostr_emails_from_spam: move from '{}' failed: {}", folder, e),
         }
     }
     moved_total
-}
-
-/// Extract and return the `Message-ID` of a raw RFC822 message, if present.
-fn extract_message_id_from_raw(raw_body: &[u8]) -> Option<String> {
-    let email = parse_mail(raw_body).ok()?;
-    let raw_headers = email
-        .headers
-        .iter()
-        .map(|h| format!("{}: {}", h.get_key(), h.get_value()))
-        .collect::<Vec<_>>()
-        .join("\n");
-    extract_message_id_from_headers(&raw_headers)
 }
 
 fn extend_with_spam_folders(

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -5203,7 +5203,7 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
             extend_with_spam_folders(&mut session, &mut folders);
         }
         if spam_rescue {
-            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target);
+            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target, db, active_pubkey);
             if moved > 0 {
                 println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
             }
@@ -5241,7 +5241,7 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
             extend_with_spam_folders(&mut session, &mut folders);
         }
         if spam_rescue {
-            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target);
+            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target, db, active_pubkey);
             if moved > 0 {
                 println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
             }
@@ -6442,6 +6442,8 @@ fn move_uids_to_folder(
 fn rescue_nostr_emails_from_spam(
     session: &mut imap::Session<impl std::io::Read + std::io::Write>,
     target_folder: &str,
+    db: &Database,
+    active_pubkey: &str,
 ) -> usize {
     let spam_folders = list_spam_folders(session);
     if spam_folders.is_empty() {
@@ -6459,19 +6461,20 @@ fn rescue_nostr_emails_from_spam(
             continue;
         }
 
-        // Cheap server-side narrowing to candidate UIDs: header-marked messages
-        // (X-Nostr-Pubkey / X-Nostr-Sig) plus anything whose body carries a nostr
-        // armor block (encrypted, signed, signature, or seal). BODY search support
-        // varies by server, so we re-confirm each candidate by fetching it and
-        // checking the transport auth gate.
+        // Cheap server-side narrowing to candidate UIDs: UNREAD messages that are
+        // header-marked (X-Nostr-Pubkey / X-Nostr-Sig) or carry a nostr armor block
+        // (encrypted, signed, signature, or seal). The UNSEEN guard means a message
+        // the user has read and deliberately filed into spam is left alone. BODY
+        // search support varies by server, so we re-confirm each candidate by
+        // fetching it and checking the transport auth gate.
         let mut candidates: std::collections::HashSet<u32> = std::collections::HashSet::new();
         for query in &[
-            "HEADER X-Nostr-Pubkey \"\"",
-            "HEADER X-Nostr-Sig \"\"",
-            "BODY \"BEGIN NOSTR NIP-\"",
-            "BODY \"BEGIN NOSTR SIGNED\"",
-            "BODY \"BEGIN NOSTR SIGNATURE\"",
-            "BODY \"BEGIN NOSTR SEAL\"",
+            "UNSEEN HEADER X-Nostr-Pubkey \"\"",
+            "UNSEEN HEADER X-Nostr-Sig \"\"",
+            "UNSEEN BODY \"BEGIN NOSTR NIP-\"",
+            "UNSEEN BODY \"BEGIN NOSTR SIGNED\"",
+            "UNSEEN BODY \"BEGIN NOSTR SIGNATURE\"",
+            "UNSEEN BODY \"BEGIN NOSTR SEAL\"",
         ] {
             if let Ok(found) = session.uid_search(*query) {
                 candidates.extend(found);
@@ -6481,7 +6484,10 @@ fn rescue_nostr_emails_from_spam(
             continue;
         }
 
-        let mut confirmed: Vec<u32> = Vec::new();
+        // (uid, message_id) pairs that pass all checks and haven't been rescued
+        // before. Skipping already-rescued message-ids means that if the user
+        // later moves a rescued message back into spam, we respect that choice.
+        let mut to_move: Vec<(u32, String)> = Vec::new();
         let uids: Vec<u32> = candidates.into_iter().collect();
         for chunk in uids.chunks(500) {
             let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
@@ -6494,27 +6500,52 @@ fn rescue_nostr_emails_from_spam(
             };
             for msg in messages.iter() {
                 if let (Some(uid), Some(body)) = (msg.uid, msg.body()) {
-                    if should_rescue_message(body) {
-                        confirmed.push(uid);
+                    if !should_rescue_message(body) {
+                        continue;
                     }
+                    let message_id = match extract_message_id_from_raw(body) {
+                        Some(id) => id,
+                        None => continue,
+                    };
+                    if db.is_message_id_rescued(active_pubkey, &message_id).unwrap_or(false) {
+                        continue;
+                    }
+                    to_move.push((uid, message_id));
                 }
             }
         }
 
-        if confirmed.is_empty() {
+        if to_move.is_empty() {
             continue;
         }
-        let uid_set = confirmed.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
+        let uid_set = to_move.iter().map(|(u, _)| u.to_string()).collect::<Vec<_>>().join(",");
         match move_uids_to_folder(session, &uid_set, target_folder) {
             Ok(_) => {
                 debug_log!("[RUST] rescue_nostr_emails_from_spam: moved {} message(s) from '{}' to '{}'",
-                    confirmed.len(), folder, target_folder);
-                moved_total += confirmed.len();
+                    to_move.len(), folder, target_folder);
+                for (_, message_id) in &to_move {
+                    if let Err(e) = db.add_rescued_message_id(active_pubkey, message_id) {
+                        debug_log!("[RUST] rescue_nostr_emails_from_spam: failed to record rescued id {}: {}", message_id, e);
+                    }
+                }
+                moved_total += to_move.len();
             }
             Err(e) => debug_log!("[RUST] rescue_nostr_emails_from_spam: move from '{}' failed: {}", folder, e),
         }
     }
     moved_total
+}
+
+/// Extract and return the `Message-ID` of a raw RFC822 message, if present.
+fn extract_message_id_from_raw(raw_body: &[u8]) -> Option<String> {
+    let email = parse_mail(raw_body).ok()?;
+    let raw_headers = email
+        .headers
+        .iter()
+        .map(|h| format!("{}: {}", h.get_key(), h.get_value()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    extract_message_id_from_headers(&raw_headers)
 }
 
 fn extend_with_spam_folders(

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -978,6 +978,140 @@ fn move_to_trash(
     Err(anyhow::anyhow!("Failed to move email to trash"))
 }
 
+/// Move an inbox email (identified by Message-ID) to an arbitrary IMAP folder.
+///
+/// Mirrors `delete_inbox_email_from_server`, but instead of moving the matched
+/// message to trash it moves it into `target_folder`, creating that folder if it
+/// does not already exist. Searches the same source folders the inbox is synced
+/// from (`INBOX`, `nostr-mail`).
+pub async fn move_inbox_email_to_folder(
+    config: &EmailConfig,
+    message_id: &str,
+    target_folder: &str,
+) -> Result<()> {
+    let host = config.imap_host.clone();
+    let port = config.imap_port;
+    let username = config.email_address.clone();
+    let password = config.password.clone();
+    let use_tls = config.use_tls;
+    let message_id = message_id.to_string();
+    let target_folder = target_folder.to_string();
+
+    debug_log!("[RUST] move_inbox_email_to_folder: Moving Message-ID {} to folder {}", message_id, target_folder);
+
+    tokio::task::spawn_blocking(move || {
+        use std::net::TcpStream;
+        let addr = format!("{}:{}", host, port);
+
+        let result = if use_tls {
+            let client = create_imap_tls_client!(&host, &addr)?;
+            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
+            let result = move_email_to_folder_sync(&mut session, &message_id, &target_folder, &["INBOX", "nostr-mail"]);
+            let _ = session.logout();
+            result
+        } else {
+            let tcp_stream = TcpStream::connect(&addr)?;
+            let client = imap::Client::new(tcp_stream);
+            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
+            let result = move_email_to_folder_sync(&mut session, &message_id, &target_folder, &["INBOX", "nostr-mail"]);
+            let _ = session.logout();
+            result
+        };
+        result
+    }).await.map_err(|e| anyhow::anyhow!("Task join error: {}", e))?
+}
+
+/// Find an email by Message-ID across `source_folders` and move it to `target_folder`.
+fn move_email_to_folder_sync(
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+    message_id: &str,
+    target_folder: &str,
+    source_folders: &[&str],
+) -> Result<()> {
+    let mut folder_selected = false;
+    for folder in source_folders {
+        // No-op if the message already lives in the destination folder.
+        if folder.eq_ignore_ascii_case(target_folder) {
+            continue;
+        }
+        debug_log!("[RUST] move_email_to_folder_sync: Trying folder: {}", folder);
+        if session.select(folder).is_ok() {
+            folder_selected = true;
+
+            let normalized_msg_id = message_id.trim().trim_start_matches('<').trim_end_matches('>');
+            let full_msg_id = if normalized_msg_id.contains('@') {
+                format!("<{}>", normalized_msg_id)
+            } else {
+                format!("<{}@nostr-mail>", normalized_msg_id)
+            };
+
+            let search_queries = vec![
+                format!("HEADER Message-ID \"{}\"", full_msg_id),
+                format!("HEADER Message-ID \"{}\"", normalized_msg_id),
+                format!("HEADER Message-ID \"{}\"", message_id.trim()),
+            ];
+
+            let mut matching_messages = std::collections::HashSet::new();
+            for search_query in &search_queries {
+                if let Ok(results) = session.search(search_query) {
+                    if !results.is_empty() {
+                        matching_messages.extend(results);
+                        debug_log!("[RUST] move_email_to_folder_sync: Found {} match(es) in {}", matching_messages.len(), folder);
+                        break;
+                    }
+                }
+            }
+
+            if !matching_messages.is_empty() {
+                let message_seq = *matching_messages.iter().next().unwrap();
+                return move_message_to_folder(session, message_seq, target_folder);
+            }
+        }
+    }
+
+    if !folder_selected {
+        return Err(anyhow::anyhow!("Could not select any source folder"));
+    }
+    Err(anyhow::anyhow!("Email not found on server"))
+}
+
+/// Move a message (by sequence number) into `target_folder`, creating the folder
+/// if necessary. Uses the IMAP MOVE command, falling back to COPY + DELETE +
+/// EXPUNGE on servers that don't support MOVE.
+fn move_message_to_folder(
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+    message_seq: u32,
+    target_folder: &str,
+) -> Result<()> {
+    let seq_str = format!("{}", message_seq);
+
+    debug_log!("[RUST] move_message_to_folder: Moving message {} to {}", message_seq, target_folder);
+
+    // Try MOVE first.
+    if session.mv(&seq_str, target_folder).is_ok() {
+        debug_log!("[RUST] move_message_to_folder: Successfully moved via MOVE command");
+        return Ok(());
+    }
+
+    // The target folder may not exist yet — create it and retry MOVE.
+    if session.create(target_folder).is_ok() {
+        debug_log!("[RUST] move_message_to_folder: Created folder {}", target_folder);
+        if session.mv(&seq_str, target_folder).is_ok() {
+            return Ok(());
+        }
+    }
+
+    // Fallback for servers without MOVE support: COPY + flag deleted + EXPUNGE.
+    if session.copy(&seq_str, target_folder).is_ok() {
+        session.store(&seq_str, "+FLAGS (\\Deleted)")?;
+        session.expunge()?;
+        debug_log!("[RUST] move_message_to_folder: Successfully moved to {} via COPY", target_folder);
+        return Ok(());
+    }
+
+    Err(anyhow::anyhow!("Failed to move email to folder {}", target_folder))
+}
+
 /// List available IMAP folders/mailboxes
 pub async fn list_imap_folders(config: &EmailConfig) -> Result<Vec<String>> {
     let host = &config.imap_host;

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -5246,9 +5246,11 @@ fn persist_attachments_for_email(db: &Database, email: &RawNostrEmail, email_id:
 /// server are tolerated by `uid_sync_folder` (logged and skipped), so this can
 /// include best-guess names like `Archive` without breaking anything.
 ///
-/// Spam/junk folders are NOT in this static list — they're appended at sync
-/// time by `extend_with_spam_folders` which finds the real folder names on
-/// the server (`[Gmail]/Spam`, `Junk Email`, `Junk`, etc.).
+/// Spam/junk folders are not in this static list. How spam is handled depends
+/// on the spam-rescue setting (decided at sync time): with rescue ON, spam is
+/// never scanned and `rescue_nostr_emails_from_spam` moves misfiled nostr mail
+/// into the rescue target; with rescue OFF, `extend_with_spam_folders` appends
+/// discovered spam folders so that mail still surfaces in the inbox.
 pub fn default_inbox_folders(imap_host: &str) -> Vec<String> {
     let h = imap_host.to_lowercase();
     if h.contains("gmail.com") || h.contains("googlemail.com") {
@@ -5291,12 +5293,10 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
     debug_log!("[RUST] sync: spam_rescue={}, rescue_target='{}'", spam_rescue, rescue_target);
 
     // Folders to scan. Default (empty/None) = provider-aware list from
-    // `default_inbox_folders`, with any *spam*-named server folder appended
-    // after login (Nostr-encrypted bodies routinely get mis-classified as
-    // spam). Multiple folders may be supplied to scan in a single pass;
-    // dedupe to avoid re-scanning the same folder twice if a caller passed
-    // duplicates.
-    let (folders, expand_spam): (Vec<String>, bool) = match folders_arg {
+    // `default_inbox_folders`. Multiple folders may be supplied to scan in a
+    // single pass; dedupe to avoid re-scanning the same folder twice if a
+    // caller passed duplicates.
+    let folders: Vec<String> = match folders_arg {
         Some(list) => {
             let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
             let mut out: Vec<String> = Vec::new();
@@ -5308,14 +5308,29 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
                 }
             }
             if out.is_empty() {
-                (default_inbox_folders(&config.imap_host), true)
+                default_inbox_folders(&config.imap_host)
             } else {
-                (out, false)
+                out
             }
         }
-        None => (default_inbox_folders(&config.imap_host), true),
+        None => default_inbox_folders(&config.imap_host),
     };
-    let mut folders = folders;
+
+    // Strip any spam/junk/bulk name from the base list (a default never has
+    // one; a stale persisted selection might). Whether spam gets scanned is
+    // decided below, by the spam_rescue flag — not by the saved selection:
+    //   - rescue ON  → spam is NOT scanned. Scanning it would let an in-app
+    //     read mark the message \Seen, which rescue treats as "the user filed
+    //     this here, leave it" — permanently suppressing the rescue. Rescue
+    //     instead moves eligible mail into the rescue target (added below).
+    //   - rescue OFF → discovered spam folders ARE appended to the scan set
+    //     (inside the IMAP session) so nostr mail a provider misfiled still
+    //     surfaces in the inbox. Nothing moves it, so it stays in spam and is
+    //     eventually auto-purged by the provider — which some users prefer.
+    let mut folders: Vec<String> = folders
+        .into_iter()
+        .filter(|f| !is_spam_folder_name(f))
+        .collect();
 
     // With spam rescue on, ensure the rescue target is in the scan set so moved
     // messages land in the local DB during this same pass.
@@ -5345,16 +5360,15 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
     if config.use_tls {
         let client = create_imap_tls_client!(host, &addr)?;
         let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        if expand_spam {
-            extend_with_spam_folders(&mut session, &mut folders);
-        }
         if spam_rescue {
-            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target);
+            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target, /* unseen_only = */ true);
             if moved > 0 {
                 println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
             }
+        } else {
+            extend_with_spam_folders(&mut session, &mut folders);
         }
-        println!("[RUST] sync_nostr_emails_to_db: folders after spam expansion: {:?}", folders);
+        println!("[RUST] sync_nostr_emails_to_db: folders to scan: {:?}", folders);
         for f in &folders {
             match uid_sync_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
                                   parse_nostr_email_from_imap_body) {
@@ -5383,16 +5397,15 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
         let tcp_stream = TcpStream::connect(&addr)?;
         let client = imap::Client::new(tcp_stream);
         let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        if expand_spam {
-            extend_with_spam_folders(&mut session, &mut folders);
-        }
         if spam_rescue {
-            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target);
+            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target, /* unseen_only = */ true);
             if moved > 0 {
                 println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
             }
+        } else {
+            extend_with_spam_folders(&mut session, &mut folders);
         }
-        println!("[RUST] sync_nostr_emails_to_db: folders after spam expansion: {:?}", folders);
+        println!("[RUST] sync_nostr_emails_to_db: folders to scan: {:?}", folders);
         for f in &folders {
             match uid_sync_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
                                   parse_nostr_email_from_imap_body) {
@@ -6516,18 +6529,9 @@ pub(crate) fn lookup_spam_rescue_target(db: &Database, pubkey: &str) -> String {
     "nostr-mail".to_string()
 }
 
-/// Discover sent mailbox name using IMAP LIST command
-/// Returns the actual mailbox name found, or None if no sent mailbox exists
-/// Append any server mailbox whose name contains "spam", "junk", or "bulk"
-/// (case-insensitive) to `folders`, skipping names already present. Used to
-/// expand the default sync set so Nostr-encrypted mail that providers
-/// mis-classified still gets picked up. Catches `[Gmail]/Spam`, Outlook's
-/// `Junk Email`, Fastmail's `Junk`, Yahoo's `Bulk Mail`, etc. Failures during
-/// LIST are non-fatal — the sync will just proceed with the pre-expansion
-/// folder set.
-/// Return every server mailbox whose name contains "spam", "junk", or "bulk"
-/// (case-insensitive). Failures during LIST are non-fatal — returns empty.
-/// True if a mailbox name looks like a provider spam/junk/bulk folder.
+/// True if a mailbox name looks like a provider spam/junk/bulk folder
+/// (case-insensitive). Catches `[Gmail]/Spam`, Outlook's `Junk Email`,
+/// Fastmail's `Junk`, Yahoo's `Bulk Mail`, etc.
 fn is_spam_folder_name(name: &str) -> bool {
     let lower = name.to_lowercase();
     lower.contains("spam") || lower.contains("junk") || lower.contains("bulk")
@@ -6548,6 +6552,23 @@ fn list_spam_folders(
         .map(|mb| mb.name().to_string())
         .filter(|name| is_spam_folder_name(name))
         .collect()
+}
+
+/// Append discovered spam/junk/bulk server folders to `folders` (deduped).
+/// Called only when spam rescue is OFF, so nostr mail a provider misfiled into
+/// spam still surfaces in the inbox view. (With rescue ON we never scan spam —
+/// rescue moves eligible mail into the rescue target instead, and scanning spam
+/// would let an in-app read mark it \Seen and suppress its rescue.) LIST
+/// failures are non-fatal: the sync proceeds with the unexpanded folder set.
+fn extend_with_spam_folders(
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+    folders: &mut Vec<String>,
+) {
+    for name in list_spam_folders(session) {
+        if folders.iter().any(|f| f.eq_ignore_ascii_case(&name)) { continue; }
+        debug_log!("[RUST] extend_with_spam_folders: adding {}", name);
+        folders.push(name);
+    }
 }
 
 /// Decide whether a message sitting in a spam folder should be rescued.
@@ -6618,17 +6639,20 @@ fn move_uids_to_folder(
 /// Returns the number of messages moved. Per-folder failures are logged and
 /// skipped — rescue is best-effort and never aborts the surrounding sync.
 ///
-/// Rescue is stateless: a message is moved out whenever it's UNSEEN in spam and
-/// looks like authenticated nostr mail. There is no rescue-once ledger — to keep
-/// a message in spam, the user (via the app's move-to-spam) marks it \Seen, which
-/// the server replicates to every device. The UNSEEN guard alone therefore
-/// encodes intent, identically on all clients.
+/// When `unseen_only` is true (the normal per-sync rescue) only UNSEEN mail is
+/// considered: there is no rescue-once ledger — to keep a message in spam, the
+/// user (via the app's move-to-spam) marks it \Seen, which the server
+/// replicates to every device, so the UNSEEN guard alone encodes intent
+/// identically on all clients. When false (the one-time catch-up run when a
+/// user first enables rescue) the \Seen guard is dropped so already-read nostr
+/// mail sitting in spam — which the normal run would skip — is swept out too.
 fn rescue_nostr_emails_from_spam(
     session: &mut imap::Session<impl std::io::Read + std::io::Write>,
     target_folder: &str,
+    unseen_only: bool,
 ) -> usize {
     let spam_folders = list_spam_folders(session);
-    debug_log!("[RUST] rescue: spam folders found = {:?}, target = '{}'", spam_folders, target_folder);
+    debug_log!("[RUST] rescue: spam folders found = {:?}, target = '{}', unseen_only = {}", spam_folders, target_folder, unseen_only);
     if spam_folders.is_empty() {
         return 0;
     }
@@ -6644,33 +6668,36 @@ fn rescue_nostr_emails_from_spam(
             continue;
         }
 
-        // Cheap server-side narrowing to candidate UIDs: UNREAD messages that are
-        // header-marked (X-Nostr-Pubkey / X-Nostr-Sig) or carry a nostr armor block
-        // (encrypted, signed, signature, or seal). The UNSEEN guard means a message
-        // the user has read and deliberately filed into spam is left alone. BODY
+        // Cheap server-side narrowing to candidate UIDs: messages that are
+        // header-marked (X-Nostr-Pubkey / X-Nostr-Sig) or carry a nostr armor
+        // block (encrypted, signed, signature, or seal). With `unseen_only` the
+        // search is gated by UNSEEN so a message the user read and deliberately
+        // filed into spam is left alone; the catch-up run drops that gate. BODY
         // search support varies by server, so we re-confirm each candidate by
         // fetching it and checking the transport auth gate.
+        let guard = if unseen_only { "UNSEEN " } else { "" };
         let mut candidates: std::collections::HashSet<u32> = std::collections::HashSet::new();
-        for query in &[
-            "UNSEEN HEADER X-Nostr-Pubkey \"\"",
-            "UNSEEN HEADER X-Nostr-Sig \"\"",
-            "UNSEEN BODY \"BEGIN NOSTR NIP-\"",
-            "UNSEEN BODY \"BEGIN NOSTR SIGNED\"",
-            "UNSEEN BODY \"BEGIN NOSTR SIGNATURE\"",
-            "UNSEEN BODY \"BEGIN NOSTR SEAL\"",
+        for q in &[
+            "HEADER X-Nostr-Pubkey \"\"",
+            "HEADER X-Nostr-Sig \"\"",
+            "BODY \"BEGIN NOSTR NIP-\"",
+            "BODY \"BEGIN NOSTR SIGNED\"",
+            "BODY \"BEGIN NOSTR SIGNATURE\"",
+            "BODY \"BEGIN NOSTR SEAL\"",
         ] {
-            if let Ok(found) = session.uid_search(*query) {
+            let query = format!("{}{}", guard, q);
+            if let Ok(found) = session.uid_search(&query) {
                 candidates.extend(found);
             }
         }
-        debug_log!("[RUST] rescue: folder '{}' UNSEEN nostr candidate UIDs = {}", folder, candidates.len());
+        debug_log!("[RUST] rescue: folder '{}' nostr candidate UIDs = {}", folder, candidates.len());
         if candidates.is_empty() {
             continue;
         }
 
-        // UIDs that pass the eligibility gate. No ledger: a deliberate
-        // move-to-spam is respected because the app marks such mail \Seen, so it
-        // never appears in the UNSEEN candidate set above.
+        // UIDs that pass the eligibility gate. No ledger: in the normal run a
+        // deliberate move-to-spam is respected because the app marks such mail
+        // \Seen, so it never appears in the UNSEEN candidate set above.
         let mut to_move: Vec<u32> = Vec::new();
         let uids: Vec<u32> = candidates.into_iter().collect();
         for chunk in uids.chunks(500) {
@@ -6712,25 +6739,34 @@ fn rescue_nostr_emails_from_spam(
     moved_total
 }
 
-fn extend_with_spam_folders(
-    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
-    folders: &mut Vec<String>,
-) {
-    let mailboxes = match session.list(Some(""), Some("*")) {
-        Ok(m) => m,
-        Err(e) => {
-            debug_log!("[RUST] extend_with_spam_folders: LIST failed: {}", e);
-            return;
-        }
+/// One-time "catch-up" rescue invoked when the user first switches spam rescue
+/// ON. Opens an IMAP session and runs `rescue_nostr_emails_from_spam` with the
+/// \Seen guard dropped, so already-read nostr mail sitting in spam (which the
+/// per-sync rescue intentionally skips) is moved into `target_folder` too.
+/// Returns the number of messages moved. The caller is expected to sync
+/// afterwards so the moved messages land in the local DB.
+pub async fn rescue_spam_now(config: &EmailConfig, target_folder: &str) -> anyhow::Result<usize> {
+    let host = config.imap_host.clone();
+    let port = config.imap_port;
+    let username = &config.email_address;
+    let password = &config.password;
+    let addr = format!("{}:{}", host, port);
+
+    let moved = if config.use_tls {
+        let client = create_imap_tls_client!(&host, &addr)?;
+        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
+        let m = rescue_nostr_emails_from_spam(&mut session, target_folder, /* unseen_only = */ false);
+        let _ = session.logout();
+        m
+    } else {
+        let tcp_stream = TcpStream::connect(&addr)?;
+        let client = imap::Client::new(tcp_stream);
+        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
+        let m = rescue_nostr_emails_from_spam(&mut session, target_folder, /* unseen_only = */ false);
+        let _ = session.logout();
+        m
     };
-    for mailbox in mailboxes.iter() {
-        let name = mailbox.name();
-        let lower = name.to_lowercase();
-        if !lower.contains("spam") && !lower.contains("junk") && !lower.contains("bulk") { continue; }
-        if folders.iter().any(|f| f.eq_ignore_ascii_case(name)) { continue; }
-        debug_log!("[RUST] extend_with_spam_folders: adding {}", name);
-        folders.push(name.to_string());
-    }
+    Ok(moved)
 }
 
 fn discover_sent_mailbox(session: &mut imap::Session<impl std::io::Read + std::io::Write>) -> anyhow::Result<Option<String>> {

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -982,8 +982,10 @@ fn move_to_trash(
 ///
 /// Mirrors `delete_inbox_email_from_server`, but instead of moving the matched
 /// message to trash it moves it into `target_folder`, creating that folder if it
-/// does not already exist. Searches the same source folders the inbox is synced
-/// from (`INBOX`, `nostr-mail`).
+/// does not already exist. The message may live anywhere (it could have been
+/// moved before), so the search spans the user's real folders rather than a fixed
+/// `INBOX`/`nostr-mail` pair; if it's already in `target_folder` the move is a
+/// no-op success.
 pub async fn move_inbox_email_to_folder(
     config: &EmailConfig,
     message_id: &str,
@@ -1006,14 +1008,16 @@ pub async fn move_inbox_email_to_folder(
         let result = if use_tls {
             let client = create_imap_tls_client!(&host, &addr)?;
             let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let result = move_email_to_folder_sync(&mut session, &message_id, &target_folder, &["INBOX", "nostr-mail"]);
+            let source_folders = searchable_source_folders(&mut session, &target_folder);
+            let result = move_email_to_folder_sync(&mut session, &message_id, &target_folder, &source_folders);
             let _ = session.logout();
             result
         } else {
             let tcp_stream = TcpStream::connect(&addr)?;
             let client = imap::Client::new(tcp_stream);
             let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let result = move_email_to_folder_sync(&mut session, &message_id, &target_folder, &["INBOX", "nostr-mail"]);
+            let source_folders = searchable_source_folders(&mut session, &target_folder);
+            let result = move_email_to_folder_sync(&mut session, &message_id, &target_folder, &source_folders);
             let _ = session.logout();
             result
         };
@@ -1021,19 +1025,51 @@ pub async fn move_inbox_email_to_folder(
     }).await.map_err(|e| anyhow::anyhow!("Task join error: {}", e))?
 }
 
-/// Find an email by Message-ID across `source_folders` and move it to `target_folder`.
+/// List the folders worth searching for a message we're about to move, ordered so
+/// the cheap/likely ones come first: the target itself (to detect an already-there
+/// no-op), then INBOX and nostr-mail, then everything else. Gmail's "All Mail" is
+/// excluded — it contains every message (labels, not folders), so it would always
+/// match and make the move ambiguous. Falls back to INBOX/nostr-mail if LIST fails.
+fn searchable_source_folders(
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+    target_folder: &str,
+) -> Vec<String> {
+    let mut folders: Vec<String> = match session.list(Some(""), Some("*")) {
+        Ok(mailboxes) => mailboxes
+            .iter()
+            .map(|mb| mb.name().to_string())
+            .filter(|n| !n.to_lowercase().contains("all mail"))
+            .collect(),
+        Err(_) => vec!["INBOX".to_string(), "nostr-mail".to_string()],
+    };
+
+    let rank = |f: &str| -> u8 {
+        let fl = f.to_lowercase();
+        if fl == target_folder.to_lowercase() {
+            0
+        } else if fl == "inbox" {
+            1
+        } else if fl == "nostr-mail" {
+            2
+        } else {
+            3
+        }
+    };
+    // Stable sort preserves the server's order within each rank.
+    folders.sort_by_key(|f| rank(f));
+    folders
+}
+
+/// Find an email by Message-ID across `source_folders` and move it to
+/// `target_folder`. Finding it already in `target_folder` is a no-op success.
 fn move_email_to_folder_sync(
     session: &mut imap::Session<impl std::io::Read + std::io::Write>,
     message_id: &str,
     target_folder: &str,
-    source_folders: &[&str],
+    source_folders: &[String],
 ) -> Result<()> {
     let mut folder_selected = false;
     for folder in source_folders {
-        // No-op if the message already lives in the destination folder.
-        if folder.eq_ignore_ascii_case(target_folder) {
-            continue;
-        }
         debug_log!("[RUST] move_email_to_folder_sync: Trying folder: {}", folder);
         if session.select(folder).is_ok() {
             folder_selected = true;
@@ -1063,6 +1099,11 @@ fn move_email_to_folder_sync(
             }
 
             if !matching_messages.is_empty() {
+                // Already in the destination — nothing to move.
+                if folder.eq_ignore_ascii_case(target_folder) {
+                    debug_log!("[RUST] move_email_to_folder_sync: Already in target {}, no-op", target_folder);
+                    return Ok(());
+                }
                 let message_seq = *matching_messages.iter().next().unwrap();
                 return move_message_to_folder(session, message_seq, target_folder);
             }
@@ -1123,6 +1164,76 @@ fn move_message_to_folder(
     }
 
     Err(anyhow::anyhow!("Failed to move email to folder {}", target_folder))
+}
+
+/// Find which of `candidate_folders` currently contains the message identified by
+/// `message_id`, returning the first match in the given order (or None if it
+/// isn't found in any). Inbox emails carry no folder field, so the server is the
+/// only source of truth for the move picker's "(current)" label once a message
+/// has been moved. Callers should order cheap/likely folders first; the search
+/// stops at the first hit.
+pub async fn find_message_folder(
+    config: &EmailConfig,
+    message_id: &str,
+    candidate_folders: Vec<String>,
+) -> Result<Option<String>> {
+    let host = config.imap_host.clone();
+    let port = config.imap_port;
+    let username = config.email_address.clone();
+    let password = config.password.clone();
+    let use_tls = config.use_tls;
+    let message_id = message_id.to_string();
+
+    tokio::task::spawn_blocking(move || {
+        use std::net::TcpStream;
+        let addr = format!("{}:{}", host, port);
+        if use_tls {
+            let client = create_imap_tls_client!(&host, &addr)?;
+            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
+            let found = find_message_folder_sync(&mut session, &message_id, &candidate_folders);
+            let _ = session.logout();
+            found
+        } else {
+            let tcp_stream = TcpStream::connect(&addr)?;
+            let client = imap::Client::new(tcp_stream);
+            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
+            let found = find_message_folder_sync(&mut session, &message_id, &candidate_folders);
+            let _ = session.logout();
+            found
+        }
+    }).await.map_err(|e| anyhow::anyhow!("Task join error: {}", e))?
+}
+
+fn find_message_folder_sync(
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+    message_id: &str,
+    candidate_folders: &[String],
+) -> Result<Option<String>> {
+    let normalized_msg_id = message_id.trim().trim_start_matches('<').trim_end_matches('>');
+    let full_msg_id = if normalized_msg_id.contains('@') {
+        format!("<{}>", normalized_msg_id)
+    } else {
+        format!("<{}@nostr-mail>", normalized_msg_id)
+    };
+    let search_queries = [
+        format!("HEADER Message-ID \"{}\"", full_msg_id),
+        format!("HEADER Message-ID \"{}\"", normalized_msg_id),
+        format!("HEADER Message-ID \"{}\"", message_id.trim()),
+    ];
+
+    for folder in candidate_folders {
+        if session.select(folder).is_err() {
+            continue;
+        }
+        for search_query in &search_queries {
+            if let Ok(results) = session.search(search_query) {
+                if !results.is_empty() {
+                    return Ok(Some(folder.clone()));
+                }
+            }
+        }
+    }
+    Ok(None)
 }
 
 /// Resolve the logged-in user's configured inbox source folders, with spam/junk

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -1090,9 +1090,11 @@ fn move_message_to_folder(
     // When the user deliberately files a message INTO a spam folder, mark it
     // \Seen first. Spam rescue only pulls UNSEEN mail out of spam, so a read
     // message sitting in spam is the user's "leave it here" signal — and because
-    // it's a server flag it's the same answer on every device. Our sync uses
-    // BODY.PEEK[] everywhere, so nothing automated ever sets \Seen; this is the
-    // only path that does, and that flag must not be auto-cleared on spam mail.
+    // it's a server flag it's the same answer on every device. Our fetches use
+    // BODY.PEEK[] (reading a body never sets \Seen), and the read-state sync
+    // (`mark_inbox_email_seen_on_server`) only sets \Seen in non-spam inbox
+    // folders — so within spam folders this move path is the only thing that
+    // ever sets \Seen, and that flag must not be auto-cleared on spam mail.
     // IMAP COPY/MOVE preserve flags, so setting it before the move is enough.
     if is_spam_folder_name(target_folder) {
         let _ = session.store(&seq_str, "+FLAGS (\\Seen)");
@@ -1121,6 +1123,134 @@ fn move_message_to_folder(
     }
 
     Err(anyhow::anyhow!("Failed to move email to folder {}", target_folder))
+}
+
+/// Resolve the logged-in user's configured inbox source folders, with spam/junk
+/// folders filtered out. Mirrors how the sync chooses folders: the `inbox_folder`
+/// setting (one folder per line) when set, otherwise the provider-aware
+/// `default_inbox_folders`. Spam/junk folders are excluded because the read-state
+/// sync must not touch the `\Seen` flag inside spam folders, where that flag is
+/// reserved as the spam-rescue "user filed this here" signal.
+pub fn configured_inbox_folders_excluding_spam(
+    inbox_folder_setting: Option<&str>,
+    imap_host: &str,
+) -> Vec<String> {
+    let configured: Vec<String> = inbox_folder_setting
+        .map(|s| {
+            s.split('\n')
+                .map(|f| f.trim().to_string())
+                .filter(|f| !f.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    let folders = if configured.is_empty() {
+        default_inbox_folders(imap_host)
+    } else {
+        configured
+    };
+    folders.into_iter().filter(|f| !is_spam_folder_name(f)).collect()
+}
+
+/// Mark an inbox email (identified by Message-ID) as `\Seen` on the IMAP server,
+/// so read state set in the app propagates to other clients/devices.
+///
+/// `source_folders` is the user's configured inbox folders with spam/junk
+/// excluded (see `configured_inbox_folders_excluding_spam`). Restricting the
+/// search to non-spam folders is deliberate: inside spam/junk folders the
+/// `\Seen` flag is reserved as the "user deliberately filed this here" signal
+/// that spam rescue keys off of (see `move_message_to_folder`), so the read path
+/// must never set it there.
+pub async fn mark_inbox_email_seen_on_server(
+    config: &EmailConfig,
+    message_id: &str,
+    source_folders: &[String],
+) -> Result<()> {
+    let host = config.imap_host.clone();
+    let port = config.imap_port;
+    let username = config.email_address.clone();
+    let password = config.password.clone();
+    let use_tls = config.use_tls;
+    let message_id = message_id.to_string();
+    let source_folders: Vec<String> = source_folders.to_vec();
+
+    debug_log!("[RUST] mark_inbox_email_seen_on_server: Marking Message-ID {} as \\Seen in {:?}", message_id, source_folders);
+
+    tokio::task::spawn_blocking(move || {
+        use std::net::TcpStream;
+        let addr = format!("{}:{}", host, port);
+
+        let result = if use_tls {
+            let client = create_imap_tls_client!(&host, &addr)?;
+            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
+            let result = set_seen_in_folder_sync(&mut session, &message_id, &source_folders);
+            let _ = session.logout();
+            result
+        } else {
+            let tcp_stream = TcpStream::connect(&addr)?;
+            let client = imap::Client::new(tcp_stream);
+            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
+            let result = set_seen_in_folder_sync(&mut session, &message_id, &source_folders);
+            let _ = session.logout();
+            result
+        };
+        result
+    }).await.map_err(|e| anyhow::anyhow!("Task join error: {}", e))?
+}
+
+/// Find an email by Message-ID across `source_folders` and set its `\Seen` flag.
+/// Stops at the first folder where the message is found. Mirrors the Message-ID
+/// search used by `delete_email_from_folder_sync` / `move_email_to_folder_sync`.
+fn set_seen_in_folder_sync(
+    session: &mut imap::Session<impl std::io::Read + std::io::Write>,
+    message_id: &str,
+    source_folders: &[String],
+) -> Result<()> {
+    let mut folder_selected = false;
+    for folder in source_folders {
+        debug_log!("[RUST] set_seen_in_folder_sync: Trying folder: {}", folder);
+        if session.select(folder).is_ok() {
+            folder_selected = true;
+
+            let normalized_msg_id = message_id.trim().trim_start_matches('<').trim_end_matches('>');
+            let full_msg_id = if normalized_msg_id.contains('@') {
+                format!("<{}>", normalized_msg_id)
+            } else {
+                format!("<{}@nostr-mail>", normalized_msg_id)
+            };
+
+            let search_queries = vec![
+                format!("HEADER Message-ID \"{}\"", full_msg_id),
+                format!("HEADER Message-ID \"{}\"", normalized_msg_id),
+                format!("HEADER Message-ID \"{}\"", message_id.trim()),
+            ];
+
+            let mut matching_messages = std::collections::HashSet::new();
+            for search_query in &search_queries {
+                if let Ok(results) = session.search(search_query) {
+                    if !results.is_empty() {
+                        matching_messages.extend(results);
+                        break;
+                    }
+                }
+            }
+
+            if !matching_messages.is_empty() {
+                let seq_list = matching_messages
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                session.store(&seq_list, "+FLAGS (\\Seen)")?;
+                debug_log!("[RUST] set_seen_in_folder_sync: marked {} message(s) \\Seen in {}", matching_messages.len(), folder);
+                return Ok(());
+            }
+        }
+    }
+
+    if !folder_selected {
+        return Err(anyhow::anyhow!("Could not select any source folder"));
+    }
+    Err(anyhow::anyhow!("Email not found on server"))
 }
 
 /// List available IMAP folders/mailboxes
@@ -5064,7 +5194,11 @@ fn persist_inbox_raw_emails(
                 recipient_pubkey: email.recipient_pubkey.clone(),
                 raw_headers: Some(email.raw_headers.clone()),
                 is_draft: false,
-                is_read: false,
+                // Seed read state from the server `\Seen` flag captured at fetch
+                // time, so mail already read on another client/device imports as
+                // read. Unknown (`None`) → unread. Existing rows above keep their
+                // local read state; this only seeds the initial insert.
+                is_read: email.seen.unwrap_or(false),
                 updated_at: None,
                 created_at: chrono::Utc::now(),
                 signature_valid: email.signature_valid,
@@ -5833,6 +5967,11 @@ pub struct RawNostrEmail {
     pub signature_valid: Option<bool>,
     pub signature_source: Option<String>,
     pub transport_auth_verified: Option<bool>,
+    /// Server `\Seen` flag at fetch time, when the IMAP fetch requested FLAGS.
+    /// `None` means "not known from this fetch" (parse paths don't see flags);
+    /// callers treat `None` as unread for new inserts. Set by the inbox fetch
+    /// loops so read state set on another client/device imports on first sync.
+    pub seen: Option<bool>,
 }
 
 /// Parse an IMAP RFC822 message body and return Some(RawNostrEmail) if it is a
@@ -5924,6 +6063,9 @@ fn parse_nostr_email_from_imap_body_inner(
         signature_valid,
         signature_source,
         transport_auth_verified,
+        // Parsing only sees the message body, not IMAP flags. The fetch loop
+        // overrides this from `msg.flags()` when it requested FLAGS.
+        seen: None,
     })
 }
 
@@ -6031,10 +6173,11 @@ fn uid_sync_folder<S: std::io::Read + std::io::Write>(
     let mut max_uid: u32 = 0;
     for chunk in uids.chunks(FETCH_BATCH) {
         let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
-        // BODY.PEEK[] (not RFC822) so background sync never sets \Seen — read
-        // state is tracked in our own DB, not the server flag. Response key is
-        // still BODY[], so msg.body() works unchanged.
-        let messages = session.uid_fetch(&uid_list, "(UID BODY.PEEK[])")?;
+        // BODY.PEEK[] (not RFC822) so reading a message body never *sets* \Seen.
+        // We additionally request FLAGS so we can *read* the server's \Seen flag
+        // and seed local read state from it (import read-elsewhere on first
+        // sync). Response key is still BODY[], so msg.body() works unchanged.
+        let messages = session.uid_fetch(&uid_list, "(UID FLAGS BODY.PEEK[])")?;
         for msg in messages.iter() {
             if let Some(uid) = msg.uid {
                 if uid > max_uid {
@@ -6042,7 +6185,8 @@ fn uid_sync_folder<S: std::io::Read + std::io::Write>(
                 }
             }
             if let Some(body) = msg.body() {
-                if let Some(parsed) = parse_fn(body, config) {
+                if let Some(mut parsed) = parse_fn(body, config) {
+                    parsed.seen = Some(msg.flags().iter().any(|f| matches!(f, imap::types::Flag::Seen)));
                     emails.push(parsed);
                 }
             }
@@ -6174,14 +6318,16 @@ fn fetch_older_in_folder<S: std::io::Read + std::io::Write>(
         let batch = &uids[start..end];
 
         let uid_list = batch.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
-        // BODY.PEEK[] so paging older mail doesn't mark it \Seen on the server.
-        let msgs = session.uid_fetch(&uid_list, "(UID BODY.PEEK[])")?;
+        // BODY.PEEK[] so paging older mail doesn't *set* \Seen; FLAGS so we can
+        // read it and seed local read state for newly-imported rows.
+        let msgs = session.uid_fetch(&uid_list, "(UID FLAGS BODY.PEEK[])")?;
         for msg in msgs.iter() {
             if let Some(uid) = msg.uid {
                 if uid < lowest_scanned { lowest_scanned = uid; }
             }
             if let Some(body) = msg.body() {
-                if let Some(parsed) = parse_fn(body, config) {
+                if let Some(mut parsed) = parse_fn(body, config) {
+                    parsed.seen = Some(msg.flags().iter().any(|f| matches!(f, imap::types::Flag::Seen)));
                     emails.push(parsed);
                 }
             }
@@ -6312,11 +6458,13 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
     let mut emails: Vec<RawNostrEmail> = Vec::new();
     for chunk in missing.chunks(FETCH_BATCH) {
         let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
-        // BODY.PEEK[] so gap-fill backfill doesn't mark messages \Seen.
-        let msgs = session.uid_fetch(&uid_list, "(UID BODY.PEEK[])")?;
+        // BODY.PEEK[] so gap-fill backfill doesn't *set* \Seen; FLAGS so we can
+        // read it and seed local read state for newly-imported rows.
+        let msgs = session.uid_fetch(&uid_list, "(UID FLAGS BODY.PEEK[])")?;
         for msg in msgs.iter() {
             if let Some(body) = msg.body() {
-                if let Some(parsed) = parse_fn(body, config) {
+                if let Some(mut parsed) = parse_fn(body, config) {
+                    parsed.seen = Some(msg.flags().iter().any(|f| matches!(f, imap::types::Flag::Seen)));
                     emails.push(parsed);
                 }
             }

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -6489,9 +6489,75 @@ async fn move_inbox_email(message_id: String, target_folder: String, _user_email
 }
 
 #[tauri::command]
-fn db_mark_as_read(message_id: String, state: tauri::State<AppState>) -> Result<(), String> {
+async fn db_mark_as_read(message_id: String, state: tauri::State<'_, AppState>) -> Result<(), String> {
     let db = state.get_database()?;
-    db.mark_as_read(&message_id).map_err(|e| e.to_string())
+
+    // Only mirror to the server on a genuine unread -> read transition, so
+    // re-opening an already-read email doesn't trigger a redundant IMAP login.
+    let was_unread = db
+        .get_email(&message_id)
+        .map_err(|e| e.to_string())?
+        .map(|e| !e.is_read)
+        .unwrap_or(false);
+
+    db.mark_as_read(&message_id).map_err(|e| e.to_string())?;
+
+    if !was_unread {
+        return Ok(());
+    }
+
+    // Best-effort: mirror read state to the IMAP server (\Seen) so other
+    // clients/devices see the message as read. Local read state is already
+    // persisted above; a server failure must not fail the command or block the
+    // UI, so this runs detached and its result is only logged. Scoped to
+    // non-spam folders inside `mark_inbox_email_seen_on_server`.
+    let active_pubkey = match active_user_npub(&state) {
+        Some(pk) => pk,
+        None => return Ok(()),
+    };
+    let all_settings = match db.get_all_settings(&active_pubkey) {
+        Ok(s) => s,
+        Err(_) => return Ok(()),
+    };
+
+    let email_address = all_settings.get("email_address").cloned();
+    let password = all_settings.get("password").cloned();
+    let imap_host = all_settings.get("imap_host").cloned();
+    let imap_port = all_settings.get("imap_port").and_then(|s| s.parse::<u16>().ok());
+    let use_tls = all_settings.get("imap_use_tls").map(|s| s == "true").unwrap_or(true);
+
+    if let (Some(email_addr), Some(pwd), Some(host), Some(port)) = (email_address, password, imap_host, imap_port) {
+        let email_config = crate::types::EmailConfig {
+            email_address: email_addr,
+            password: pwd,
+            smtp_host: all_settings.get("smtp_host").cloned().unwrap_or_default(),
+            smtp_port: all_settings.get("smtp_port").and_then(|s| s.parse::<u16>().ok()).unwrap_or(587),
+            imap_host: host,
+            imap_port: port,
+            use_tls,
+            private_key: all_settings.get("nostr_private_key").cloned(),
+        };
+        // Search the logged-in user's configured inbox folders (the `inbox_folder`
+        // setting, else provider defaults), with spam/junk excluded — the same
+        // source set the sync uses, not a hardcoded list.
+        let source_folders = crate::email::configured_inbox_folders_excluding_spam(
+            all_settings.get("inbox_folder").map(|s| s.as_str()),
+            &email_config.imap_host,
+        );
+        let msg_id = message_id.clone();
+        tokio::spawn(async move {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                crate::email::mark_inbox_email_seen_on_server(&email_config, &msg_id, &source_folders),
+            ).await {
+                Ok(Ok(_)) => println!("[RUST] db_mark_as_read: marked {} \\Seen on server", msg_id),
+                Ok(Err(e)) => crate::debug_log!("[RUST] db_mark_as_read: server \\Seen failed for {}: {}", msg_id, e),
+                Err(_) => crate::debug_log!("[RUST] db_mark_as_read: server \\Seen timed out for {}", msg_id),
+            }
+        });
+    }
+
+    Ok(())
 }
 
 #[tauri::command]

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -2655,6 +2655,20 @@ async fn list_imap_folders(email_config: EmailConfig) -> Result<Vec<String>, Str
         })
 }
 
+/// Find the IMAP folder a message currently lives in, searching `candidate_folders`
+/// in order and returning the first match (or None). Used by the move picker so the
+/// "(current)" label reflects the server, not a local guess.
+#[tauri::command]
+async fn find_message_folder(
+    email_config: EmailConfig,
+    message_id: String,
+    candidate_folders: Vec<String>,
+) -> Result<Option<String>, String> {
+    email::find_message_folder(&email_config, &message_id, candidate_folders)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 async fn test_smtp_connection(email_config: EmailConfig) -> Result<(), String> {
     email::test_smtp_connection(&email_config)
@@ -7104,6 +7118,7 @@ pub fn run() {
         test_imap_connection,
         test_smtp_connection,
         list_imap_folders,
+        find_message_folder,
         check_message_confirmation,
         get_default_private_key_from_config,
         generate_qr_code,

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -73,6 +73,27 @@ fn resolve_private_key(explicit: Option<String>, state: &AppState) -> Result<Str
     state.get_active_private_key()
 }
 
+/// Decrypt the IMAP/SMTP password stored in settings.
+///
+/// The password is encrypted-at-rest with the active account's private key (see
+/// `db_save_settings_batch`); the raw `db.get_all_settings()` returns ciphertext.
+/// Frontend-supplied `EmailConfig`s already carry the decrypted password (the UI
+/// gets it via `db_get_all_settings`, which decrypts), but any backend path that
+/// builds an `EmailConfig` directly from the DB must decrypt it here first — else
+/// IMAP login is attempted with ciphertext and fails with "Invalid credentials".
+/// Falls back to the stored value when no key is available or decryption fails,
+/// matching `db_get_all_settings`' backward-compatibility with plaintext records.
+fn decrypt_setting_password(encrypted: &str, state: &AppState) -> String {
+    if encrypted.is_empty() {
+        return String::new();
+    }
+    match state.get_active_private_key() {
+        Ok(priv_key) => crypto::decrypt_setting_value(&priv_key, encrypted)
+            .unwrap_or_else(|_| encrypted.to_string()),
+        Err(_) => encrypted.to_string(),
+    }
+}
+
 /// The active user's pubkey in bech32 (npub) form, if any. Used as the
 /// direction anchor for DM↔email pubkey backfill.
 fn active_user_npub(state: &AppState) -> Option<String> {
@@ -6353,7 +6374,7 @@ async fn db_delete_sent_email(message_id: String, delete_from_server: Option<boo
                 if let (Some(email_addr), Some(pwd), Some(host), Some(port)) = (email_address, password, imap_host, imap_port) {
                     let email_config = crate::types::EmailConfig {
                         email_address: email_addr,
-                        password: pwd,
+                        password: decrypt_setting_password(&pwd, &state),
                         smtp_host: all_settings.get("smtp_host").cloned().unwrap_or_default(),
                         smtp_port: all_settings.get("smtp_port").and_then(|s| s.parse::<u16>().ok()).unwrap_or(587),
                         imap_host: host,
@@ -6404,7 +6425,7 @@ async fn db_delete_inbox_email(message_id: String, delete_from_server: Option<bo
                 if let (Some(email_addr), Some(pwd), Some(host), Some(port)) = (email_address, password, imap_host, imap_port) {
                     let email_config = crate::types::EmailConfig {
                         email_address: email_addr,
-                        password: pwd,
+                        password: decrypt_setting_password(&pwd, &state),
                         smtp_host: all_settings.get("smtp_host").cloned().unwrap_or_default(),
                         smtp_port: all_settings.get("smtp_port").and_then(|s| s.parse::<u16>().ok()).unwrap_or(587),
                         imap_host: host,
@@ -6460,7 +6481,7 @@ async fn move_inbox_email(message_id: String, target_folder: String, _user_email
     if let (Some(email_addr), Some(pwd), Some(host), Some(port)) = (email_address, password, imap_host, imap_port) {
         let email_config = crate::types::EmailConfig {
             email_address: email_addr,
-            password: pwd,
+            password: decrypt_setting_password(&pwd, &state),
             smtp_host: all_settings.get("smtp_host").cloned().unwrap_or_default(),
             smtp_port: all_settings.get("smtp_port").and_then(|s| s.parse::<u16>().ok()).unwrap_or(587),
             imap_host: host,
@@ -6508,7 +6529,7 @@ async fn rescue_spam_now(state: tauri::State<'_, AppState>) -> Result<usize, Str
     if let (Some(email_addr), Some(pwd), Some(host), Some(port)) = (email_address, password, imap_host, imap_port) {
         let email_config = crate::types::EmailConfig {
             email_address: email_addr,
-            password: pwd,
+            password: decrypt_setting_password(&pwd, &state),
             smtp_host: all_settings.get("smtp_host").cloned().unwrap_or_default(),
             smtp_port: all_settings.get("smtp_port").and_then(|s| s.parse::<u16>().ok()).unwrap_or(587),
             imap_host: host,
@@ -6577,7 +6598,7 @@ async fn db_mark_as_read(message_id: String, state: tauri::State<'_, AppState>) 
     if let (Some(email_addr), Some(pwd), Some(host), Some(port)) = (email_address, password, imap_host, imap_port) {
         let email_config = crate::types::EmailConfig {
             email_address: email_addr,
-            password: pwd,
+            password: decrypt_setting_password(&pwd, &state),
             smtp_host: all_settings.get("smtp_host").cloned().unwrap_or_default(),
             smtp_port: all_settings.get("smtp_port").and_then(|s| s.parse::<u16>().ok()).unwrap_or(587),
             imap_host: host,

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -6488,6 +6488,54 @@ async fn move_inbox_email(message_id: String, target_folder: String, _user_email
     }
 }
 
+/// One-time spam-rescue catch-up, run when the user first enables spam rescue.
+/// Moves ALL authenticated nostr mail out of spam — including already-read
+/// messages that the normal per-sync rescue (UNSEEN-only) would skip — then
+/// syncs so the moved messages appear in the inbox. Returns how many were moved
+/// so the frontend can tell the user.
+#[tauri::command]
+async fn rescue_spam_now(state: tauri::State<'_, AppState>) -> Result<usize, String> {
+    let active_pubkey = active_user_npub(&state).ok_or_else(|| "No active user".to_string())?;
+    let db = state.get_database()?;
+    let all_settings = db.get_all_settings(&active_pubkey).map_err(|e| e.to_string())?;
+
+    let email_address = all_settings.get("email_address").cloned();
+    let password = all_settings.get("password").cloned();
+    let imap_host = all_settings.get("imap_host").cloned();
+    let imap_port = all_settings.get("imap_port").and_then(|s| s.parse::<u16>().ok());
+    let use_tls = all_settings.get("imap_use_tls").map(|s| s == "true").unwrap_or(true);
+
+    if let (Some(email_addr), Some(pwd), Some(host), Some(port)) = (email_address, password, imap_host, imap_port) {
+        let email_config = crate::types::EmailConfig {
+            email_address: email_addr,
+            password: pwd,
+            smtp_host: all_settings.get("smtp_host").cloned().unwrap_or_default(),
+            smtp_port: all_settings.get("smtp_port").and_then(|s| s.parse::<u16>().ok()).unwrap_or(587),
+            imap_host: host,
+            imap_port: port,
+            use_tls,
+            private_key: all_settings.get("nostr_private_key").cloned(),
+        };
+
+        let target = crate::email::lookup_spam_rescue_target(&db, &active_pubkey);
+        let moved = crate::email::rescue_spam_now(&email_config, &target)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // Ingest the moved messages so they surface in the inbox immediately.
+        // The rescue target is part of the synced folder set whenever rescue is
+        // on, so a normal sync picks them up. Best-effort: a sync failure here
+        // doesn't undo the (already-completed) move, so just log it.
+        if let Err(e) = crate::email::sync_nostr_emails_to_db(&email_config, None, &active_pubkey, &db).await {
+            println!("[RUST] rescue_spam_now: post-rescue sync failed: {}", e);
+        }
+
+        Ok(moved)
+    } else {
+        Err("Incomplete email configuration".to_string())
+    }
+}
+
 #[tauri::command]
 async fn db_mark_as_read(message_id: String, state: tauri::State<'_, AppState>) -> Result<(), String> {
     let db = state.get_database()?;
@@ -7142,6 +7190,7 @@ pub fn run() {
         db_delete_sent_email,
         db_delete_inbox_email,
         move_inbox_email,
+        rescue_spam_now,
         db_mark_as_read,
         db_check_dm_matches_email_encrypted,
         db_check_dms_match_email_encrypted_batch,

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -6438,6 +6438,57 @@ async fn db_delete_inbox_email(message_id: String, delete_from_server: Option<bo
 }
 
 #[tauri::command]
+async fn move_inbox_email(message_id: String, target_folder: String, _user_email: Option<String>, state: tauri::State<'_, AppState>) -> Result<(), String> {
+    println!("[RUST] move_inbox_email called for message_id: {}, target_folder: {}", message_id, target_folder);
+
+    let target_folder = target_folder.trim().to_string();
+    if target_folder.is_empty() {
+        return Err("Target folder must not be empty".to_string());
+    }
+
+    // Same active-pubkey scoping rationale as db_delete_inbox_email above.
+    let active_pubkey = active_user_npub(&state).ok_or_else(|| "No active user".to_string())?;
+    let db = state.get_database()?;
+    let all_settings = db.get_all_settings(&active_pubkey).map_err(|e| e.to_string())?;
+
+    let email_address = all_settings.get("email_address").cloned();
+    let password = all_settings.get("password").cloned();
+    let imap_host = all_settings.get("imap_host").cloned();
+    let imap_port = all_settings.get("imap_port").and_then(|s| s.parse::<u16>().ok());
+    let use_tls = all_settings.get("imap_use_tls").map(|s| s == "true").unwrap_or(true);
+
+    if let (Some(email_addr), Some(pwd), Some(host), Some(port)) = (email_address, password, imap_host, imap_port) {
+        let email_config = crate::types::EmailConfig {
+            email_address: email_addr,
+            password: pwd,
+            smtp_host: all_settings.get("smtp_host").cloned().unwrap_or_default(),
+            smtp_port: all_settings.get("smtp_port").and_then(|s| s.parse::<u16>().ok()).unwrap_or(587),
+            imap_host: host,
+            imap_port: port,
+            use_tls,
+            private_key: all_settings.get("nostr_private_key").cloned(),
+        };
+
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            crate::email::move_inbox_email_to_folder(&email_config, &message_id, &target_folder)
+        ).await {
+            Ok(Ok(_)) => {
+                println!("[RUST] move_inbox_email: Successfully moved email on server to {}", target_folder);
+                // Drop the local copy; the next sync re-surfaces it if the target
+                // folder is part of the synced inbox folder set.
+                db.delete_inbox_email(&message_id).map_err(|e| e.to_string())?;
+                Ok(())
+            }
+            Ok(Err(e)) => Err(format!("Failed to move email: {}", e)),
+            Err(_) => Err("Server move timed out after 30 seconds".to_string()),
+        }
+    } else {
+        Err("Incomplete email configuration".to_string())
+    }
+}
+
+#[tauri::command]
 fn db_mark_as_read(message_id: String, state: tauri::State<AppState>) -> Result<(), String> {
     let db = state.get_database()?;
     db.mark_as_read(&message_id).map_err(|e| e.to_string())
@@ -7024,6 +7075,7 @@ pub fn run() {
         db_delete_draft,
         db_delete_sent_email,
         db_delete_inbox_email,
+        move_inbox_email,
         db_mark_as_read,
         db_check_dm_matches_email_encrypted,
         db_check_dms_match_email_encrypted_batch,

--- a/tauri-app/frontend/index.html
+++ b/tauri-app/frontend/index.html
@@ -681,7 +681,21 @@
                                     </div>
                                     <small class="form-text text-muted">Permanently reject incoming emails that claim a Nostr pubkey but whose signature fails to verify (likely forged or tampered). These are never saved to your inbox. Plain emails with no Nostr signature are still accepted.</small>
                                 </li>
-                                
+
+                                <li class="toggle-settings-item">
+                                    <div class="toggle-setting">
+                                        <label for="spam-rescue-preference">Spam Rescue</label>
+                                        <label class="toggle-switch">
+                                            <input type="checkbox" id="spam-rescue-preference">
+                                        </label>
+                                    </div>
+                                    <small class="form-text text-muted">On each sync, automatically move Nostr-encrypted messages out of your Spam/Junk folder into the folder below. Encrypted bodies are often misflagged as spam by mail providers; this keeps them reliably accessible.</small>
+                                    <div class="form-group" style="margin-top: 8px;">
+                                        <label for="spam-rescue-target-preference">Rescue into folder</label>
+                                        <input type="text" id="spam-rescue-target-preference" class="form-control" placeholder="nostr-mail">
+                                    </div>
+                                </li>
+
                                 <li class="toggle-settings-item">
                                     <div class="toggle-setting">
                                         <label for="hide-undecryptable-emails-preference">Hide Undecryptable Emails</label>

--- a/tauri-app/frontend/index.html
+++ b/tauri-app/frontend/index.html
@@ -686,7 +686,7 @@
                                     <div class="toggle-setting">
                                         <label for="spam-rescue-preference">Spam Rescue</label>
                                         <label class="toggle-switch">
-                                            <input type="checkbox" id="spam-rescue-preference">
+                                            <input type="checkbox" id="spam-rescue-preference" checked>
                                         </label>
                                     </div>
                                     <small class="form-text text-muted">On each sync, automatically move Nostr-encrypted messages out of your Spam/Junk folder into the folder below. Encrypted bodies are often misflagged as spam by mail providers; this keeps them reliably accessible.</small>

--- a/tauri-app/frontend/index.html
+++ b/tauri-app/frontend/index.html
@@ -692,7 +692,7 @@
                                     <small class="form-text text-muted">On each sync, automatically move Nostr-encrypted messages out of your Spam/Junk folder into the folder below. Encrypted bodies are often misflagged as spam by mail providers; this keeps them reliably accessible.</small>
                                     <div class="form-group" style="margin-top: 8px;">
                                         <label for="spam-rescue-target-preference">Rescue into folder</label>
-                                        <input type="text" id="spam-rescue-target-preference" class="form-control" placeholder="nostr-mail">
+                                        <select id="spam-rescue-target-preference" class="form-control"></select>
                                     </div>
                                 </li>
 

--- a/tauri-app/frontend/js/app.js
+++ b/tauri-app/frontend/js/app.js
@@ -1528,6 +1528,9 @@ NostrMailApp.prototype.setupEventListeners = function() {
                 const settings = appState.getSettings() || {};
                 settings.inbox_folder = joined;
                 appState.setSettings(settings);
+                // Keep the spam-rescue target dropdown in sync with the inbox
+                // folder selection (its options are derived from it, minus spam).
+                this.populateSpamRescueTargetOptions(settings);
                 if (window.emailService) {
                     window.emailService.inboxOffset = 0;
                     await window.emailService.loadEmails();
@@ -3422,6 +3425,47 @@ NostrMailApp.prototype.setupEmailValidation = function() {
     }
 }
 
+// Populate the "Rescue into folder" <select> from the folders the user selected
+// for their inbox, excluding spam/junk/bulk folders (we never rescue into spam).
+// The currently-saved target is preserved as an option even if it isn't part of
+// the current inbox selection, so changing inbox folders can't silently drop it.
+NostrMailApp.prototype.populateSpamRescueTargetOptions = function(settings) {
+    const select = domManager.get('spam-rescue-target-preference');
+    if (!select) return;
+
+    settings = settings || appState.getSettings() || {};
+
+    // Prefer the live multiselect DOM selection; fall back to the persisted list.
+    let inboxFolders = (window.FolderMultiselect && window.FolderMultiselect.getSelection)
+        ? window.FolderMultiselect.getSelection()
+        : [];
+    if (!inboxFolders || inboxFolders.length === 0) {
+        inboxFolders = (settings.inbox_folder || '').split('\n').map(f => f.trim()).filter(Boolean);
+    }
+
+    const isSpammy = (name) => {
+        const lower = name.toLowerCase();
+        return lower.includes('spam') || lower.includes('junk') || lower.includes('bulk');
+    };
+
+    const options = inboxFolders.filter(f => f && !isSpammy(f));
+
+    const saved = (settings.spam_rescue_target || 'nostr-mail').trim() || 'nostr-mail';
+    // Keep the saved target selectable even if it's not in the inbox selection.
+    if (saved && !options.includes(saved)) {
+        options.unshift(saved);
+    }
+
+    select.innerHTML = '';
+    for (const folder of options) {
+        const opt = document.createElement('option');
+        opt.value = folder;
+        opt.textContent = folder;
+        select.appendChild(opt);
+    }
+    select.value = saved;
+};
+
 NostrMailApp.prototype.populateSettingsForm = async function() {
     console.log('[QR] populateSettingsForm called');
     const settings = appState.getSettings();
@@ -3514,10 +3558,7 @@ NostrMailApp.prototype.populateSettingsForm = async function() {
         if (spamRescuePref) {
             spamRescuePref.checked = settings.spam_rescue === true;
         }
-        const spamRescueTargetPref = domManager.get('spam-rescue-target-preference');
-        if (spamRescueTargetPref) {
-            spamRescueTargetPref.value = settings.spam_rescue_target || 'nostr-mail';
-        }
+        this.populateSpamRescueTargetOptions(settings);
 
         // Set hide undecryptable emails preference (default to true if not set)
         const hideUndecryptablePref = domManager.get('hide-undecryptable-emails-preference');

--- a/tauri-app/frontend/js/app.js
+++ b/tauri-app/frontend/js/app.js
@@ -3295,6 +3295,40 @@ NostrMailApp.prototype.setupAutoSaveSettings = function() {
         }
     });
     
+    // Special handling: enabling Spam Rescue triggers a one-time catch-up that
+    // sweeps ALL nostr mail (read + unread) out of spam. The normal per-sync
+    // rescue only moves UNSEEN mail, so messages the user already read while
+    // they sat in spam would otherwise be stranded; this run clears them once,
+    // then reports how many were moved. Programmatic `.checked =` during form
+    // population doesn't fire 'change', so a checked=true event here is always
+    // a genuine user-initiated off→on transition.
+    const spamRescuePref = domManager.get('spam-rescue-preference');
+    if (spamRescuePref) {
+        spamRescuePref.addEventListener('change', async (e) => {
+            if (isPopulatingForm || !e.target.checked) return;
+            try {
+                // Persist spam_rescue=true first so the catch-up's post-move
+                // sync scans with rescue enabled (target folder in the set).
+                await this.saveSettings(false);
+                const moved = await TauriService.rescueSpamNow();
+                if (moved > 0) {
+                    notificationService.showSuccess(
+                        `Spam rescue: moved ${moved} message${moved === 1 ? '' : 's'} out of spam.`
+                    );
+                    if (window.emailService && typeof window.emailService.loadEmails === 'function') {
+                        window.emailService.loadEmails().catch(err =>
+                            console.warn('[APP] reload after spam rescue failed:', err));
+                    }
+                } else {
+                    notificationService.showInfo('Spam rescue: no messages needed rescuing.');
+                }
+            } catch (err) {
+                console.error('[APP] rescue_spam_now failed:', err);
+                notificationService.showError('Spam rescue failed: ' + err);
+            }
+        });
+    }
+
     // Special handling: When auto-encrypt is enabled, also enable auto-sign
     const autoEncryptPref = domManager.get('automatically-encrypt-preference');
     const autoSignPref = domManager.get('automatically-sign-preference');
@@ -3523,13 +3557,12 @@ NostrMailApp.prototype.populateSettingsForm = async function() {
                 window.FolderMultiselect.setSelectionOnly(persistedList);
                 // Reflect the backend's provider-aware defaults in the
                 // placeholder so the user can see what "no selection" will
-                // sync. The backend also auto-adds any *spam*-named folder at
-                // sync time; signal that with an ellipsis + a note in the
-                // help text.
+                // sync. Spam/junk/bulk folders are intentionally excluded —
+                // misfiled nostr mail is recovered by spam rescue instead.
                 TauriService.getDefaultInboxFolders(settings.imap_host).then(defaults => {
                     if (defaults && defaults.length > 0) {
                         window.FolderMultiselect.setPlaceholder(
-                            `Default (${defaults.join(', ')}, + spam/junk/bulk folders)`
+                            `Default (${defaults.join(', ')})`
                         );
                     }
                 }).catch(() => { /* placeholder stays at the initial value */ });

--- a/tauri-app/frontend/js/app.js
+++ b/tauri-app/frontend/js/app.js
@@ -273,7 +273,7 @@ NostrMailApp.prototype.loadSettings = async function() {
                         emails_per_page: parseInt(dbSettings.emails_per_page) || 50, // Default to 50
                         inbox_folder: dbSettings.inbox_folder || '',
                         require_signature: dbSettings.require_signature !== 'false', // Default to true if not set
-                        spam_rescue: dbSettings.spam_rescue === 'true', // Default to false (opt-in)
+                        spam_rescue: dbSettings.spam_rescue !== 'false', // Default to true (on by default)
                         spam_rescue_target: dbSettings.spam_rescue_target || 'nostr-mail',
                         hide_undecryptable_emails: dbSettings.hide_undecryptable_emails !== 'false', // Default to true if not set
                         automatically_encrypt: dbSettings.automatically_encrypt !== 'false', // Default to true if not set
@@ -332,7 +332,7 @@ NostrMailApp.prototype.resetSettingsToDefaults = async function() {
         emails_per_page: 50,
         inbox_folder: '',
         require_signature: true,
-        spam_rescue: false,
+        spam_rescue: true,
         spam_rescue_target: 'nostr-mail',
         glossia_encoding_body: 'latin',
         glossia_encoding_signature: 'latin',
@@ -383,7 +383,7 @@ NostrMailApp.prototype.resetSettingsToDefaultsForPubkey = function(pubkey) {
         emails_per_page: 50,
         inbox_folder: '',
         require_signature: true,
-        spam_rescue: false,
+        spam_rescue: true,
         spam_rescue_target: 'nostr-mail',
         hide_undecryptable_emails: true,
         automatically_encrypt: true,
@@ -447,7 +447,7 @@ NostrMailApp.prototype.loadSettingsForPubkey = async function(pubkey) {
                 emails_per_page: parseInt(dbSettings.emails_per_page) || 50, // Default to 50
                 inbox_folder: dbSettings.inbox_folder || '',
                 require_signature: dbSettings.require_signature !== 'false', // Default to true if not set
-                spam_rescue: dbSettings.spam_rescue === 'true', // Default to false (opt-in)
+                spam_rescue: dbSettings.spam_rescue !== 'false', // Default to true (on by default)
                 spam_rescue_target: dbSettings.spam_rescue_target || 'nostr-mail',
                 hide_undecryptable_emails: dbSettings.hide_undecryptable_emails !== 'false', // Default to true if not set
                 automatically_encrypt: dbSettings.automatically_encrypt !== 'false', // Default to true if not set
@@ -3078,7 +3078,7 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
                 emails_per_page: (loadedSettings && loadedSettings.emails_per_page) ? loadedSettings.emails_per_page : (parseInt(domManager.getValue('emailsPerPage')) || 50),
                 inbox_folder: (loadedSettings && loadedSettings.inbox_folder !== undefined) ? loadedSettings.inbox_folder : readInboxFolderSelection(),
                 require_signature: (loadedSettings && loadedSettings.require_signature !== undefined) ? loadedSettings.require_signature : (domManager.get('require-signature-preference')?.checked !== false),
-                spam_rescue: (loadedSettings && loadedSettings.spam_rescue !== undefined) ? loadedSettings.spam_rescue : (domManager.get('spam-rescue-preference')?.checked === true),
+                spam_rescue: (loadedSettings && loadedSettings.spam_rescue !== undefined) ? loadedSettings.spam_rescue : (domManager.get('spam-rescue-preference')?.checked !== false),
                 spam_rescue_target: (loadedSettings && loadedSettings.spam_rescue_target !== undefined) ? loadedSettings.spam_rescue_target : ((domManager.get('spam-rescue-target-preference')?.value || '').trim() || 'nostr-mail'),
                 hide_undecryptable_emails: (loadedSettings && loadedSettings.hide_undecryptable_emails !== undefined) ? loadedSettings.hide_undecryptable_emails : (domManager.get('hide-undecryptable-emails-preference')?.checked !== false),
                 automatically_encrypt: (loadedSettings && loadedSettings.automatically_encrypt !== undefined) ? loadedSettings.automatically_encrypt : (domManager.get('automatically-encrypt-preference')?.checked !== false),
@@ -3119,7 +3119,7 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
                 emails_per_page: parseInt(domManager.getValue('emailsPerPage')) || 50, // Default to 50
                 inbox_folder: readInboxFolderSelection(),
                 require_signature: domManager.get('require-signature-preference')?.checked !== false, // Default to true
-                spam_rescue: domManager.get('spam-rescue-preference')?.checked === true, // Default to false (opt-in)
+                spam_rescue: domManager.get('spam-rescue-preference')?.checked !== false, // Default to true (on by default)
                 spam_rescue_target: (domManager.get('spam-rescue-target-preference')?.value || '').trim() || 'nostr-mail',
                 hide_undecryptable_emails: domManager.get('hide-undecryptable-emails-preference')?.checked !== false, // Default to true
                 automatically_encrypt: autoEncryptEnabled,
@@ -3166,7 +3166,7 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
             settingsMap.set('emails_per_page', settings.emails_per_page.toString());
             settingsMap.set('inbox_folder', settings.inbox_folder || '');
             settingsMap.set('require_signature', settings.require_signature.toString());
-            settingsMap.set('spam_rescue', (settings.spam_rescue || false).toString());
+            settingsMap.set('spam_rescue', (settings.spam_rescue !== false).toString());
             settingsMap.set('spam_rescue_target', settings.spam_rescue_target || 'nostr-mail');
             settingsMap.set('hide_undecryptable_emails', (settings.hide_undecryptable_emails || false).toString());
             settingsMap.set('automatically_encrypt', (settings.automatically_encrypt !== undefined ? settings.automatically_encrypt : true).toString());
@@ -3556,7 +3556,7 @@ NostrMailApp.prototype.populateSettingsForm = async function() {
         // Set spam rescue preference (default to false — opt-in) and target folder
         const spamRescuePref = domManager.get('spam-rescue-preference');
         if (spamRescuePref) {
-            spamRescuePref.checked = settings.spam_rescue === true;
+            spamRescuePref.checked = settings.spam_rescue !== false;
         }
         this.populateSpamRescueTargetOptions(settings);
 

--- a/tauri-app/frontend/js/app.js
+++ b/tauri-app/frontend/js/app.js
@@ -273,6 +273,8 @@ NostrMailApp.prototype.loadSettings = async function() {
                         emails_per_page: parseInt(dbSettings.emails_per_page) || 50, // Default to 50
                         inbox_folder: dbSettings.inbox_folder || '',
                         require_signature: dbSettings.require_signature !== 'false', // Default to true if not set
+                        spam_rescue: dbSettings.spam_rescue === 'true', // Default to false (opt-in)
+                        spam_rescue_target: dbSettings.spam_rescue_target || 'nostr-mail',
                         hide_undecryptable_emails: dbSettings.hide_undecryptable_emails !== 'false', // Default to true if not set
                         automatically_encrypt: dbSettings.automatically_encrypt !== 'false', // Default to true if not set
                         automatically_sign: dbSettings.automatically_sign !== 'false', // Default to true if not set
@@ -330,6 +332,8 @@ NostrMailApp.prototype.resetSettingsToDefaults = async function() {
         emails_per_page: 50,
         inbox_folder: '',
         require_signature: true,
+        spam_rescue: false,
+        spam_rescue_target: 'nostr-mail',
         glossia_encoding_body: 'latin',
         glossia_encoding_signature: 'latin',
         glossia_encoding_pubkey: 'latin'
@@ -379,6 +383,8 @@ NostrMailApp.prototype.resetSettingsToDefaultsForPubkey = function(pubkey) {
         emails_per_page: 50,
         inbox_folder: '',
         require_signature: true,
+        spam_rescue: false,
+        spam_rescue_target: 'nostr-mail',
         hide_undecryptable_emails: true,
         automatically_encrypt: true,
         automatically_sign: true,
@@ -441,6 +447,8 @@ NostrMailApp.prototype.loadSettingsForPubkey = async function(pubkey) {
                 emails_per_page: parseInt(dbSettings.emails_per_page) || 50, // Default to 50
                 inbox_folder: dbSettings.inbox_folder || '',
                 require_signature: dbSettings.require_signature !== 'false', // Default to true if not set
+                spam_rescue: dbSettings.spam_rescue === 'true', // Default to false (opt-in)
+                spam_rescue_target: dbSettings.spam_rescue_target || 'nostr-mail',
                 hide_undecryptable_emails: dbSettings.hide_undecryptable_emails !== 'false', // Default to true if not set
                 automatically_encrypt: dbSettings.automatically_encrypt !== 'false', // Default to true if not set
                 automatically_sign: dbSettings.automatically_sign !== 'false', // Default to true if not set
@@ -3067,6 +3075,8 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
                 emails_per_page: (loadedSettings && loadedSettings.emails_per_page) ? loadedSettings.emails_per_page : (parseInt(domManager.getValue('emailsPerPage')) || 50),
                 inbox_folder: (loadedSettings && loadedSettings.inbox_folder !== undefined) ? loadedSettings.inbox_folder : readInboxFolderSelection(),
                 require_signature: (loadedSettings && loadedSettings.require_signature !== undefined) ? loadedSettings.require_signature : (domManager.get('require-signature-preference')?.checked !== false),
+                spam_rescue: (loadedSettings && loadedSettings.spam_rescue !== undefined) ? loadedSettings.spam_rescue : (domManager.get('spam-rescue-preference')?.checked === true),
+                spam_rescue_target: (loadedSettings && loadedSettings.spam_rescue_target !== undefined) ? loadedSettings.spam_rescue_target : ((domManager.get('spam-rescue-target-preference')?.value || '').trim() || 'nostr-mail'),
                 hide_undecryptable_emails: (loadedSettings && loadedSettings.hide_undecryptable_emails !== undefined) ? loadedSettings.hide_undecryptable_emails : (domManager.get('hide-undecryptable-emails-preference')?.checked !== false),
                 automatically_encrypt: (loadedSettings && loadedSettings.automatically_encrypt !== undefined) ? loadedSettings.automatically_encrypt : (domManager.get('automatically-encrypt-preference')?.checked !== false),
                 automatically_sign: (loadedSettings && loadedSettings.automatically_sign !== undefined) ? loadedSettings.automatically_sign : (domManager.get('automatically-sign-preference')?.checked !== false),
@@ -3106,6 +3116,8 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
                 emails_per_page: parseInt(domManager.getValue('emailsPerPage')) || 50, // Default to 50
                 inbox_folder: readInboxFolderSelection(),
                 require_signature: domManager.get('require-signature-preference')?.checked !== false, // Default to true
+                spam_rescue: domManager.get('spam-rescue-preference')?.checked === true, // Default to false (opt-in)
+                spam_rescue_target: (domManager.get('spam-rescue-target-preference')?.value || '').trim() || 'nostr-mail',
                 hide_undecryptable_emails: domManager.get('hide-undecryptable-emails-preference')?.checked !== false, // Default to true
                 automatically_encrypt: autoEncryptEnabled,
                 automatically_sign: autoSignPref?.checked !== false, // Default to true (will be true if auto-encrypt is enabled)
@@ -3151,6 +3163,8 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
             settingsMap.set('emails_per_page', settings.emails_per_page.toString());
             settingsMap.set('inbox_folder', settings.inbox_folder || '');
             settingsMap.set('require_signature', settings.require_signature.toString());
+            settingsMap.set('spam_rescue', (settings.spam_rescue || false).toString());
+            settingsMap.set('spam_rescue_target', settings.spam_rescue_target || 'nostr-mail');
             settingsMap.set('hide_undecryptable_emails', (settings.hide_undecryptable_emails || false).toString());
             settingsMap.set('automatically_encrypt', (settings.automatically_encrypt !== undefined ? settings.automatically_encrypt : true).toString());
             settingsMap.set('automatically_sign', (settings.automatically_sign !== undefined ? settings.automatically_sign : true).toString());
@@ -3248,6 +3262,8 @@ NostrMailApp.prototype.setupAutoSaveSettings = function() {
         'emailFilterPreference',
         'send-matching-dm-preference',
         'require-signature-preference',
+        'spam-rescue-preference',
+        'spam-rescue-target-preference',
         'hide-undecryptable-emails-preference',
         'automatically-encrypt-preference',
         'automatically-sign-preference',
@@ -3492,7 +3508,17 @@ NostrMailApp.prototype.populateSettingsForm = async function() {
         if (requireSignaturePref) {
             requireSignaturePref.checked = settings.require_signature !== false;
         }
-        
+
+        // Set spam rescue preference (default to false — opt-in) and target folder
+        const spamRescuePref = domManager.get('spam-rescue-preference');
+        if (spamRescuePref) {
+            spamRescuePref.checked = settings.spam_rescue === true;
+        }
+        const spamRescueTargetPref = domManager.get('spam-rescue-target-preference');
+        if (spamRescueTargetPref) {
+            spamRescueTargetPref.value = settings.spam_rescue_target || 'nostr-mail';
+        }
+
         // Set hide undecryptable emails preference (default to true if not set)
         const hideUndecryptablePref = domManager.get('hide-undecryptable-emails-preference');
         if (hideUndecryptablePref) {

--- a/tauri-app/frontend/js/dom-manager.js
+++ b/tauri-app/frontend/js/dom-manager.js
@@ -105,6 +105,8 @@ class DOMManager {
             emailFilterPreference: this.getElement('email-filter-preference'),
             'send-matching-dm-preference': this.getElement('send-matching-dm-preference'),
             'require-signature-preference': this.getElement('require-signature-preference'),
+            'spam-rescue-preference': this.getElement('spam-rescue-preference'),
+            'spam-rescue-target-preference': this.getElement('spam-rescue-target-preference'),
             'hide-undecryptable-emails-preference': this.getElement('hide-undecryptable-emails-preference'),
             'automatically-encrypt-preference': this.getElement('automatically-encrypt-preference'),
             'automatically-sign-preference': this.getElement('automatically-sign-preference'),

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -5708,25 +5708,53 @@ ${attachmentsHtml}
         const settings = appState.getSettings() || {};
         const userEmail = settings.email_address || null;
 
+        const emailConfig = {
+            email_address: settings.email_address,
+            password: settings.password,
+            smtp_host: settings.smtp_host || '',
+            smtp_port: settings.smtp_port || 587,
+            imap_host: settings.imap_host,
+            imap_port: settings.imap_port || 993,
+            use_tls: settings.use_tls !== false,
+        };
+
         // Fetch the current server folder list to populate the picker. Failure is
         // non-fatal — the user can still type a new folder name.
         let folders = [];
         try {
-            const emailConfig = {
-                email_address: settings.email_address,
-                password: settings.password,
-                smtp_host: settings.smtp_host || '',
-                smtp_port: settings.smtp_port || 587,
-                imap_host: settings.imap_host,
-                imap_port: settings.imap_port || 993,
-                use_tls: settings.use_tls !== false,
-            };
             folders = (await TauriService.listImapFolders(emailConfig)) || [];
         } catch (error) {
             console.warn('[JS] Could not list folders for move picker:', error);
         }
 
-        const target = await notificationService.showFolderPicker(folders, 'Move to folder');
+        // Resolve the message's ACTUAL current folder from the server so the
+        // picker's "(current)" label is correct even after a prior move (inbox
+        // emails carry no per-email folder). Check inbox folders first (cheap,
+        // common case), then the rest; fall back to the inbox heuristic if the
+        // server can't be reached or the message isn't found.
+        const inboxFolders = (settings.inbox_folder || '')
+            .split('\n')
+            .map(s => s.trim())
+            .filter(Boolean);
+        if (inboxFolders.length === 0) inboxFolders.push('INBOX');
+        let currentFolder = inboxFolders[0];
+        try {
+            // Gmail's "All Mail"/"Important"/"Starred" are label views that match
+            // virtually every message, so excluding them keeps the resolved folder
+            // a real storage location.
+            const isVirtual = f => /all mail|important|starred/i.test(f);
+            const seen = new Set(inboxFolders.map(f => f.toLowerCase()));
+            const ordered = [
+                ...inboxFolders,
+                ...folders.filter(f => !seen.has(f.toLowerCase()) && !isVirtual(f)),
+            ];
+            const actual = await TauriService.findMessageFolder(emailConfig, messageId, ordered);
+            if (actual) currentFolder = actual;
+        } catch (error) {
+            console.warn('[JS] Could not resolve current folder for move picker:', error);
+        }
+
+        const target = await notificationService.showFolderPicker(folders, 'Move to folder', currentFolder);
         if (!target) return false;
 
         const loading = notificationService.showLoading('Moving email...');

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -5350,6 +5350,7 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
 <button class="thread-action-btn thread-more-btn" title="More"><i class="fas fa-ellipsis-v"></i></button>
 <div class="thread-more-dropdown">
 <button class="thread-menu-item thread-raw-toggle">Show Raw</button>
+${source === 'inbox' ? '<button class="thread-menu-item thread-move-action">Move to folder</button>' : ''}
 <button class="thread-menu-item thread-delete-action">Delete</button>
 </div>
 </div>
@@ -5449,6 +5450,21 @@ ${attachmentsHtml}
                                     this.showSentList();
                                     await this.loadSentEmails();
                                 }
+                            }
+                        });
+                    }
+                    const moveCardBtn = cardDiv.querySelector('.thread-move-action');
+                    if (moveCardBtn) {
+                        moveCardBtn.addEventListener('click', async () => {
+                            moreDropdown.classList.remove('open');
+                            const messageId = email.message_id || email.id;
+                            const ok = await this._moveEmailFromDetail(messageId);
+                            if (!ok) return;
+                            cardDiv.remove();
+                            const remaining = threadContent.querySelectorAll('.email-detail-card').length;
+                            if (remaining === 0) {
+                                this.showEmailList();
+                                await this.loadEmails();
                             }
                         });
                     }

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -5926,8 +5926,16 @@ ${attachmentsHtml}
             const folders = await TauriService.listImapFolders(emailConfig);
 
             if (window.FolderMultiselect) {
+                // Spam/junk/bulk folders are never inbox folders — the backend
+                // recovers misfiled nostr mail via spam rescue instead. Keep
+                // them out of the option list entirely so they can't be picked
+                // (and aren't shown as selected from a stale persisted value).
+                const isSpammy = (name) => {
+                    const lower = name.toLowerCase();
+                    return lower.includes('spam') || lower.includes('junk') || lower.includes('bulk');
+                };
                 const filteredFolders = (folders || []).filter(folder =>
-                    folder.toLowerCase() !== 'sent'
+                    folder.toLowerCase() !== 'sent' && !isSpammy(folder)
                 );
                 // Only keep prior selections that still exist on the server.
                 const filteredSet = new Set(filteredFolders);
@@ -5936,8 +5944,7 @@ ${attachmentsHtml}
                 // No usable saved selection? Pre-select the provider-aware
                 // defaults so users SEE what will be synced as pills (rather
                 // than as ghosted placeholder text). Mirrors the backend's
-                // default logic: static defaults + any folder whose name
-                // contains spam/junk/bulk. setOptions calls setValue with
+                // `default_inbox_folders`. setOptions calls setValue with
                 // silent=true so this doesn't trigger autosave — the user's
                 // persisted "" stays "" until they actively change something.
                 if (restoreSelection.length === 0) {
@@ -5951,12 +5958,6 @@ ${attachmentsHtml}
                     const effective = new Set();
                     for (const name of (staticDefaults || [])) {
                         if (filteredSet.has(name)) effective.add(name);
-                    }
-                    for (const name of filteredFolders) {
-                        const lower = name.toLowerCase();
-                        if (lower.includes('spam') || lower.includes('junk') || lower.includes('bulk')) {
-                            effective.add(name);
-                        }
                     }
                     restoreSelection = Array.from(effective);
                 }

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -4619,6 +4619,7 @@ ${securityRows ? `<hr><div class="email-security-info">${securityRows}</div>` : 
 <button class="thread-action-btn thread-more-btn" title="More"><i class="fas fa-ellipsis-v"></i></button>
 <div class="thread-more-dropdown">
 <button class="thread-menu-item thread-raw-toggle">Show Raw</button>
+<button class="thread-menu-item thread-move-action">Move to folder</button>
 <button class="thread-menu-item thread-delete-action">Delete</button>
 </div>
 </div>
@@ -4710,6 +4711,17 @@ ${attachmentsHtml}
                         inboxDeleteBtn.addEventListener('click', async () => {
                             inboxMoreDropdown.classList.remove('open');
                             const ok = await this._deleteEmailFromDetail(email.message_id || email.id, 'inbox');
+                            if (!ok) return;
+                            this.showEmailList();
+                            await this.loadEmails();
+                        });
+                    }
+
+                    const inboxMoveBtn = emailDetailContent.querySelector('.thread-move-action');
+                    if (inboxMoveBtn) {
+                        inboxMoveBtn.addEventListener('click', async () => {
+                            inboxMoreDropdown.classList.remove('open');
+                            const ok = await this._moveEmailFromDetail(email.message_id || email.id);
                             if (!ok) return;
                             this.showEmailList();
                             await this.loadEmails();
@@ -5670,6 +5682,47 @@ ${attachmentsHtml}
         } catch (error) {
             console.error(`[JS] Error deleting ${source} email:`, error);
             notificationService.showError('Failed to delete email: ' + error);
+            return false;
+        }
+    }
+
+    // Prompt for a destination folder and move a single inbox email there on the
+    // server. Returns true if the move succeeded so the caller can refresh the UI.
+    async _moveEmailFromDetail(messageId) {
+        const settings = appState.getSettings() || {};
+        const userEmail = settings.email_address || null;
+
+        // Fetch the current server folder list to populate the picker. Failure is
+        // non-fatal — the user can still type a new folder name.
+        let folders = [];
+        try {
+            const emailConfig = {
+                email_address: settings.email_address,
+                password: settings.password,
+                smtp_host: settings.smtp_host || '',
+                smtp_port: settings.smtp_port || 587,
+                imap_host: settings.imap_host,
+                imap_port: settings.imap_port || 993,
+                use_tls: settings.use_tls !== false,
+            };
+            folders = (await TauriService.listImapFolders(emailConfig)) || [];
+        } catch (error) {
+            console.warn('[JS] Could not list folders for move picker:', error);
+        }
+
+        const target = await notificationService.showFolderPicker(folders, 'Move to folder');
+        if (!target) return false;
+
+        const loading = notificationService.showLoading('Moving email...');
+        try {
+            await TauriService.moveInboxEmail(messageId, target, userEmail);
+            notificationService.hideLoading(loading);
+            notificationService.showSuccess(`Email moved to "${target}".`);
+            return true;
+        } catch (error) {
+            notificationService.hideLoading(loading);
+            console.error('[JS] Error moving email:', error);
+            notificationService.showError('Failed to move email: ' + error);
             return false;
         }
     }

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -5964,6 +5964,12 @@ ${attachmentsHtml}
                 window.FolderMultiselect.setOptions(filteredFolders, restoreSelection);
             }
 
+            // The spam-rescue target dropdown derives its options from the inbox
+            // folder selection, so refresh it once the live folder list lands.
+            if (window.app && typeof window.app.populateSpamRescueTargetOptions === 'function') {
+                window.app.populateSpamRescueTargetOptions();
+            }
+
             console.log(`[EMAIL-SERVICE] Loaded ${folders?.length || 0} folders`);
 
         } catch (error) {

--- a/tauri-app/frontend/js/notification-service.js
+++ b/tauri-app/frontend/js/notification-service.js
@@ -385,6 +385,104 @@ class NotificationService {
             });
         });
     }
+
+    /**
+     * Prompt the user to pick a destination folder for moving an email.
+     * Shows a dropdown of existing folders plus a field for creating a new one.
+     * Resolves to the chosen folder name, or null if cancelled.
+     */
+    async showFolderPicker(folders = [], title = 'Move to folder') {
+        return new Promise((resolve) => {
+            const options = (folders || [])
+                .filter(Boolean)
+                .map(f => `<option value="${this.escapeAttr(f)}">${this.escapeAttr(f)}</option>`)
+                .join('');
+
+            const modal = document.createElement('div');
+            modal.className = 'confirmation-modal';
+            modal.innerHTML = `
+                <div class="confirmation-overlay">
+                    <div class="confirmation-dialog">
+                        <h3>${title}</h3>
+                        <p>Choose an existing folder or type a new one.</p>
+                        <select id="folder-picker-select" style="width:100%;padding:8px;margin-bottom:10px;">
+                            ${options}
+                        </select>
+                        <input type="text" id="folder-picker-new" placeholder="Or new folder name" style="width:100%;padding:8px;box-sizing:border-box;" />
+                        <div class="confirmation-actions">
+                            <button class="btn btn-secondary" id="folder-cancel">Cancel</button>
+                            <button class="btn btn-primary" id="folder-confirm">Move</button>
+                        </div>
+                    </div>
+                </div>
+            `;
+
+            modal.style.cssText = `
+                position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+                z-index: 10000; display: flex; align-items: center;
+                justify-content: center; pointer-events: auto;
+            `;
+
+            const overlay = modal.querySelector('.confirmation-overlay');
+            overlay.style.cssText = `
+                position: absolute; top: 0; left: 0; width: 100%; height: 100%;
+                background: rgba(0, 0, 0, 0.5); display: flex;
+                align-items: center; justify-content: center;
+            `;
+
+            const dialog = modal.querySelector('.confirmation-dialog');
+            dialog.style.cssText = `
+                background: white; padding: 20px; border-radius: 8px;
+                max-width: 480px; width: 90%; text-align: center;
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15); word-wrap: break-word;
+            `;
+
+            const actions = modal.querySelector('.confirmation-actions');
+            actions.style.cssText = `
+                margin-top: 20px; display: flex; gap: 10px;
+                justify-content: center; flex-wrap: wrap;
+            `;
+
+            document.body.appendChild(modal);
+
+            const select = modal.querySelector('#folder-picker-select');
+            const newInput = modal.querySelector('#folder-picker-new');
+            const cancelBtn = modal.querySelector('#folder-cancel');
+            const confirmBtn = modal.querySelector('#folder-confirm');
+
+            const cleanup = () => {
+                if (modal.parentNode) modal.parentNode.removeChild(modal);
+            };
+
+            cancelBtn.addEventListener('click', () => { cleanup(); resolve(null); });
+
+            confirmBtn.addEventListener('click', () => {
+                const typed = (newInput.value || '').trim();
+                const chosen = typed || (select.value || '').trim();
+                cleanup();
+                resolve(chosen || null);
+            });
+
+            overlay.addEventListener('click', (e) => {
+                if (e.target === overlay) {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    cleanup();
+                    resolve(null);
+                }
+            });
+
+            dialog.addEventListener('click', (e) => e.stopPropagation());
+        });
+    }
+
+    escapeAttr(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    }
 }
 
 // Create and export a singleton instance

--- a/tauri-app/frontend/js/notification-service.js
+++ b/tauri-app/frontend/js/notification-service.js
@@ -391,11 +391,20 @@ class NotificationService {
      * Shows a dropdown of existing folders plus a field for creating a new one.
      * Resolves to the chosen folder name, or null if cancelled.
      */
-    async showFolderPicker(folders = [], title = 'Move to folder') {
+    async showFolderPicker(folders = [], title = 'Move to folder', currentFolder = '') {
         return new Promise((resolve) => {
-            const options = (folders || [])
-                .filter(Boolean)
-                .map(f => `<option value="${this.escapeAttr(f)}">${this.escapeAttr(f)}</option>`)
+            const cur = (currentFolder || '').trim();
+            const folderList = (folders || []).filter(Boolean);
+            // Make sure the current folder is present so it can be shown/selected.
+            if (cur && !folderList.some(f => f.toLowerCase() === cur.toLowerCase())) {
+                folderList.unshift(cur);
+            }
+            const options = folderList
+                .map(f => {
+                    const isCurrent = cur && f.toLowerCase() === cur.toLowerCase();
+                    const label = isCurrent ? `${f} (current)` : f;
+                    return `<option value="${this.escapeAttr(f)}"${isCurrent ? ' selected' : ''}>${this.escapeAttr(label)}</option>`;
+                })
                 .join('');
 
             const modal = document.createElement('div');
@@ -405,13 +414,13 @@ class NotificationService {
                     <div class="confirmation-dialog">
                         <h3>${title}</h3>
                         <p>Choose an existing folder or type a new one.</p>
-                        <select id="folder-picker-select" style="width:100%;padding:8px;margin-bottom:10px;">
+                        <select id="folder-picker-select" style="width:100%;margin-bottom:10px;">
                             ${options}
                         </select>
-                        <input type="text" id="folder-picker-new" placeholder="Or new folder name" style="width:100%;padding:8px;box-sizing:border-box;" />
+                        <input type="text" id="folder-picker-new" placeholder="Or new folder name" style="width:100%;box-sizing:border-box;" />
                         <div class="confirmation-actions">
                             <button class="btn btn-secondary" id="folder-cancel">Cancel</button>
-                            <button class="btn btn-primary" id="folder-confirm">Move</button>
+                            <button class="btn btn-primary" id="folder-confirm" disabled>Move</button>
                         </div>
                     </div>
                 </div>
@@ -454,11 +463,26 @@ class NotificationService {
                 if (modal.parentNode) modal.parentNode.removeChild(modal);
             };
 
+            // Keep Move disabled until the user picks a folder that differs from
+            // the current one (typed name takes precedence over the dropdown).
+            const resolvedTarget = () => {
+                const typed = (newInput.value || '').trim();
+                return typed || (select.value || '').trim();
+            };
+            const updateConfirmState = () => {
+                const target = resolvedTarget();
+                const unchanged = !target || target.toLowerCase() === cur.toLowerCase();
+                confirmBtn.disabled = unchanged;
+            };
+            select.addEventListener('change', updateConfirmState);
+            newInput.addEventListener('input', updateConfirmState);
+            updateConfirmState();
+
             cancelBtn.addEventListener('click', () => { cleanup(); resolve(null); });
 
             confirmBtn.addEventListener('click', () => {
-                const typed = (newInput.value || '').trim();
-                const chosen = typed || (select.value || '').trim();
+                if (confirmBtn.disabled) return;
+                const chosen = resolvedTarget();
                 cleanup();
                 resolve(chosen || null);
             });

--- a/tauri-app/frontend/js/tauri-service.js
+++ b/tauri-app/frontend/js/tauri-service.js
@@ -662,6 +662,10 @@ const TauriService = {
         return await this.invoke('db_delete_inbox_email', { messageId, deleteFromServer, userEmail });
     },
 
+    moveInboxEmail: async function(messageId, targetFolder, userEmail) {
+        return await this.invoke('move_inbox_email', { messageId, targetFolder, userEmail });
+    },
+
     markAsRead: async function(messageId) {
         return await this.invoke('db_mark_as_read', { messageId });
     },

--- a/tauri-app/frontend/js/tauri-service.js
+++ b/tauri-app/frontend/js/tauri-service.js
@@ -666,6 +666,12 @@ const TauriService = {
         return await this.invoke('move_inbox_email', { messageId, targetFolder, userEmail });
     },
 
+    // One-time catch-up rescue when the user first enables spam rescue: moves
+    // ALL nostr mail (read + unread) out of spam and returns how many moved.
+    rescueSpamNow: async function() {
+        return await this.invoke('rescue_spam_now', {});
+    },
+
     markAsRead: async function(messageId) {
         return await this.invoke('db_mark_as_read', { messageId });
     },

--- a/tauri-app/frontend/js/tauri-service.js
+++ b/tauri-app/frontend/js/tauri-service.js
@@ -292,6 +292,9 @@ const TauriService = {
     listImapFolders: async function(emailConfig) {
         return await this.invoke('list_imap_folders', { emailConfig });
     },
+    findMessageFolder: async function(emailConfig, messageId, candidateFolders) {
+        return await this.invoke('find_message_folder', { emailConfig, messageId, candidateFolders });
+    },
     fetchImage: async function(url) {
         return await this.invoke('fetch_image', { url });
     },

--- a/tauri-app/frontend/styles/modals.css
+++ b/tauri-app/frontend/styles/modals.css
@@ -258,6 +258,58 @@ body.dark-mode .confirmation-modal .confirmation-actions button#confirm-ok {
     color: #fff;
 }
 
+/* Disabled action button (e.g. Move while no new folder is chosen). Scoped here
+   so it beats the !important dark-mode button background above. */
+.confirmation-modal .confirmation-actions button:disabled,
+body.dark-mode .confirmation-modal .confirmation-actions button:disabled {
+    opacity: 0.5 !important;
+    cursor: not-allowed !important;
+}
+
+/* Folder picker select/input inside the confirmation dialog (e.g. Move to
+   folder). These aren't .form-group children, so they need their own styling;
+   mirrors the settings-page controls (.form-group input/select). Sizing applies
+   in both themes; colors are overridden in dark mode below. */
+.confirmation-modal .confirmation-dialog select,
+.confirmation-modal .confirmation-dialog input[type="text"] {
+    font-size: 1rem;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--radius-md);
+}
+
+
+body.dark-mode .confirmation-modal .confirmation-dialog select,
+body.dark-mode .confirmation-modal .confirmation-dialog input[type="text"] {
+    background-color: #232946 !important;
+    color: #e0e0e0 !important;
+    border: 2px solid #232946 !important;
+}
+
+body.dark-mode .confirmation-modal .confirmation-dialog select {
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23e0e0e0' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m1 6 7 7 7-7'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 16px 12px;
+    padding-right: 40px;
+}
+
+body.dark-mode .confirmation-modal .confirmation-dialog select:focus,
+body.dark-mode .confirmation-modal .confirmation-dialog input[type="text"]:focus {
+    border-color: #667eea !important;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1) !important;
+}
+
+body.dark-mode .confirmation-modal .confirmation-dialog select:focus {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23667eea' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m1 6 7 7 7-7'/%3e%3c/svg%3e");
+}
+
+body.dark-mode .confirmation-modal .confirmation-dialog select option {
+    background-color: #232946;
+    color: #e0e0e0;
+}
+
 /* Mobile-specific modal fixes */
 @media (max-width: 480px) {
     .modal-overlay {


### PR DESCRIPTION
## Summary
Two related features:

1. **Manual "Move to folder"** (#73) — move an inbox email to any IMAP folder (existing or new) from the email detail view.
2. **Automated "Spam rescue"** (#72) — when enabled, each sync moves Nostr-encrypted messages out of the provider's Spam/Junk folders into a chosen destination folder, built on the move primitive from #73.

## Key Changes

**Backend (Rust)**
- `move_inbox_email_to_folder()` + helpers + `move_inbox_email` Tauri command — move an email by Message-ID to a target folder (IMAP MOVE with COPY+DELETE+EXPUNGE fallback, auto-creates destination).
- **Spam rescue:** settings helpers; `list_spam_folders`; `should_rescue_message`; `rescue_nostr_emails_from_spam`; `move_uids_to_folder`. Hooked into `sync_nostr_emails_to_db_inner` (both TLS/non-TLS paths).
- **All IMAP fetches use `BODY.PEEK[]`** (not `RFC822`) — background sync, paging, gap-fill, and rescue never set `\Seen` on the server. Read state lives in our own DB.
- **`\Seen` as the rescue-intent signal:** `move_message_to_folder` sets `+FLAGS (\Seen)` before moving when the target is a spam/junk/bulk folder, so a deliberate move-to-spam keeps the message out of the rescue set.
- Spam rescue **defaults ON** (only an explicit `false` disables it).

**Frontend (JavaScript)**
- `showFolderPicker()` modal + "Move to folder" menu item + `moveInboxEmail()` for #73.
- "Spam Rescue" toggle (now on by default) + **"Rescue into folder" dropdown** (`populateSpamRescueTargetOptions`) sourced from the selected inbox folders minus spam, refreshed on load / folder-list load / inbox-selection change. `spam_rescue` + `spam_rescue_target` wired through all load/save paths.
- `dom-manager` registers `spam-rescue-preference` / `spam-rescue-target-preference`.

## Design — what gets rescued (stateless)
Rescue is derived entirely from server state on every sync, so all devices compute the same answer:

> A spam-folder message is rescued **⟺** it is **`UNSEEN`** **AND** authenticated nostr mail.

"Authenticated nostr mail" means it carries a nostr marker (`X-Nostr-Pubkey`/`X-Nostr-Sig` header or a `BEGIN NOSTR …` armor block — encrypted/signed/signature/seal) **and** passes **transport authentication** (SPF/DKIM/alignment). SPF/DKIM-failing mail is left in spam, matching the inbox's existing enforcement.

**Intent is carried by the `\Seen` flag**, which the IMAP server replicates to every client:
- To keep a message in spam, the user files it there via the app's move-to-folder, which marks it `\Seen` first. A read message in spam is never rescued.
- This works because nothing automated ever sets `\Seen` (all fetches use `BODY.PEEK[]`), so the flag is a trustworthy "a human filed this here" signal.

There is **no rescue-once ledger.** The earlier design recorded every moved Message-ID in a `rescued_message_ids` table; that was per-device, depended on a Message-ID that may be absent or collide, and could permanently strand a message (a partial move marked all ids rescued, and any return to spam — provider re-filing, a server rule — was treated as deliberate and never retried). The `UNSEEN` + `\Seen` rule replaces all of it with a single server-synced source of truth. The old table, if present, is left vestigial; new DBs never create one.

Rescue runs on each sync (event-driven, no new scheduler). Sender-level blocking is intentionally out of scope.

## Verification
- `cargo check` passes on the Rust backend; `node --check` passes on all edited JS.
- Manual IMAP behavior still needs a real-account run — see checklist.

## Test Checklist

**Manual "Move to folder" (#73)**
- [x] More-menu (⋮) → **Move to folder** lists existing IMAP folders.
- [x] Move into an **existing** folder → email leaves the inbox and is in the target folder on the server.
- [x] Move into a **new** typed folder → folder auto-created on the server and the email lands there.
- [x] Local inbox view updates + success notification; cancel/outside-click does nothing.
- [ ] Error path shows a notification and leaves the email in place.
- [ ] On a non-Gmail / no-MOVE server, the COPY+DELETE+EXPUNGE fallback still moves it.

**Spam rescue (#72)**

Settings check:
- [x] In Settings → Preferences, **Spam Rescue** is **on by default**; the **Rescue into folder** dropdown lists exactly the selected inbox folders **minus** spam/junk/bulk; changing the inbox selection updates the dropdown; the saved value reloads.

Gmail end-to-end (happy path) — rescue only acts on **unread** mail, so unread it *before* moving:
1. [x] Send/receive a real nostrmail message so it lands in the NostrMail inbox (`INBOX` or `nostr-mail`).
2. [x] In the **Gmail web UI**, open that message's folder, select it, and choose **Mark as unread** so it shows bold/unread.
3. [x] Still in Gmail, move the (now unread) message to **Spam**. Confirm it lives in `[Gmail]/Spam`.
4. [x] Back in the **NostrMail app**, trigger a sync (open/refresh the Inbox tab).
5. [x] Confirm the app **moves the message out of `[Gmail]/Spam`** into your configured Rescue-into folder (default `nostr-mail`) and that it shows up unread in the NostrMail inbox view.

Guard cases (confirm rescue respects intent / doesn't over-reach):
- [x] **Deliberate move-to-spam via the app:** use **Move to folder → Spam** in NostrMail → the message is marked read and lands in spam; next sync **leaves it in Spam** (it's `\Seen`).
- [x] **Already-read mail:** mark a nostr message as **read**, then move it to Spam in Gmail → next sync **leaves it in Spam** (unread-only guard).
- [ ] **Failed auth:** a message that fails transport auth (SPF/DKIM) is **NOT** rescued, even with nostr markers.
- [x] **Non-nostr spam** is left untouched.
- [x] With Spam Rescue **off**, nothing is moved out of Spam.

https://claude.ai/code/session_01XDc2g6MnA2qqxQCCCs5FH3

---

## Update: keep spam folders out of the inbox + on-enable catch-up (commit 292bd11)

Follow-up to the read-state/`\Seen` sync (#75): scanning spam as part of the inbox conflicted with the `\Seen`-as-intent rule. Reading a misfiled message in the inbox marked it `\Seen` on the server, which spam rescue reads as "the user filed this here, leave it" — permanently suppressing its rescue.

**Spam handling is now decided per sync by the `spam_rescue` setting:**

| `spam_rescue` | Spam scanned? | Behavior |
|---|---|---|
| **ON** (default) | No | Rescue **moves** authenticated nostr mail into the rescue target (already in the scan set, so it surfaces). Spam stays out of `\Seen` bookkeeping. |
| **OFF** | Yes | Spam is scanned so misfiled nostr mail **appears** in the inbox; nothing moves it, so it stays in spam and is auto-purged by the provider (some users prefer this). |

**Changes**
- Removed the unconditional `extend_with_spam_folders` expansion; it's now called **only when rescue is OFF**, and reimplemented on top of `list_spam_folders`.
- Backend filters any stale persisted spam selection out of the scan set unconditionally — spam is never an inbox folder.
- Frontend: the inbox-folder multiselect no longer offers or auto-selects spam/junk/bulk folders; placeholder text updated.
- **On-enable catch-up:** `rescue_nostr_emails_from_spam` gained an `unseen_only` flag. The per-sync rescue stays `UNSEEN`-only; switching rescue ON runs a one-time `rescue_spam_now` (Tauri command + `rescueSpamNow()` IPC wrapper) that sweeps **all** nostr mail (read + unread) out of spam — otherwise already-read mail stranded in spam would never be rescued — then reports how many were moved via a popup.
- Spec: new **§9 Spam Rescue & Folder Handling** documents the ON/OFF table, the stateless `UNSEEN` + `\Seen` rule, the catch-up, and a **future mark-as-spam** note (route through `move_message_to_folder` so it sets `\Seen`; revisit the catch-up to honor `\Seen` once deliberate spam-filing exists). There is currently no first-class mark-as-spam action.

**Verification:** `cargo check` passes; `node --check` passes on all edited JS.

### Added test checklist
- [x] With rescue **ON**, the inbox-folder dropdown shows no spam/junk/bulk options; misfiled nostr mail is moved into the rescue target and appears in the inbox.
- [x] With rescue **OFF**, misfiled nostr mail in spam appears in the inbox but is **not** moved off the server.
- [x] Reading a (rescue-ON) inbox message no longer suppresses rescue of other spam mail.
- [x] Toggling rescue from **OFF → ON** sweeps already-read nostr mail out of spam and shows a "moved N message(s)" popup; toggling it again does not re-sweep.

https://claude.ai/code/session_01XDc2g6MnA2qqxQCCCs5FH3
