### PR TITLE
Publish NIP-05 for nostr-mail.com via GitHub Pages

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -52,6 +52,10 @@ jobs:
         cp tauri-app/frontend/assets/nostr-mail-logo-white.png _site/assets/
         # MkDocs docs under /docs/
         cp -r _site_docs/* _site/docs/
+        # NIP-05 identity: serve /.well-known/nostr.json at the apex domain.
+        # .nojekyll keeps GitHub Pages from stripping the dotfile directory.
+        touch _site/.nojekyll
+        cp -r docs/landing/.well-known _site/.well-known
         # Preserve CNAME for custom domain
         echo "nostr-mail.com" > _site/CNAME
 

--- a/docs/landing/.well-known/nostr.json
+++ b/docs/landing/.well-known/nostr.json
@@ -1,0 +1,8 @@
+{
+  "names": {
+    "_": "ea11ede7f866f99f31d25380dbab5ad56953328c8379e9a97bb33d14fdfd7ae0"
+  },
+  "relays": {
+    "ea11ede7f866f99f31d25380dbab5ad56953328c8379e9a97bb33d14fdfd7ae0": []
+  }
+}


### PR DESCRIPTION
## What

Serves a NIP-05 identity at the apex domain so any Nostr client can resolve `_@nostr-mail.com` to the project pubkey.

When a client looks up `_@nostr-mail.com` it fetches:

```
https://nostr-mail.com/.well-known/nostr.json?name=_
```

GitHub Pages already serves the site under the `nostr-mail.com` custom domain (`docs/CNAME`), and it adds `Access-Control-Allow-Origin: *`, which NIP-05 requires — so no extra hosting is needed.

## Changes

- **`docs/landing/.well-known/nostr.json`** — committed source file mapping the NIP-05 name `_` (the convention for a bare-domain identity) to the project pubkey:
  - npub: `npub1agg7melcvmue7vwj2wqdh2666454xv5vsdu7n2tmkv73fl0a0tsq7asr9j`
  - hex: `ea11ede7f866f99f31d25380dbab5ad56953328c8379e9a97bb33d14fdfd7ae0`
- **`.github/workflows/mkdocs-deploy.yml`** — the `Assemble final site` step now:
  - copies `docs/landing/.well-known/` into the published site root, and
  - `touch`es `.nojekyll` so GitHub Pages doesn't strip the dotfile directory during its default Jekyll build.

## Notes

- The `?name=` query param is ignored by static hosting; clients read the full `names` map and look up `_` themselves — this is standard and works fine.
- The `relays` list is currently empty. If you want clients to learn preferred relays from NIP-05, add relay URLs to the array for that pubkey.
- After this deploys, verify with: `curl https://nostr-mail.com/.well-known/nostr.json`

https://claude.ai/code/session_01EmiD81ute4rDeA6P3xePGk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmiD81ute4rDeA6P3xePGk)_