### PR TITLE
NIP-05: advertise app default relays in nostr.json

### DIFF
--- a/docs/landing/.well-known/nostr.json
+++ b/docs/landing/.well-known/nostr.json
@@ -3,6 +3,15 @@
     "_": "ea11ede7f866f99f31d25380dbab5ad56953328c8379e9a97bb33d14fdfd7ae0"
   },
   "relays": {
-    "ea11ede7f866f99f31d25380dbab5ad56953328c8379e9a97bb33d14fdfd7ae0": []
+    "ea11ede7f866f99f31d25380dbab5ad56953328c8379e9a97bb33d14fdfd7ae0": [
+      "wss://relay.damus.io",
+      "wss://nos.lol",
+      "wss://relay.nostr.pub",
+      "wss://nostr.rocks",
+      "wss://nostr.mom",
+      "wss://nostr.wine",
+      "wss://cache1.primal.net",
+      "wss://relay.nostr.band"
+    ]
   }
 }


### PR DESCRIPTION
Follow-up to #76. Fills the previously-empty `relays` list in `/.well-known/nostr.json` for the project pubkey with nostr-mail's **eight default relays**, sourced from `tauri-app/backend/nostr-mail-config.json` (the same set hardcoded as the fallback in `storage.rs`):

```
wss://relay.damus.io
wss://nos.lol
wss://relay.nostr.pub
wss://nostr.rocks
wss://nostr.mom
wss://nostr.wine
wss://cache1.primal.net
wss://relay.nostr.band
```

Per NIP-05, clients may read this list to learn which relays to query for the identity's events. JSON validated; relay count = 8.

Once merged, the Deploy Site workflow republishes `gh-pages`; verify with `curl https://nostr-mail.com/.well-known/nostr.json`.

https://claude.ai/code/session_01EmiD81ute4rDeA6P3xePGk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmiD81ute4rDeA6P3xePGk)_