### PR TITLE
Speed up IMAP: connection pool, timeouts, and IDLE push

### DIFF
--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -12,7 +12,6 @@ use tokio::task;
 use tokio::time::timeout;
 use std::time::Duration;
 use crate::types::{TransportAuthVerdict, TransportAuthMethod};
-use std::net::TcpStream;
 
 // Verbose [RUST] logs in the decrypt hot path are silent by default — set the
 // NOSTR_MAIL_DEBUG environment variable to any value to re-enable them for
@@ -50,56 +49,13 @@ fn maybe_evict<K: Clone + Eq + std::hash::Hash, V>(
         }
     }
 }
-#[cfg(not(target_os = "android"))]
-use native_tls::TlsConnector;
-#[cfg(target_os = "android")]
-use rustls::{ClientConfig, ClientConnection, RootCertStore, pki_types::ServerName};
-#[cfg(target_os = "android")]
-use std::sync::Arc;
 use uuid::Uuid;
 use base64::{Engine as _, engine::general_purpose};
 
-/// Macro to create a TLS-wrapped IMAP client connection
-/// Uses native-tls on desktop and rustls on Android
-#[cfg(not(target_os = "android"))]
-macro_rules! create_imap_tls_client {
-    ($host:expr, $addr:expr) => {{
-        let tls = TlsConnector::builder().build()?;
-        let tcp_stream = TcpStream::connect($addr)?;
-        let tls_stream: native_tls::TlsStream<TcpStream> = tls.connect($host, tcp_stream)?;
-        Ok::<imap::Client<native_tls::TlsStream<TcpStream>>, anyhow::Error>(imap::Client::new(tls_stream))
-    }};
-}
-
-#[cfg(target_os = "android")]
-macro_rules! create_imap_tls_client {
-    ($host:expr, $addr:expr) => {{
-        // Initialize rustls crypto provider if not already initialized (required for rustls 0.23+)
-        {
-            use std::sync::Once;
-            static INIT: Once = Once::new();
-            INIT.call_once(|| {
-                // Try to install default provider, but don't fail if already installed
-                let _ = rustls::crypto::ring::default_provider().install_default();
-            });
-        }
-        
-        let mut root_store = RootCertStore::empty();
-        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-        
-        let config = ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-        
-        let server_name = ServerName::try_from($host.to_string())
-            .map_err(|_| anyhow::anyhow!("Invalid server name"))?;
-        
-        let tcp_stream = TcpStream::connect($addr)?;
-        let client = ClientConnection::new(Arc::new(config), server_name)?;
-        let tls_stream = rustls::StreamOwned::new(client, tcp_stream);
-        Ok::<imap::Client<rustls::StreamOwned<rustls::ClientConnection, TcpStream>>, anyhow::Error>(imap::Client::new(tls_stream))
-    }};
-}
+// IMAP connections are established and reused through `crate::imap_pool`, which
+// owns TLS setup, socket timeouts, and warm-connection pooling for the active
+// account. See that module for the per-transport details.
+use crate::imap_pool::{self, ImapTarget};
 
 /// Decode RFC 2047 encoded header value and fix UTF-8 encoding issues
 /// mailparse should handle RFC 2047 automatically, but this fixes common UTF-8 misinterpretations
@@ -652,27 +608,11 @@ pub async fn delete_sent_email_from_server(config: &EmailConfig, message_id: &st
 
     // Run all blocking IMAP I/O on a dedicated thread to avoid blocking the Tokio runtime
     tokio::task::spawn_blocking(move || {
-        use std::net::TcpStream;
-        let addr = format!("{}:{}", host, port);
-        let is_gmail = host.contains("gmail.com");
-
-        let result = if use_tls {
-            let client = create_imap_tls_client!(&host, &addr)?;
-            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let result = delete_sent_email_from_session_sync(&mut session, is_gmail, &message_id);
-            let _ = session.logout();
-            debug_log!("[RUST] delete_sent_email_from_server: Session closed");
-            result
-        } else {
-            let tcp_stream = TcpStream::connect(&addr)?;
-            let client = imap::Client::new(tcp_stream);
-            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let result = delete_sent_email_from_session_sync(&mut session, is_gmail, &message_id);
-            let _ = session.logout();
-            debug_log!("[RUST] delete_sent_email_from_server: Session closed");
-            result
-        };
-        result
+        let target = ImapTarget { host, port, username, password, use_tls };
+        let is_gmail = target.host.contains("gmail.com");
+        imap_pool::with_session(&target, |session| {
+            delete_sent_email_from_session_sync(session, is_gmail, &message_id)
+        })
     }).await.map_err(|e| anyhow::anyhow!("Task join error: {}", e))?
 }
 
@@ -868,25 +808,11 @@ pub async fn delete_inbox_email_from_server(config: &EmailConfig, message_id: &s
     debug_log!("[RUST] delete_inbox_email_from_server: Attempting to delete email with Message-ID: {}", message_id);
 
     tokio::task::spawn_blocking(move || {
-        use std::net::TcpStream;
-        let addr = format!("{}:{}", host, port);
-        let is_gmail = host.contains("gmail.com");
-
-        let result = if use_tls {
-            let client = create_imap_tls_client!(&host, &addr)?;
-            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let result = delete_email_from_folder_sync(&mut session, is_gmail, &message_id, &["INBOX", "nostr-mail"]);
-            let _ = session.logout();
-            result
-        } else {
-            let tcp_stream = TcpStream::connect(&addr)?;
-            let client = imap::Client::new(tcp_stream);
-            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let result = delete_email_from_folder_sync(&mut session, is_gmail, &message_id, &["INBOX", "nostr-mail"]);
-            let _ = session.logout();
-            result
-        };
-        result
+        let target = ImapTarget { host, port, username, password, use_tls };
+        let is_gmail = target.host.contains("gmail.com");
+        imap_pool::with_session(&target, |session| {
+            delete_email_from_folder_sync(session, is_gmail, &message_id, &["INBOX", "nostr-mail"])
+        })
     }).await.map_err(|e| anyhow::anyhow!("Task join error: {}", e))?
 }
 
@@ -1002,26 +928,11 @@ pub async fn move_inbox_email_to_folder(
     debug_log!("[RUST] move_inbox_email_to_folder: Moving Message-ID {} to folder {}", message_id, target_folder);
 
     tokio::task::spawn_blocking(move || {
-        use std::net::TcpStream;
-        let addr = format!("{}:{}", host, port);
-
-        let result = if use_tls {
-            let client = create_imap_tls_client!(&host, &addr)?;
-            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let source_folders = searchable_source_folders(&mut session, &target_folder);
-            let result = move_email_to_folder_sync(&mut session, &message_id, &target_folder, &source_folders);
-            let _ = session.logout();
-            result
-        } else {
-            let tcp_stream = TcpStream::connect(&addr)?;
-            let client = imap::Client::new(tcp_stream);
-            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let source_folders = searchable_source_folders(&mut session, &target_folder);
-            let result = move_email_to_folder_sync(&mut session, &message_id, &target_folder, &source_folders);
-            let _ = session.logout();
-            result
-        };
-        result
+        let target = ImapTarget { host, port, username, password, use_tls };
+        imap_pool::with_session(&target, |session| {
+            let source_folders = searchable_source_folders(session, &target_folder);
+            move_email_to_folder_sync(session, &message_id, &target_folder, &source_folders)
+        })
     }).await.map_err(|e| anyhow::anyhow!("Task join error: {}", e))?
 }
 
@@ -1185,22 +1096,10 @@ pub async fn find_message_folder(
     let message_id = message_id.to_string();
 
     tokio::task::spawn_blocking(move || {
-        use std::net::TcpStream;
-        let addr = format!("{}:{}", host, port);
-        if use_tls {
-            let client = create_imap_tls_client!(&host, &addr)?;
-            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let found = find_message_folder_sync(&mut session, &message_id, &candidate_folders);
-            let _ = session.logout();
-            found
-        } else {
-            let tcp_stream = TcpStream::connect(&addr)?;
-            let client = imap::Client::new(tcp_stream);
-            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let found = find_message_folder_sync(&mut session, &message_id, &candidate_folders);
-            let _ = session.logout();
-            found
-        }
+        let target = ImapTarget { host, port, username, password, use_tls };
+        imap_pool::with_session(&target, |session| {
+            find_message_folder_sync(session, &message_id, &candidate_folders)
+        })
     }).await.map_err(|e| anyhow::anyhow!("Task join error: {}", e))?
 }
 
@@ -1287,24 +1186,10 @@ pub async fn mark_inbox_email_seen_on_server(
     debug_log!("[RUST] mark_inbox_email_seen_on_server: Marking Message-ID {} as \\Seen in {:?}", message_id, source_folders);
 
     tokio::task::spawn_blocking(move || {
-        use std::net::TcpStream;
-        let addr = format!("{}:{}", host, port);
-
-        let result = if use_tls {
-            let client = create_imap_tls_client!(&host, &addr)?;
-            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let result = set_seen_in_folder_sync(&mut session, &message_id, &source_folders);
-            let _ = session.logout();
-            result
-        } else {
-            let tcp_stream = TcpStream::connect(&addr)?;
-            let client = imap::Client::new(tcp_stream);
-            let mut session = client.login(&username, &password).map_err(|e| anyhow::anyhow!(e.0))?;
-            let result = set_seen_in_folder_sync(&mut session, &message_id, &source_folders);
-            let _ = session.logout();
-            result
-        };
-        result
+        let target = ImapTarget { host, port, username, password, use_tls };
+        imap_pool::with_session(&target, |session| {
+            set_seen_in_folder_sync(session, &message_id, &source_folders)
+        })
     }).await.map_err(|e| anyhow::anyhow!("Task join error: {}", e))?
 }
 
@@ -1366,61 +1251,30 @@ fn set_seen_in_folder_sync(
 
 /// List available IMAP folders/mailboxes
 pub async fn list_imap_folders(config: &EmailConfig) -> Result<Vec<String>> {
-    let host = &config.imap_host;
-    let port = config.imap_port;
-    let username = &config.email_address;
-    let password = &config.password;
-    let use_tls = config.use_tls;
-    let addr = format!("{}:{}", host, port);
-    
-    debug_log!("[RUST] list_imap_folders: Connecting to IMAP server: {}", addr);
-    
-    let mailboxes = if use_tls {
-        let client = create_imap_tls_client!(host, &addr)?;
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
+    let target = ImapTarget::from_config(config);
+    debug_log!("[RUST] list_imap_folders: Connecting to IMAP server: {}:{}", config.imap_host, config.imap_port);
+
+    let folder_names = imap_pool::with_session(&target, |session| {
         let mailboxes = session.list(Some(""), Some("*"))?;
-        session.logout()?;
-        mailboxes
-    } else {
-        let tcp_stream = TcpStream::connect(&addr)?;
-        let client = imap::Client::new(tcp_stream);
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        let mailboxes = session.list(Some(""), Some("*"))?;
-        session.logout()?;
-        mailboxes
-    };
-    
-    let folder_names: Vec<String> = mailboxes.iter()
-        .map(|mb| mb.name().to_string())
-        .collect();
-    
+        Ok(mailboxes.iter().map(|mb| mb.name().to_string()).collect::<Vec<String>>())
+    })?;
+
     debug_log!("[RUST] list_imap_folders: Found {} folders", folder_names.len());
     Ok(folder_names)
 }
 
 /// Test IMAP connection with the given config. Returns Ok(()) if successful, Err otherwise.
 pub async fn test_imap_connection(config: &EmailConfig) -> Result<()> {
-    let host = &config.imap_host;
-    let port = config.imap_port;
-    let username = &config.email_address;
-    let password = &config.password;
-    let use_tls = config.use_tls;
+    let target = ImapTarget::from_config(config);
+    debug_log!("[RUST] Testing IMAP connection to: {}:{} (TLS: {})", config.imap_host, config.imap_port, config.use_tls);
 
-    let addr = format!("{}:{}", host, port);
-    
-    debug_log!("[RUST] Testing IMAP connection to: {}", addr);
-    debug_log!("[RUST] Host: {}, Port: {}, Use TLS: {}", host, port, use_tls);
+    // checkout connects (or validates a warm connection), proving credentials
+    // and reachability; with_session returns it to the pool so the test also
+    // warms the pool for the next real operation.
+    imap_pool::with_session(&target, |session| {
+        session.noop().map_err(|e| anyhow::anyhow!("{}", e))
+    })?;
 
-    if use_tls {
-        let client = create_imap_tls_client!(host, &addr)?;
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        session.logout()?;
-    } else {
-        let tcp_stream = TcpStream::connect(&addr)?;
-        let client = imap::Client::new(tcp_stream);
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        session.logout()?;
-    }
     debug_log!("[RUST] IMAP connection test successful");
     Ok(())
 }
@@ -5462,86 +5316,42 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
     let mut pending_state: Vec<(String, u32, u32, Option<u32>)> = Vec::new();
     let mut raw_nostr_emails: Vec<RawNostrEmail> = Vec::new();
 
-    let host = &config.imap_host;
-    let port = config.imap_port;
-    let username = &config.email_address;
-    let password = &config.password;
-    let addr = format!("{}:{}", host, port);
-
-    if config.use_tls {
-        let client = create_imap_tls_client!(host, &addr)?;
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        if spam_rescue {
-            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target, /* unseen_only = */ true);
-            if moved > 0 {
-                println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
-            }
-        } else {
-            extend_with_spam_folders(&mut session, &mut folders);
-        }
-        println!("[RUST] sync_nostr_emails_to_db: folders to scan: {:?}", folders);
-        for f in &folders {
-            match uid_sync_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
-                                  parse_nostr_email_from_imap_body) {
-                Ok(r) => {
-                    if r.max_uid > 0 || !r.had_existing_state {
-                        let bootstrap_min = if !r.had_existing_state && r.min_uid > 0 {
-                            Some(r.min_uid)
-                        } else {
-                            None
-                        };
-                        pending_state.push((f.clone(), r.uid_validity, r.max_uid, bootstrap_min));
-                    }
-                    raw_nostr_emails.extend(r.emails);
-                }
-                Err(e) => debug_log!("[RUST] sync_nostr_emails_to_db: folder '{}' failed: {}", f, e),
-            }
-            if include_gap_fill {
-                match gap_fill_in_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
-                                          parse_nostr_email_from_imap_body) {
-                    Ok(emails) => raw_nostr_emails.extend(emails),
-                    Err(e) => debug_log!("[RUST] sync_nostr_emails_to_db: gap_fill folder '{}' failed: {}", f, e),
-                }
-            }
+    let target = ImapTarget::from_config(config);
+    let mut session = imap_pool::checkout(&target)?;
+    if spam_rescue {
+        let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target, /* unseen_only = */ true);
+        if moved > 0 {
+            println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
         }
     } else {
-        let tcp_stream = TcpStream::connect(&addr)?;
-        let client = imap::Client::new(tcp_stream);
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        if spam_rescue {
-            let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target, /* unseen_only = */ true);
-            if moved > 0 {
-                println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
+        extend_with_spam_folders(&mut session, &mut folders);
+    }
+    println!("[RUST] sync_nostr_emails_to_db: folders to scan: {:?}", folders);
+    for f in &folders {
+        match uid_sync_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
+                              parse_nostr_email_from_imap_body) {
+            Ok(r) => {
+                if r.max_uid > 0 || !r.had_existing_state {
+                    let bootstrap_min = if !r.had_existing_state && r.min_uid > 0 {
+                        Some(r.min_uid)
+                    } else {
+                        None
+                    };
+                    pending_state.push((f.clone(), r.uid_validity, r.max_uid, bootstrap_min));
+                }
+                raw_nostr_emails.extend(r.emails);
             }
-        } else {
-            extend_with_spam_folders(&mut session, &mut folders);
+            Err(e) => debug_log!("[RUST] sync_nostr_emails_to_db: folder '{}' failed: {}", f, e),
         }
-        println!("[RUST] sync_nostr_emails_to_db: folders to scan: {:?}", folders);
-        for f in &folders {
-            match uid_sync_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
-                                  parse_nostr_email_from_imap_body) {
-                Ok(r) => {
-                    if r.max_uid > 0 || !r.had_existing_state {
-                        let bootstrap_min = if !r.had_existing_state && r.min_uid > 0 {
-                            Some(r.min_uid)
-                        } else {
-                            None
-                        };
-                        pending_state.push((f.clone(), r.uid_validity, r.max_uid, bootstrap_min));
-                    }
-                    raw_nostr_emails.extend(r.emails);
-                }
-                Err(e) => debug_log!("[RUST] sync_nostr_emails_to_db: folder '{}' failed: {}", f, e),
-            }
-            if include_gap_fill {
-                match gap_fill_in_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
-                                          parse_nostr_email_from_imap_body) {
-                    Ok(emails) => raw_nostr_emails.extend(emails),
-                    Err(e) => debug_log!("[RUST] sync_nostr_emails_to_db: gap_fill folder '{}' failed: {}", f, e),
-                }
+        if include_gap_fill {
+            match gap_fill_in_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
+                                      parse_nostr_email_from_imap_body) {
+                Ok(emails) => raw_nostr_emails.extend(emails),
+                Err(e) => debug_log!("[RUST] sync_nostr_emails_to_db: gap_fill folder '{}' failed: {}", f, e),
             }
         }
     }
+    imap_pool::checkin(&target, session);
 
     let new_count = persist_inbox_raw_emails(raw_nostr_emails, db, require_signature)?;
 
@@ -5624,56 +5434,27 @@ pub async fn fetch_older_inbox_emails_to_db(
     let mut any_folder_scanned = false;
     let mut all_folders_exhausted = true;
 
-    let host = &config.imap_host;
-    let port = config.imap_port;
-    let username = &config.email_address;
-    let password = &config.password;
-    let addr = format!("{}:{}", host, port);
-
-    if config.use_tls {
-        let client = create_imap_tls_client!(host, &addr)?;
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        for f in &folders {
-            match fetch_older_in_folder(&mut session, config, db, &account_key, f,
-                                         page_size, sync_cutoff_days,
-                                         parse_nostr_email_from_imap_body) {
-                Ok(r) => {
-                    any_folder_scanned = true;
-                    if !r.hit_bottom { all_folders_exhausted = false; }
-                    if let Some(new_floor) = r.new_floor_uid {
-                        pending_floors.push((f.clone(), new_floor));
-                    }
-                    raw_emails.extend(r.emails);
+    let target = ImapTarget::from_config(config);
+    let mut session = imap_pool::checkout(&target)?;
+    for f in &folders {
+        match fetch_older_in_folder(&mut session, config, db, &account_key, f,
+                                     page_size, sync_cutoff_days,
+                                     parse_nostr_email_from_imap_body) {
+            Ok(r) => {
+                any_folder_scanned = true;
+                if !r.hit_bottom { all_folders_exhausted = false; }
+                if let Some(new_floor) = r.new_floor_uid {
+                    pending_floors.push((f.clone(), new_floor));
                 }
-                Err(e) => {
-                    debug_log!("[RUST] fetch_older_inbox_emails_to_db: folder '{}' failed: {}", f, e);
-                    all_folders_exhausted = false;
-                }
+                raw_emails.extend(r.emails);
             }
-        }
-    } else {
-        let tcp_stream = TcpStream::connect(&addr)?;
-        let client = imap::Client::new(tcp_stream);
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        for f in &folders {
-            match fetch_older_in_folder(&mut session, config, db, &account_key, f,
-                                         page_size, sync_cutoff_days,
-                                         parse_nostr_email_from_imap_body) {
-                Ok(r) => {
-                    any_folder_scanned = true;
-                    if !r.hit_bottom { all_folders_exhausted = false; }
-                    if let Some(new_floor) = r.new_floor_uid {
-                        pending_floors.push((f.clone(), new_floor));
-                    }
-                    raw_emails.extend(r.emails);
-                }
-                Err(e) => {
-                    debug_log!("[RUST] fetch_older_inbox_emails_to_db: folder '{}' failed: {}", f, e);
-                    all_folders_exhausted = false;
-                }
+            Err(e) => {
+                debug_log!("[RUST] fetch_older_inbox_emails_to_db: folder '{}' failed: {}", f, e);
+                all_folders_exhausted = false;
             }
         }
     }
+    imap_pool::checkin(&target, session);
 
     let new_count = persist_inbox_raw_emails(raw_emails, db, require_signature)?;
 
@@ -5709,66 +5490,36 @@ pub async fn fetch_older_sent_emails_to_db(
     let account_key = config.email_address.trim().to_lowercase();
     let sync_cutoff_days = lookup_sync_cutoff_days(db, active_pubkey);
 
-    let host = &config.imap_host;
-    let port = config.imap_port;
-    let username = &config.email_address;
-    let password = &config.password;
-    let addr = format!("{}:{}", host, port);
-    let is_gmail = host.contains("gmail.com");
+    let is_gmail = config.imap_host.contains("gmail.com");
 
     let mut pending_floors: Vec<(String, u32)> = Vec::new();
     let mut raw_emails: Vec<RawNostrEmail> = Vec::new();
     let mut any_folder_scanned = false;
     let mut all_folders_exhausted = true;
 
-    if config.use_tls {
-        let client = create_imap_tls_client!(host, &addr)?;
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        let sent_folder = discover_sent_mailbox(&mut session)?
-            .unwrap_or_else(|| if is_gmail { "[Gmail]/Sent Mail".to_string() } else { "Sent".to_string() });
-        for f in [sent_folder.as_str(), "nostr-mail"] {
-            match fetch_older_in_folder(&mut session, config, db, &account_key, f,
-                                         page_size, sync_cutoff_days,
-                                         parse_nostr_sent_email_from_imap_body) {
-                Ok(r) => {
-                    any_folder_scanned = true;
-                    if !r.hit_bottom { all_folders_exhausted = false; }
-                    if let Some(new_floor) = r.new_floor_uid {
-                        pending_floors.push((f.to_string(), new_floor));
-                    }
-                    raw_emails.extend(r.emails);
+    let target = ImapTarget::from_config(config);
+    let mut session = imap_pool::checkout(&target)?;
+    let sent_folder = discover_sent_mailbox(&mut session)?
+        .unwrap_or_else(|| if is_gmail { "[Gmail]/Sent Mail".to_string() } else { "Sent".to_string() });
+    for f in [sent_folder.as_str(), "nostr-mail"] {
+        match fetch_older_in_folder(&mut session, config, db, &account_key, f,
+                                     page_size, sync_cutoff_days,
+                                     parse_nostr_sent_email_from_imap_body) {
+            Ok(r) => {
+                any_folder_scanned = true;
+                if !r.hit_bottom { all_folders_exhausted = false; }
+                if let Some(new_floor) = r.new_floor_uid {
+                    pending_floors.push((f.to_string(), new_floor));
                 }
-                Err(e) => {
-                    debug_log!("[RUST] fetch_older_sent_emails_to_db: folder '{}' failed: {}", f, e);
-                    all_folders_exhausted = false;
-                }
+                raw_emails.extend(r.emails);
             }
-        }
-    } else {
-        let tcp_stream = TcpStream::connect(&addr)?;
-        let client = imap::Client::new(tcp_stream);
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        let sent_folder = discover_sent_mailbox(&mut session)?
-            .unwrap_or_else(|| if is_gmail { "[Gmail]/Sent Mail".to_string() } else { "Sent".to_string() });
-        for f in [sent_folder.as_str(), "nostr-mail"] {
-            match fetch_older_in_folder(&mut session, config, db, &account_key, f,
-                                         page_size, sync_cutoff_days,
-                                         parse_nostr_sent_email_from_imap_body) {
-                Ok(r) => {
-                    any_folder_scanned = true;
-                    if !r.hit_bottom { all_folders_exhausted = false; }
-                    if let Some(new_floor) = r.new_floor_uid {
-                        pending_floors.push((f.to_string(), new_floor));
-                    }
-                    raw_emails.extend(r.emails);
-                }
-                Err(e) => {
-                    debug_log!("[RUST] fetch_older_sent_emails_to_db: folder '{}' failed: {}", f, e);
-                    all_folders_exhausted = false;
-                }
+            Err(e) => {
+                debug_log!("[RUST] fetch_older_sent_emails_to_db: folder '{}' failed: {}", f, e);
+                all_folders_exhausted = false;
             }
         }
     }
+    imap_pool::checkin(&target, session);
 
     // Sent emails skip the require_signature filter — see the forward sync
     // path for the same exception.
@@ -5815,73 +5566,37 @@ async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str,
     let mut pending_state: Vec<(String, u32, u32, Option<u32>)> = Vec::new();
     let mut raw_sent_emails: Vec<RawNostrEmail> = Vec::new();
 
-    let host = &config.imap_host;
-    let port = config.imap_port;
-    let username = &config.email_address;
-    let password = &config.password;
-    let addr = format!("{}:{}", host, port);
-    let is_gmail = host.contains("gmail.com");
+    let is_gmail = config.imap_host.contains("gmail.com");
 
-    if config.use_tls {
-        let client = create_imap_tls_client!(host, &addr)?;
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        let sent_folder = discover_sent_mailbox(&mut session)?
-            .unwrap_or_else(|| if is_gmail { "[Gmail]/Sent Mail".to_string() } else { "Sent".to_string() });
-        for f in [sent_folder.as_str(), "nostr-mail"] {
-            match uid_sync_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
-                                  parse_nostr_sent_email_from_imap_body) {
-                Ok(r) => {
-                    if r.max_uid > 0 || !r.had_existing_state {
-                        let bootstrap_min = if !r.had_existing_state && r.min_uid > 0 {
-                            Some(r.min_uid)
-                        } else {
-                            None
-                        };
-                        pending_state.push((f.to_string(), r.uid_validity, r.max_uid, bootstrap_min));
-                    }
-                    raw_sent_emails.extend(r.emails);
+    let target = ImapTarget::from_config(config);
+    let mut session = imap_pool::checkout(&target)?;
+    let sent_folder = discover_sent_mailbox(&mut session)?
+        .unwrap_or_else(|| if is_gmail { "[Gmail]/Sent Mail".to_string() } else { "Sent".to_string() });
+    for f in [sent_folder.as_str(), "nostr-mail"] {
+        match uid_sync_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
+                              parse_nostr_sent_email_from_imap_body) {
+            Ok(r) => {
+                if r.max_uid > 0 || !r.had_existing_state {
+                    let bootstrap_min = if !r.had_existing_state && r.min_uid > 0 {
+                        Some(r.min_uid)
+                    } else {
+                        None
+                    };
+                    pending_state.push((f.to_string(), r.uid_validity, r.max_uid, bootstrap_min));
                 }
-                Err(e) => debug_log!("[RUST] sync_sent_emails_to_db: folder '{}' failed: {}", f, e),
+                raw_sent_emails.extend(r.emails);
             }
-            if include_gap_fill {
-                match gap_fill_in_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
-                                          parse_nostr_sent_email_from_imap_body) {
-                    Ok(emails) => raw_sent_emails.extend(emails),
-                    Err(e) => debug_log!("[RUST] sync_sent_emails_to_db: gap_fill folder '{}' failed: {}", f, e),
-                }
-            }
+            Err(e) => debug_log!("[RUST] sync_sent_emails_to_db: folder '{}' failed: {}", f, e),
         }
-    } else {
-        let tcp_stream = TcpStream::connect(&addr)?;
-        let client = imap::Client::new(tcp_stream);
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        let sent_folder = discover_sent_mailbox(&mut session)?
-            .unwrap_or_else(|| if is_gmail { "[Gmail]/Sent Mail".to_string() } else { "Sent".to_string() });
-        for f in [sent_folder.as_str(), "nostr-mail"] {
-            match uid_sync_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
-                                  parse_nostr_sent_email_from_imap_body) {
-                Ok(r) => {
-                    if r.max_uid > 0 || !r.had_existing_state {
-                        let bootstrap_min = if !r.had_existing_state && r.min_uid > 0 {
-                            Some(r.min_uid)
-                        } else {
-                            None
-                        };
-                        pending_state.push((f.to_string(), r.uid_validity, r.max_uid, bootstrap_min));
-                    }
-                    raw_sent_emails.extend(r.emails);
-                }
-                Err(e) => debug_log!("[RUST] sync_sent_emails_to_db: folder '{}' failed: {}", f, e),
-            }
-            if include_gap_fill {
-                match gap_fill_in_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
-                                          parse_nostr_sent_email_from_imap_body) {
-                    Ok(emails) => raw_sent_emails.extend(emails),
-                    Err(e) => debug_log!("[RUST] sync_sent_emails_to_db: gap_fill folder '{}' failed: {}", f, e),
-                }
+        if include_gap_fill {
+            match gap_fill_in_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
+                                      parse_nostr_sent_email_from_imap_body) {
+                Ok(emails) => raw_sent_emails.extend(emails),
+                Err(e) => debug_log!("[RUST] sync_sent_emails_to_db: gap_fill folder '{}' failed: {}", f, e),
             }
         }
     }
+    imap_pool::checkin(&target, session);
 
     debug_log!("[RUST] sync_sent_emails_to_db: Fetched {} emails from IMAP", raw_sent_emails.len());
 
@@ -6857,26 +6572,10 @@ fn rescue_nostr_emails_from_spam(
 /// Returns the number of messages moved. The caller is expected to sync
 /// afterwards so the moved messages land in the local DB.
 pub async fn rescue_spam_now(config: &EmailConfig, target_folder: &str) -> anyhow::Result<usize> {
-    let host = config.imap_host.clone();
-    let port = config.imap_port;
-    let username = &config.email_address;
-    let password = &config.password;
-    let addr = format!("{}:{}", host, port);
-
-    let moved = if config.use_tls {
-        let client = create_imap_tls_client!(&host, &addr)?;
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        let m = rescue_nostr_emails_from_spam(&mut session, target_folder, /* unseen_only = */ false);
-        let _ = session.logout();
-        m
-    } else {
-        let tcp_stream = TcpStream::connect(&addr)?;
-        let client = imap::Client::new(tcp_stream);
-        let mut session = client.login(username, password).map_err(|e| anyhow::anyhow!(e.0))?;
-        let m = rescue_nostr_emails_from_spam(&mut session, target_folder, /* unseen_only = */ false);
-        let _ = session.logout();
-        m
-    };
+    let target = ImapTarget::from_config(config);
+    let moved = imap_pool::with_session(&target, |session| {
+        Ok(rescue_nostr_emails_from_spam(session, target_folder, /* unseen_only = */ false))
+    })?;
     Ok(moved)
 }
 

--- a/tauri-app/backend/src/imap_idle.rs
+++ b/tauri-app/backend/src/imap_idle.rs
@@ -1,0 +1,211 @@
+//! Background IMAP IDLE watcher.
+//!
+//! Why this exists: the inbox previously only refreshed on a manual action.
+//! This watcher holds a dedicated IMAP connection in IDLE on the active
+//! account's INBOX and, when the server reports a change, emits an
+//! `imap-new-mail` event. The frontend reacts by running its normal sync, so
+//! new mail shows up within seconds without polling.
+//!
+//! Scope: exactly one watcher runs at a time, for the active account only (see
+//! memory `feedback_imap_pool_active_account_only`). Switching accounts stops
+//! the old watcher and starts a new one.
+//!
+//! Connection ownership: IDLE monopolizes a connection for minutes at a time,
+//! so the watcher uses its **own** dedicated connection rather than borrowing
+//! from `imap_pool`. It also needs a `SetReadTimeout`-capable concrete session
+//! type (the pool's boxed `dyn ReadWrite` can't satisfy that bound), which is
+//! why the connection is built here with platform-specific code:
+//!   - desktop (`imap` 2.4.1): native-tls `TlsStream<TcpStream>`
+//!   - Android (`imap` 3.0-alpha): `ClientBuilder` → `Session<Connection>`
+//! IDLE requires TLS here; on a non-TLS server the watcher is a no-op and the
+//! app falls back to manual refresh.
+
+use anyhow::{anyhow, Result};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::Emitter;
+
+use crate::imap_pool::ImapTarget;
+use crate::types::EmailConfig;
+
+/// Connect timeout for the dedicated IDLE socket. Desktop only — the Android
+/// path builds its connection through `imap::ClientBuilder`.
+#[cfg(not(target_os = "android"))]
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+/// How long each IDLE cycle waits before re-issuing IDLE. Kept well under the
+/// RFC 2177 29-minute limit so the server doesn't drop us, and short enough
+/// that a stop request (logout / account switch) is observed promptly — the
+/// watcher only checks the stop flag at cycle boundaries.
+const IDLE_WAIT: Duration = Duration::from_secs(120);
+/// Backoff between reconnect attempts after a connection error.
+const RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
+/// Event emitted to the frontend when the watched mailbox changes.
+const NEW_MAIL_EVENT: &str = "imap-new-mail";
+
+#[cfg(not(target_os = "android"))]
+type IdleSession = imap::Session<native_tls::TlsStream<std::net::TcpStream>>;
+#[cfg(target_os = "android")]
+type IdleSession = imap::Session<imap::Connection>;
+
+/// Live handle to a running watcher. Dropping it does not stop the thread; call
+/// [`IdleHandle::stop`] (the lib.rs commands always do).
+#[derive(Debug)]
+pub struct IdleHandle {
+    pub account_email: String,
+    stop: Arc<AtomicBool>,
+}
+
+impl IdleHandle {
+    /// Signal the watcher thread to exit. It will observe this at the next IDLE
+    /// cycle boundary (within `IDLE_WAIT`) and log out cleanly.
+    pub fn stop(&self) {
+        self.stop.store(true, Ordering::SeqCst);
+    }
+}
+
+/// Start watching `config`'s INBOX. Returns a handle the caller stores so the
+/// watcher can later be stopped. Caller is responsible for stopping any prior
+/// watcher first (account switch).
+pub fn start(app: tauri::AppHandle, config: &EmailConfig) -> IdleHandle {
+    let target = ImapTarget::from_config(config);
+    let account_email = config.email_address.clone();
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let thread_stop = stop.clone();
+    let thread_account = account_email.clone();
+    std::thread::spawn(move || run(app, target, thread_account, thread_stop));
+
+    IdleHandle { account_email, stop }
+}
+
+/// Outer reconnect loop: keep a watch connection alive until asked to stop.
+fn run(app: tauri::AppHandle, target: ImapTarget, account_email: String, stop: Arc<AtomicBool>) {
+    if !target.use_tls {
+        crate::debug_log!(
+            "[RUST] imap_idle: non-TLS server, IDLE push disabled for {}",
+            account_email
+        );
+        return;
+    }
+
+    while !stop.load(Ordering::SeqCst) {
+        match watch_connection(&app, &target, &account_email, &stop) {
+            Ok(()) => break, // clean exit: stop was requested
+            Err(e) => {
+                crate::debug_log!(
+                    "[RUST] imap_idle: connection error for {}: {} (reconnecting)",
+                    account_email,
+                    e
+                );
+            }
+        }
+        // Backoff before reconnect, waking early if a stop is requested.
+        let mut waited = Duration::ZERO;
+        while waited < RECONNECT_BACKOFF {
+            if stop.load(Ordering::SeqCst) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(250));
+            waited += Duration::from_millis(250);
+        }
+    }
+    crate::debug_log!("[RUST] imap_idle: watcher stopped for {}", account_email);
+}
+
+/// Establish one connection, then IDLE in a loop emitting events on change.
+/// Returns Ok only when `stop` was observed; any I/O failure is an Err so the
+/// outer loop reconnects.
+fn watch_connection(
+    app: &tauri::AppHandle,
+    target: &ImapTarget,
+    account_email: &str,
+    stop: &Arc<AtomicBool>,
+) -> Result<()> {
+    let mut session = connect_idle_session(target)?;
+    session
+        .select("INBOX")
+        .map_err(|e| anyhow!("select INBOX failed: {}", e))?;
+    crate::debug_log!("[RUST] imap_idle: watching INBOX for {}", account_email);
+
+    while !stop.load(Ordering::SeqCst) {
+        let changed = idle_once(&mut session, IDLE_WAIT).map_err(|e| anyhow!("idle failed: {}", e))?;
+        if stop.load(Ordering::SeqCst) {
+            break;
+        }
+        if changed {
+            crate::debug_log!(
+                "[RUST] imap_idle: mailbox changed for {}, notifying frontend",
+                account_email
+            );
+            let _ = app.emit(NEW_MAIL_EVENT, account_email.to_string());
+        }
+    }
+
+    let _ = session.logout();
+    Ok(())
+}
+
+// --- Platform-specific connection + IDLE cycle ----------------------------
+
+#[cfg(not(target_os = "android"))]
+fn connect_idle_session(target: &ImapTarget) -> Result<IdleSession> {
+    use std::net::{TcpStream, ToSocketAddrs};
+
+    let addr = format!("{}:{}", target.host, target.port);
+    let sock = addr
+        .to_socket_addrs()
+        .map_err(|e| anyhow!("resolve {} failed: {}", addr, e))?
+        .next()
+        .ok_or_else(|| anyhow!("no address for {}", addr))?;
+    let tcp = TcpStream::connect_timeout(&sock, CONNECT_TIMEOUT)?;
+    // Read timeout is managed per-IDLE by the idle handle; keep a write timeout
+    // so a stalled send can't hang the watcher thread forever.
+    tcp.set_write_timeout(Some(Duration::from_secs(30)))?;
+
+    let tls = native_tls::TlsConnector::builder().build()?;
+    let tls_stream = tls.connect(&target.host, tcp)?;
+    let client = imap::Client::new(tls_stream);
+    client
+        .login(&target.username, &target.password)
+        .map_err(|e| anyhow!(e.0))
+}
+
+#[cfg(target_os = "android")]
+fn connect_idle_session(target: &ImapTarget) -> Result<IdleSession> {
+    // imap 3.0's ClientBuilder yields a boxed `Connection` that implements
+    // SetReadTimeout (required for timed IDLE waits). With the crate's
+    // `rustls-tls` feature this uses rustls under the hood.
+    let client = imap::ClientBuilder::new(target.host.clone(), target.port)
+        .connect()
+        .map_err(|e| anyhow!("connect failed: {}", e))?;
+    client
+        .login(&target.username, &target.password)
+        .map_err(|e| anyhow!(e.0))
+}
+
+/// Run a single IDLE cycle. Returns Ok(true) if the mailbox changed, Ok(false)
+/// if the wait timed out (re-IDLE keepalive). The IDLE handle API differs
+/// between the desktop (2.4.1) and Android (3.0-alpha) imap crates.
+#[cfg(not(target_os = "android"))]
+fn idle_once(session: &mut IdleSession, wait: Duration) -> imap::error::Result<bool> {
+    use imap::extensions::idle::WaitOutcome;
+    let handle = session.idle()?;
+    match handle.wait_with_timeout(wait)? {
+        WaitOutcome::MailboxChanged => Ok(true),
+        WaitOutcome::TimedOut => Ok(false),
+    }
+}
+
+#[cfg(target_os = "android")]
+fn idle_once(session: &mut IdleSession, wait: Duration) -> imap::error::Result<bool> {
+    use imap::extensions::idle::WaitOutcome;
+    let mut handle = session.idle();
+    handle.timeout(wait);
+    handle.keepalive(false);
+    // Stop on the first unsolicited response (a mailbox change).
+    match handle.wait_while(|_| false)? {
+        WaitOutcome::MailboxChanged => Ok(true),
+        WaitOutcome::TimedOut => Ok(false),
+    }
+}

--- a/tauri-app/backend/src/imap_pool.rs
+++ b/tauri-app/backend/src/imap_pool.rs
@@ -1,0 +1,280 @@
+//! IMAP connection pool with bounded timeouts and stale-connection recovery.
+//!
+//! Why this exists: every IMAP-backed action used to open a fresh TCP socket,
+//! perform a full TLS handshake, and run `LOGIN` before doing any real work.
+//! Against Gmail that round-trip dominates the latency of every interactive
+//! action. This module keeps authenticated sessions warm and hands them back
+//! out, so the handshake+login cost is paid once instead of per action. It also
+//! adds the connect/read/write timeouts that the old path lacked, so a hung
+//! server can no longer block a worker thread forever.
+//!
+//! Scope rule (see memory `feedback_imap_pool_active_account_only`): the pool
+//! only ever holds connections for the **currently active account**. When the
+//! account identity changes, the previous account's sessions are logged out and
+//! dropped — a credential-bound session is never reused for a different user.
+//!
+//! Platform note: the pooled session is boxed as `Session<Box<dyn ReadWrite>>`,
+//! which both the desktop `imap` 2.4.1 and the Android `imap` 3.0-alpha only
+//! require to be `Read + Write`. The IDLE watcher (see `imap_idle`) needs a
+//! `SetReadTimeout`-capable concrete type instead, so it builds its own
+//! connection rather than borrowing from this pool.
+
+use anyhow::{anyhow, Result};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use crate::types::EmailConfig;
+
+#[cfg(not(target_os = "android"))]
+use native_tls::TlsConnector;
+#[cfg(target_os = "android")]
+use rustls::{pki_types::ServerName, ClientConfig, ClientConnection, RootCertStore};
+#[cfg(target_os = "android")]
+use std::sync::Arc;
+
+/// How long to wait for the initial TCP connect before giving up.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+/// Read/write timeout applied to every pooled socket. Bounds any single
+/// blocking IMAP operation so a stalled server can't hang a worker thread.
+const IO_TIMEOUT: Duration = Duration::from_secs(30);
+/// A reused connection younger than this is handed out without a NOOP probe —
+/// it was almost certainly alive moments ago, so skip the extra round-trip.
+const VALIDATE_AFTER: Duration = Duration::from_secs(30);
+/// A reused connection older than this is dropped outright (servers commonly
+/// close idle IMAP connections after a few minutes; don't even probe).
+const MAX_IDLE: Duration = Duration::from_secs(300);
+/// Cap on warm connections kept per active account.
+const MAX_IDLE_CONNS: usize = 3;
+
+/// Any stream that can back a pooled IMAP session. The blanket impl means
+/// `TcpStream`, `native_tls::TlsStream<_>`, and `rustls::StreamOwned<_>` all
+/// qualify, so a single boxed type covers every transport on every platform.
+pub trait ReadWrite: std::io::Read + std::io::Write + Send {}
+impl<T: std::io::Read + std::io::Write + Send> ReadWrite for T {}
+
+/// The single concrete session type stored in the pool.
+pub type ImapSession = imap::Session<Box<dyn ReadWrite>>;
+
+/// Identity of an IMAP account: anything that differs here is a different
+/// connection. `email` is lowercased so case variations don't fragment the key.
+type AccountKey = (String, String, u16, bool);
+
+/// Connection parameters for a single IMAP account. Construct from an
+/// `EmailConfig`, or inline at call sites that only have the cloned parts.
+#[derive(Clone)]
+pub struct ImapTarget {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+    pub use_tls: bool,
+}
+
+impl ImapTarget {
+    pub fn from_config(c: &EmailConfig) -> Self {
+        ImapTarget {
+            host: c.imap_host.clone(),
+            port: c.imap_port,
+            username: c.email_address.clone(),
+            password: c.password.clone(),
+            use_tls: c.use_tls,
+        }
+    }
+
+    fn key(&self) -> AccountKey {
+        (
+            self.username.trim().to_lowercase(),
+            self.host.clone(),
+            self.port,
+            self.use_tls,
+        )
+    }
+
+    fn addr(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+struct PooledConn {
+    session: ImapSession,
+    last_used: Instant,
+}
+
+#[derive(Default)]
+struct PoolState {
+    /// The account the pooled connections belong to. `None` until first use.
+    owner: Option<AccountKey>,
+    idle: Vec<PooledConn>,
+}
+
+fn pool() -> &'static Mutex<PoolState> {
+    static POOL: OnceLock<Mutex<PoolState>> = OnceLock::new();
+    POOL.get_or_init(|| Mutex::new(PoolState::default()))
+}
+
+/// Open a TCP stream with a bounded connect timeout, then apply read/write
+/// timeouts. Tries every resolved address so dual-stack hosts still work.
+fn connect_tcp(addr: &str) -> Result<TcpStream> {
+    let socket_addrs: Vec<_> = addr
+        .to_socket_addrs()
+        .map_err(|e| anyhow!("failed to resolve {}: {}", addr, e))?
+        .collect();
+    if socket_addrs.is_empty() {
+        return Err(anyhow!("no addresses resolved for {}", addr));
+    }
+    let mut last_err = None;
+    for sa in socket_addrs {
+        match TcpStream::connect_timeout(&sa, CONNECT_TIMEOUT) {
+            Ok(tcp) => {
+                tcp.set_read_timeout(Some(IO_TIMEOUT))?;
+                tcp.set_write_timeout(Some(IO_TIMEOUT))?;
+                return Ok(tcp);
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(anyhow!(
+        "could not connect to {}: {}",
+        addr,
+        last_err.map(|e| e.to_string()).unwrap_or_default()
+    ))
+}
+
+/// Establish a fresh, authenticated session for `target`. Replaces the old
+/// `create_imap_tls_client!` macro + duplicated plain-TCP branches, adding
+/// timeouts and boxing the stream into the single pooled session type.
+pub fn connect_imap(target: &ImapTarget) -> Result<ImapSession> {
+    let addr = target.addr();
+    let stream: Box<dyn ReadWrite> = if target.use_tls {
+        build_tls_stream(&target.host, &addr)?
+    } else {
+        Box::new(connect_tcp(&addr)?)
+    };
+    let client = imap::Client::new(stream);
+    client
+        .login(&target.username, &target.password)
+        .map_err(|e| anyhow!(e.0))
+}
+
+#[cfg(not(target_os = "android"))]
+fn build_tls_stream(host: &str, addr: &str) -> Result<Box<dyn ReadWrite>> {
+    let tls = TlsConnector::builder().build()?;
+    let tcp = connect_tcp(addr)?;
+    let tls_stream = tls.connect(host, tcp)?;
+    Ok(Box::new(tls_stream))
+}
+
+#[cfg(target_os = "android")]
+fn build_tls_stream(host: &str, addr: &str) -> Result<Box<dyn ReadWrite>> {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+
+    let mut root_store = RootCertStore::empty();
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let config = ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    let server_name =
+        ServerName::try_from(host.to_string()).map_err(|_| anyhow!("invalid server name"))?;
+    let tcp = connect_tcp(addr)?;
+    let conn = ClientConnection::new(Arc::new(config), server_name)?;
+    let tls_stream = rustls::StreamOwned::new(conn, tcp);
+    Ok(Box::new(tls_stream))
+}
+
+/// Take a ready-to-use session for `target`: reuse a warm one when possible,
+/// otherwise connect fresh. Switching accounts (owner mismatch) discards the
+/// previous account's pooled sessions first. Stale reused connections are
+/// validated with NOOP (or dropped when too old) so callers always get a live
+/// session or an error from the fresh-connect attempt.
+pub fn checkout(target: &ImapTarget) -> Result<ImapSession> {
+    let key = target.key();
+
+    let reused = {
+        let mut guard = pool().lock().unwrap();
+        if guard.owner.as_ref() != Some(&key) {
+            // Account changed (or first use): tear down the old account's
+            // connections and take ownership for this one.
+            take_idle(&mut guard)
+                .into_iter()
+                .for_each(|mut c| drop(c.session.logout()));
+            guard.owner = Some(key);
+        }
+        guard.idle.pop()
+    };
+
+    if let Some(mut conn) = reused {
+        let age = conn.last_used.elapsed();
+        if age <= MAX_IDLE {
+            if age <= VALIDATE_AFTER || conn.session.noop().is_ok() {
+                return Ok(conn.session);
+            }
+        }
+        // Too old or failed validation: discard and fall through to reconnect.
+        let _ = conn.session.logout();
+    }
+
+    connect_imap(target)
+}
+
+/// Return a session to the pool for reuse. Sessions whose account no longer
+/// owns the pool, or that overflow the per-account cap, are logged out instead.
+pub fn checkin(target: &ImapTarget, mut session: ImapSession) {
+    let key = target.key();
+    let mut guard = pool().lock().unwrap();
+    if guard.owner.as_ref() != Some(&key) || guard.idle.len() >= MAX_IDLE_CONNS {
+        drop(guard);
+        let _ = session.logout();
+        return;
+    }
+    guard.idle.push(PooledConn {
+        session,
+        last_used: Instant::now(),
+    });
+}
+
+/// Run `f` against a pooled session for the duration of one operation.
+///
+/// On success the session is returned to the pool; on error it is dropped
+/// (logged out) rather than re-pooled. Staleness is handled at checkout via the
+/// NOOP probe, so a reused connection is already validated before `f` runs; a
+/// failure inside `f` is therefore treated as a real error and not retried,
+/// which avoids re-running side-effecting operations (move/delete) twice.
+pub fn with_session<T>(
+    target: &ImapTarget,
+    f: impl FnOnce(&mut ImapSession) -> Result<T>,
+) -> Result<T> {
+    let mut session = checkout(target)?;
+    match f(&mut session) {
+        Ok(v) => {
+            checkin(target, session);
+            Ok(v)
+        }
+        Err(e) => {
+            let _ = session.logout();
+            Err(e)
+        }
+    }
+}
+
+/// Drop and log out every pooled connection and forget the owner. Called on
+/// logout and account switch so no stale or foreign connection lingers.
+pub fn clear_all() {
+    let drained = {
+        let mut guard = pool().lock().unwrap();
+        guard.owner = None;
+        take_idle(&mut guard)
+    };
+    // Log out outside the lock — these may block on dead sockets.
+    for mut conn in drained {
+        let _ = conn.session.logout();
+    }
+}
+
+fn take_idle(state: &mut PoolState) -> Vec<PooledConn> {
+    std::mem::take(&mut state.idle)
+}

--- a/tauri-app/backend/src/lib.rs
+++ b/tauri-app/backend/src/lib.rs
@@ -6,6 +6,8 @@
 
 pub mod crypto;
 pub mod email;
+pub mod imap_pool;
+pub mod imap_idle;
 mod nostr;
 pub mod types;
 pub mod state;
@@ -1211,6 +1213,10 @@ fn keychain_list_accounts(state: tauri::State<AppState>) -> Result<Vec<AccountIn
 #[tauri::command]
 fn keychain_set_active_account(public_key: String, state: tauri::State<AppState>) -> Result<(), String> {
     println!("[RUST] keychain_set_active_account called for: {}...", &public_key[..20.min(public_key.len())]);
+    // Switching the active account: tear down the previous account's IMAP IDLE
+    // watcher and pooled connections so nothing credential-bound to the old
+    // user is reused. The frontend restarts IDLE for the new account.
+    state.stop_idle_watcher();
     let private_key = state.keychain.get_key(&public_key)?
         .ok_or_else(|| format!("No key found in keychain for {}", &public_key[..20.min(public_key.len())]))?;
     let secret_key = nostr_sdk::prelude::SecretKey::from_bech32(&private_key).map_err(|e| e.to_string())?;
@@ -1237,6 +1243,8 @@ fn keychain_get_private_key(public_key: String, state: tauri::State<AppState>) -
 #[tauri::command]
 fn keychain_clear_all(state: tauri::State<AppState>) -> Result<(), String> {
     println!("[RUST] keychain_clear_all called");
+    // Logout: stop the IDLE watcher and drop all pooled IMAP connections.
+    state.stop_idle_watcher();
     state.keychain.clear_all()?;
     *state.current_private_key.lock().unwrap() = None;
     *state.current_keys.lock().unwrap() = None;
@@ -2630,6 +2638,28 @@ fn update_contact_picture_data_url(pubkey: String, picture_data_url: String) -> 
     storage.update_contact_picture_data_url(&pubkey, picture_data_url).map_err(|e| e.to_string())
 }
 
+
+/// Start the background IMAP IDLE watcher for the active account. Replaces any
+/// previously running watcher (and clears the pool) so only the active account
+/// is ever watched. Emits `imap-new-mail` events when the INBOX changes.
+#[tauri::command]
+fn start_imap_idle(email_config: EmailConfig, app: tauri::AppHandle, state: tauri::State<AppState>) -> Result<(), String> {
+    println!("[RUST] start_imap_idle called for: {}@{}:{}",
+        email_config.email_address, email_config.imap_host, email_config.imap_port);
+    // Stop any prior watcher + clear pooled connections before starting fresh.
+    state.stop_idle_watcher();
+    let handle = imap_idle::start(app, &email_config);
+    state.set_idle_watcher(handle);
+    Ok(())
+}
+
+/// Stop the background IMAP IDLE watcher and drop pooled connections.
+#[tauri::command]
+fn stop_imap_idle(state: tauri::State<AppState>) -> Result<(), String> {
+    println!("[RUST] stop_imap_idle called");
+    state.stop_idle_watcher();
+    Ok(())
+}
 
 #[tauri::command]
 async fn test_imap_connection(email_config: EmailConfig) -> Result<(), String> {
@@ -7117,6 +7147,8 @@ pub fn run() {
         update_contact_picture_data_url,
         test_imap_connection,
         test_smtp_connection,
+        start_imap_idle,
+        stop_imap_idle,
         list_imap_folders,
         find_message_folder,
         check_message_confirmation,

--- a/tauri-app/backend/src/state.rs
+++ b/tauri-app/backend/src/state.rs
@@ -60,6 +60,10 @@ pub struct AppState {
     /// session. Prevents republishing on reconnect storms; flipped back to
     /// false by `republish_relay_lists` when settings change.
     pub relay_lists_published_session: Arc<Mutex<bool>>,
+    /// Background IMAP IDLE watcher for the active account, if running. Holds
+    /// at most one watcher at a time — switching accounts stops the old one and
+    /// starts a new one (see `crate::imap_idle`).
+    pub idle_watcher: Arc<Mutex<Option<crate::imap_idle::IdleHandle>>>,
 }
 
 impl AppState {
@@ -81,7 +85,27 @@ impl AppState {
             inbox_fetched: Arc::new(RwLock::new(HashMap::new())),
             nip17_capable: Arc::new(RwLock::new(HashMap::new())),
             relay_lists_published_session: Arc::new(Mutex::new(false)),
+            idle_watcher: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Stop and clear the active IMAP IDLE watcher, if any. Also clears the
+    /// IMAP connection pool so no stale or foreign connection lingers. Safe to
+    /// call when no watcher is running.
+    pub fn stop_idle_watcher(&self) {
+        if let Some(handle) = self.idle_watcher.lock().unwrap().take() {
+            handle.stop();
+        }
+        crate::imap_pool::clear_all();
+    }
+
+    /// Replace the active IMAP IDLE watcher, stopping any previous one first.
+    pub fn set_idle_watcher(&self, handle: crate::imap_idle::IdleHandle) {
+        let mut guard = self.idle_watcher.lock().unwrap();
+        if let Some(prev) = guard.take() {
+            prev.stop();
+        }
+        *guard = Some(handle);
     }
 
     pub fn init_database(&self, db_path: &std::path::Path) -> Result<(), String> {

--- a/tauri-app/frontend/js/app.js
+++ b/tauri-app/frontend/js/app.js
@@ -470,7 +470,13 @@ NostrMailApp.prototype.loadSettingsForPubkey = async function(pubkey) {
             
             // Update last loaded pubkey tracker
             appState.setLastLoadedPubkey(pubkey);
-            
+
+            // (Re)start the IMAP IDLE watcher for this account so the inbox
+            // updates via push. The backend stops any prior account's watcher
+            // and clears its pooled connections first.
+            TauriService.startImapIdle().catch(err =>
+                console.warn('[APP] Failed to start IMAP IDLE watcher:', err));
+
             // Show toast notification that settings were loaded
             notificationService.showSuccess('Settings loaded');
         } else {
@@ -1901,6 +1907,28 @@ NostrMailApp.prototype.setupLiveEventListeners = async function() {
             this.handleLiveProfileUpdate(event.payload);
         });
         
+        // Listen for IMAP IDLE push: backend detected the active account's INBOX
+        // changed. Sync + reload, guarded so overlapping pushes don't pile up.
+        this.newMailUnlisten = await window.__TAURI__.event.listen('imap-new-mail', async (event) => {
+            const account = event.payload;
+            const active = window.appState?.getSettings()?.email_address;
+            if (account && active && account !== active) {
+                return; // stale event from a previous account; ignore
+            }
+            if (this._idleSyncInFlight) return;
+            this._idleSyncInFlight = true;
+            try {
+                console.log('[APP] imap-new-mail: syncing inbox for', account);
+                if (window.emailService) {
+                    await window.emailService.syncAndReloadEmails();
+                }
+            } catch (err) {
+                console.error('[APP] imap-new-mail sync failed:', err);
+            } finally {
+                this._idleSyncInFlight = false;
+            }
+        });
+
         // Listen for relay status changes (when relays fail/disconnect)
         this.relayStatusUnlisten = await window.__TAURI__.event.listen('relay-status-changed', async (event) => {
             console.log('[APP] Relay status changed event received:', event.payload);
@@ -2076,7 +2104,12 @@ NostrMailApp.prototype.cleanupLiveEvents = async function() {
                 this.profileUnlisten();
                 this.profileUnlisten = null;
             }
-            
+
+            if (this.newMailUnlisten) {
+                this.newMailUnlisten();
+                this.newMailUnlisten = null;
+            }
+
             this.liveEventsActive = false;
             this.updateLiveEventsStatus('inactive', 'Disconnected');
             
@@ -3186,7 +3219,12 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
             
             // Update last loaded pubkey tracker after successful save
             appState.setLastLoadedPubkey(publicKey);
-            
+
+            // IMAP credentials/host may have changed — rebind the IDLE watcher
+            // (and drop stale pooled connections) to the new settings.
+            TauriService.startImapIdle().catch(err =>
+                console.warn('[APP] Failed to restart IMAP IDLE watcher after save:', err));
+
             // Update compose page warning if on compose tab
             if (document.querySelector('.tab-content#compose.active')) {
                 this.checkEmailSettingsForCompose();

--- a/tauri-app/frontend/js/tauri-service.js
+++ b/tauri-app/frontend/js/tauri-service.js
@@ -427,6 +427,39 @@ const TauriService = {
         return await this.invoke('sync_nostr_emails', { config: emailConfig, folders: foldersArg });
     },
 
+    /* Start the backend IMAP IDLE watcher for the active account. The backend
+       emits `imap-new-mail` when the INBOX changes; app.js listens and runs a
+       normal sync. No-op (resolves) when settings/keypair aren't ready yet. */
+    startImapIdle: async function() {
+        const settings = window.appState?.getSettings();
+        const keypair = window.appState?.getKeypair();
+        if (!settings || !keypair || !settings.email_address || !settings.imap_host) {
+            return; // not configured; nothing to watch
+        }
+
+        const useTls = settings.use_tls !== undefined && settings.use_tls !== null
+            ? settings.use_tls
+            : true;
+
+        const emailConfig = {
+            email_address: settings.email_address,
+            password: settings.password,
+            smtp_host: settings.smtp_host,
+            smtp_port: settings.smtp_port,
+            imap_host: settings.imap_host,
+            imap_port: settings.imap_port,
+            use_tls: useTls,
+            private_key: null
+        };
+
+        return await this.invoke('start_imap_idle', { emailConfig });
+    },
+
+    /* Stop the backend IMAP IDLE watcher and drop pooled connections. */
+    stopImapIdle: async function() {
+        return await this.invoke('stop_imap_idle');
+    },
+
     /* Provider-aware default folder list for the inbox-folder placeholder.
        Mirrors the backend's `default_inbox_folders` — the source of truth for
        what gets scanned when the user has nothing selected. The backend also


### PR DESCRIPTION
## Why

Every IMAP-backed action (folder list, move, delete, find, each sync) used to open a fresh TCP socket, run a full TLS handshake, and `LOGIN` before doing any real work — then tear it all down. Against Gmail that round-trip dominated the latency of every interactive action. There were also **no socket timeouts** anywhere on the IMAP path (a hung server blocked a worker thread forever) and no reconnect. The inbox only refreshed on a manual action.

## What

**`imap_pool.rs` (new)** — single-active-account warm connection pool.
- `connect_imap` replaces the `create_imap_tls_client!` macro and the duplicated plain-TCP branches, adding connect/read/write timeouts (15s connect, 30s I/O).
- `checkout`/`checkin`/`with_session` reuse authenticated sessions so the TLS handshake + LOGIN is paid once, not per action. Stale connections are validated with `NOOP` (skipped when <30s old) and dropped/reconnected when too old or dead.
- Scoped to the **active account only** — switching accounts logs out and discards the prior user's sessions.

**`email.rs`** — all ~12 connection sites routed through the pool (`with_session` for short ops, `checkout`/`checkin` for the long multi-folder syncs), collapsing the duplicated TLS/non-TLS bodies.

**`imap_idle.rs` (new)** — per-account background IDLE watcher on a dedicated connection; emits an `imap-new-mail` event so the inbox updates within seconds without polling. Reconnects with backoff; re-IDLEs every 120s.

**`state.rs` / `lib.rs`** — `idle_watcher` in `AppState`; `start_imap_idle`/`stop_imap_idle` commands; teardown on account switch (`keychain_set_active_account`) and logout (`keychain_clear_all`).

**Frontend** — `startImapIdle`/`stopImapIdle` wrappers; watcher (re)starts after settings load/save; `imap-new-mail` listener that syncs and reloads (overlap- and stale-account-guarded).

## Platform note

The pooled boxed `Session<Box<dyn ReadWrite>>` works on both the desktop (imap 2.4.1) and Android (imap 3.0-alpha) crates since `Session` only needs `Read+Write`. IDLE's timed wait needs `SetReadTimeout`, which the boxed type lacks, so the watcher uses a concrete cfg-gated session: native-tls `TlsStream` on desktop, `ClientBuilder`→`Session<Connection>` on Android. IDLE requires TLS; non-TLS servers fall back to manual refresh.

## Verification

- `cargo check --lib` (desktop) ✅
- `cargo check --target aarch64-linux-android --lib` ✅

Runtime behavior (faster interactive ops, stale-reconnect, IDLE push on a live inbox) not yet exercised — see the manual test steps in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)