### PR TITLE
Gap-fill: examine each UID once instead of rescanning every refresh

### DIFF
--- a/tauri-app/backend/src/database.rs
+++ b/tauri-app/backend/src/database.rs
@@ -168,6 +168,13 @@ pub struct FolderSyncState {
     // forward sync (bootstrap fills it from the SINCE-cutoff range) or by
     // the first fetch_older call.
     pub min_seen_uid: Option<u32>,
+    // Contiguous UID range gap-fill has already examined (under the current
+    // uid_validity). gap_fill_in_folder skips UIDs inside [min, max] so the
+    // expensive ENVELOPE + body re-fetch of already-seen (non-nostr) mail only
+    // happens once. None = nothing examined yet (full scan). Reset to None when
+    // uid_validity changes. Always written together.
+    pub gap_examined_min_uid: Option<u32>,
+    pub gap_examined_max_uid: Option<u32>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -516,6 +523,9 @@ impl Database {
         // Migrate: Add min_seen_uid column to folder_sync_state for backward
         // pagination ("fetch older from server").
         Self::migrate_add_min_seen_uid_column(&conn)?;
+        // Migrate: Add gap_examined_{min,max}_uid columns so gap-fill examines
+        // each UID at most once instead of rescanning the whole window.
+        Self::migrate_add_gap_examined_columns(&conn)?;
 
         // Migrate: One-shot cleanup of duplicate DM rows that slipped past the
         // old outer-wrap-id dedup. Safe to run on every startup (idempotent).
@@ -1051,6 +1061,27 @@ impl Database {
                 "ALTER TABLE folder_sync_state ADD COLUMN min_seen_uid INTEGER",
                 [],
             )?;
+        }
+        Ok(())
+    }
+
+    /// Migration: Add gap_examined_{min,max}_uid columns to folder_sync_state.
+    /// These track the contiguous UID range gap-fill has already examined so it
+    /// doesn't re-fetch already-seen (non-nostr) messages on every refresh.
+    fn migrate_add_gap_examined_columns(conn: &Connection) -> Result<()> {
+        let existing: std::collections::HashSet<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(folder_sync_state)")?;
+            let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+            rows.collect::<std::result::Result<_, _>>()?
+        };
+        for col in ["gap_examined_min_uid", "gap_examined_max_uid"] {
+            if !existing.contains(col) {
+                println!("[DB] Adding {} column to folder_sync_state", col);
+                conn.execute(
+                    &format!("ALTER TABLE folder_sync_state ADD COLUMN {} INTEGER", col),
+                    [],
+                )?;
+            }
         }
         Ok(())
     }
@@ -2344,7 +2375,7 @@ impl Database {
     pub fn get_folder_sync_state(&self, pubkey: &str, folder: &str) -> Result<Option<FolderSyncState>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT uid_validity, last_seen_uid, min_seen_uid, updated_at
+            "SELECT uid_validity, last_seen_uid, min_seen_uid, gap_examined_min_uid, gap_examined_max_uid, updated_at
              FROM folder_sync_state
              WHERE pubkey = ? AND folder_name = ?",
         )?;
@@ -2353,11 +2384,15 @@ impl Database {
             let uid_validity: i64 = row.get(0)?;
             let last_seen_uid: i64 = row.get(1)?;
             let min_seen_uid: Option<i64> = row.get(2)?;
+            let gap_examined_min_uid: Option<i64> = row.get(3)?;
+            let gap_examined_max_uid: Option<i64> = row.get(4)?;
             Ok(Some(FolderSyncState {
                 uid_validity: uid_validity as u32,
                 last_seen_uid: last_seen_uid as u32,
                 min_seen_uid: min_seen_uid.map(|v| v as u32),
-                updated_at: row.get(3)?,
+                gap_examined_min_uid: gap_examined_min_uid.map(|v| v as u32),
+                gap_examined_max_uid: gap_examined_max_uid.map(|v| v as u32),
+                updated_at: row.get(5)?,
             }))
         } else {
             Ok(None)
@@ -2383,13 +2418,56 @@ impl Database {
              ON CONFLICT(pubkey, folder_name) DO UPDATE SET
                  uid_validity = excluded.uid_validity,
                  last_seen_uid = excluded.last_seen_uid,
-                 updated_at = excluded.updated_at",
+                 updated_at = excluded.updated_at,
+                 -- A UIDVALIDITY change renumbers messages, so previously
+                 -- examined UIDs are meaningless: clear the gap-fill range.
+                 -- Same uid_validity preserves it.
+                 gap_examined_min_uid = CASE WHEN folder_sync_state.uid_validity <> excluded.uid_validity
+                     THEN NULL ELSE folder_sync_state.gap_examined_min_uid END,
+                 gap_examined_max_uid = CASE WHEN folder_sync_state.uid_validity <> excluded.uid_validity
+                     THEN NULL ELSE folder_sync_state.gap_examined_max_uid END",
             params![
                 pubkey.trim().to_lowercase(),
                 folder,
                 uid_validity as i64,
                 last_seen_uid as i64,
                 now,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Record the contiguous UID range gap-fill has examined for one (account,
+    /// folder), under `uid_validity`. Stored as [min(existing, lo), max(existing,
+    /// hi)] so the range only grows (matching the always-growing [floor,
+    /// last_seen] scan window). No-op unless the row exists and its stored
+    /// uid_validity still matches — guards against a UIDVALIDITY change between
+    /// the gap-fill scan and this post-persist commit.
+    pub fn set_folder_gap_examined(
+        &self,
+        pubkey: &str,
+        folder: &str,
+        uid_validity: u32,
+        lo: u32,
+        hi: u32,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        let now = Utc::now();
+        conn.execute(
+            "UPDATE folder_sync_state
+             SET gap_examined_min_uid = MIN(COALESCE(gap_examined_min_uid, ?), ?),
+                 gap_examined_max_uid = MAX(COALESCE(gap_examined_max_uid, ?), ?),
+                 updated_at = ?
+             WHERE pubkey = ? AND folder_name = ? AND uid_validity = ?",
+            params![
+                lo as i64,
+                lo as i64,
+                hi as i64,
+                hi as i64,
+                now,
+                pubkey.trim().to_lowercase(),
+                folder,
+                uid_validity as i64,
             ],
         )?;
         Ok(())
@@ -5910,6 +5988,61 @@ mod tests {
         let got = db.get_folder_sync_state("alice@example.com", "INBOX").unwrap().unwrap();
         assert_eq!(got.last_seen_uid, 200);
         assert_eq!(got.min_seen_uid, Some(25));
+    }
+
+    #[test]
+    fn test_folder_gap_examined_records_and_only_grows() {
+        let (db, _dir) = create_test_db();
+        db.set_folder_sync_state("alice@example.com", "INBOX", 1, 100).unwrap();
+
+        // Unset on a fresh row.
+        let got = db.get_folder_sync_state("alice@example.com", "INBOX").unwrap().unwrap();
+        assert_eq!(got.gap_examined_min_uid, None);
+        assert_eq!(got.gap_examined_max_uid, None);
+
+        // First recorded window.
+        db.set_folder_gap_examined("alice@example.com", "INBOX", 1, 30, 80).unwrap();
+        let got = db.get_folder_sync_state("alice@example.com", "INBOX").unwrap().unwrap();
+        assert_eq!(got.gap_examined_min_uid, Some(30));
+        assert_eq!(got.gap_examined_max_uid, Some(80));
+
+        // A wider window grows the range in both directions.
+        db.set_folder_gap_examined("alice@example.com", "INBOX", 1, 20, 100).unwrap();
+        let got = db.get_folder_sync_state("alice@example.com", "INBOX").unwrap().unwrap();
+        assert_eq!(got.gap_examined_min_uid, Some(20));
+        assert_eq!(got.gap_examined_max_uid, Some(100));
+
+        // A narrower window never shrinks it.
+        db.set_folder_gap_examined("alice@example.com", "INBOX", 1, 50, 60).unwrap();
+        let got = db.get_folder_sync_state("alice@example.com", "INBOX").unwrap().unwrap();
+        assert_eq!(got.gap_examined_min_uid, Some(20));
+        assert_eq!(got.gap_examined_max_uid, Some(100));
+    }
+
+    #[test]
+    fn test_folder_gap_examined_reset_on_uidvalidity_change() {
+        let (db, _dir) = create_test_db();
+        db.set_folder_sync_state("alice@example.com", "INBOX", 1, 100).unwrap();
+        db.set_folder_gap_examined("alice@example.com", "INBOX", 1, 20, 100).unwrap();
+
+        // Forward sync with the SAME uid_validity preserves the examined range.
+        db.set_folder_sync_state("alice@example.com", "INBOX", 1, 150).unwrap();
+        let got = db.get_folder_sync_state("alice@example.com", "INBOX").unwrap().unwrap();
+        assert_eq!(got.gap_examined_min_uid, Some(20));
+        assert_eq!(got.gap_examined_max_uid, Some(100));
+
+        // A UIDVALIDITY change clears it — the old UIDs are meaningless now.
+        db.set_folder_sync_state("alice@example.com", "INBOX", 2, 10).unwrap();
+        let got = db.get_folder_sync_state("alice@example.com", "INBOX").unwrap().unwrap();
+        assert_eq!(got.gap_examined_min_uid, None);
+        assert_eq!(got.gap_examined_max_uid, None);
+
+        // set_folder_gap_examined is a no-op when the passed uid_validity does
+        // not match the stored row (guards against a mid-flight change).
+        db.set_folder_gap_examined("alice@example.com", "INBOX", 99, 5, 9).unwrap();
+        let got = db.get_folder_sync_state("alice@example.com", "INBOX").unwrap().unwrap();
+        assert_eq!(got.gap_examined_min_uid, None);
+        assert_eq!(got.gap_examined_max_uid, None);
     }
 
     // =====================

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -5314,6 +5314,9 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
     // row — it seeds folder_sync_state.min_seen_uid so backward pagination has
     // a defined floor. Incremental runs leave min_seen_uid alone.
     let mut pending_state: Vec<(String, u32, u32, Option<u32>)> = Vec::new();
+    // Per-folder gap-fill examined windows (folder, uid_validity, floor,
+    // last_seen), committed after persist so a future pass skips them.
+    let mut pending_gap_examined: Vec<(String, u32, u32, u32)> = Vec::new();
     let mut raw_nostr_emails: Vec<RawNostrEmail> = Vec::new();
 
     let target = ImapTarget::from_config(config);
@@ -5346,7 +5349,12 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
         if include_gap_fill {
             match gap_fill_in_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
                                       parse_nostr_email_from_imap_body) {
-                Ok(emails) => raw_nostr_emails.extend(emails),
+                Ok(r) => {
+                    raw_nostr_emails.extend(r.emails);
+                    if let Some((uidv, lo, hi)) = r.examined {
+                        pending_gap_examined.push((f.clone(), uidv, lo, hi));
+                    }
+                }
                 Err(e) => debug_log!("[RUST] sync_nostr_emails_to_db: gap_fill folder '{}' failed: {}", f, e),
             }
         }
@@ -5382,6 +5390,16 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
                     min, folder_name
                 );
             }
+        }
+    }
+
+    // Commit gap-fill examined windows after the persist succeeded, so the next
+    // refresh skips this range instead of re-fetching all the (non-nostr) mail
+    // in it. Done post-persist for the same reason as the watermarks above: a
+    // persist failure must leave the range unexamined so it's rescanned.
+    for (folder_name, uid_validity, lo, hi) in pending_gap_examined {
+        if let Err(e) = db.set_folder_gap_examined(&account_key, &folder_name, uid_validity, lo, hi) {
+            debug_log!("[RUST] sync_nostr_emails_to_db: failed to record gap_examined for '{}': {}", folder_name, e);
         }
     }
 
@@ -5564,6 +5582,8 @@ async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str,
 
     // See sync_nostr_emails_to_db for the meaning of the 4-tuple.
     let mut pending_state: Vec<(String, u32, u32, Option<u32>)> = Vec::new();
+    // Per-folder gap-fill examined windows (folder, uid_validity, floor, last_seen).
+    let mut pending_gap_examined: Vec<(String, u32, u32, u32)> = Vec::new();
     let mut raw_sent_emails: Vec<RawNostrEmail> = Vec::new();
 
     let is_gmail = config.imap_host.contains("gmail.com");
@@ -5591,7 +5611,12 @@ async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str,
         if include_gap_fill {
             match gap_fill_in_folder(&mut session, config, db, &account_key, f, sync_cutoff_days,
                                       parse_nostr_sent_email_from_imap_body) {
-                Ok(emails) => raw_sent_emails.extend(emails),
+                Ok(r) => {
+                    raw_sent_emails.extend(r.emails);
+                    if let Some((uidv, lo, hi)) = r.examined {
+                        pending_gap_examined.push((f.to_string(), uidv, lo, hi));
+                    }
+                }
                 Err(e) => debug_log!("[RUST] sync_sent_emails_to_db: gap_fill folder '{}' failed: {}", f, e),
             }
         }
@@ -5784,6 +5809,13 @@ async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str,
                     min, folder_name
                 );
             }
+        }
+    }
+
+    // Commit gap-fill examined windows post-persist (see sync_nostr_emails_to_db).
+    for (folder_name, uid_validity, lo, hi) in pending_gap_examined {
+        if let Err(e) = db.set_folder_gap_examined(&account_key, &folder_name, uid_validity, lo, hi) {
+            debug_log!("[RUST] sync_sent_emails_to_db: failed to record gap_examined for '{}': {}", folder_name, e);
         }
     }
 
@@ -6203,6 +6235,24 @@ fn fetch_older_in_folder<S: std::io::Read + std::io::Write>(
 /// Cost shape: 1 cheap UID SEARCH, 1 batched ENVELOPE fetch (server-side
 /// parse, no body bytes), then a body fetch only for the gaps we actually
 /// find. On a healthy DB with no gaps, the body fetch is skipped entirely.
+/// Outcome of one `gap_fill_in_folder` pass.
+struct GapFillResult {
+    /// Newly-found nostr emails to persist.
+    emails: Vec<RawNostrEmail>,
+    /// The `[floor, last_seen]` window now considered fully gap-examined under
+    /// the current `uid_validity`. The caller persists it (via
+    /// `set_folder_gap_examined`) *after* a successful save, so a future pass
+    /// can skip this range. `None` when gap-fill bailed before establishing a
+    /// window (no state / UIDVALIDITY mismatch / empty search).
+    examined: Option<(u32, u32, u32)>, // (uid_validity, floor, last_seen)
+}
+
+impl GapFillResult {
+    fn empty() -> Self {
+        GapFillResult { emails: Vec::new(), examined: None }
+    }
+}
+
 fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
     session: &mut imap::Session<S>,
     config: &EmailConfig,
@@ -6211,7 +6261,7 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
     folder_name: &str,
     sync_cutoff_days: i64,
     parse_fn: fn(&[u8], &EmailConfig) -> Option<RawNostrEmail>,
-) -> anyhow::Result<Vec<RawNostrEmail>> {
+) -> anyhow::Result<GapFillResult> {
     let mb = session.select(folder_name)?;
     let uid_validity = mb.uid_validity
         .ok_or_else(|| anyhow::anyhow!("server did not advertise UIDVALIDITY for folder '{}'", folder_name))?;
@@ -6221,14 +6271,14 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
         // No state, or UIDVALIDITY change — bail. Forward sync will set up
         // fresh watermarks; gap-fill only makes sense once we have a stable
         // [min, last] range to scan inside of.
-        _ => return Ok(vec![]),
+        _ => return Ok(GapFillResult::empty()),
     };
 
     let claimed: Vec<u32> = session.uid_search(&build_bootstrap_query(sync_cutoff_days))?
         .into_iter()
         .collect();
     if claimed.is_empty() {
-        return Ok(vec![]);
+        return Ok(GapFillResult::empty());
     }
 
     // If we don't yet have a floor (legacy install), opportunistically backfill
@@ -6247,15 +6297,28 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
         }
     };
 
+    // The window we'll report as gap-examined to the caller (committed only
+    // after a successful persist). Covers the full scanned range even when no
+    // gaps are found, so a future pass can skip it.
+    let examined = Some((uid_validity, floor, stored.last_seen_uid));
+
     // Candidates: UIDs the server returned that fall inside our scanned range.
     // Below `floor` is fetch_older territory; above `last_seen_uid` is forward
     // sync territory. Both have their own paths and shouldn't be re-touched
-    // here.
+    // here. Also skip UIDs already inside the previously-examined range
+    // [gap_examined_min, gap_examined_max] — their nostr-ness was already
+    // determined (message bodies are immutable), so re-fetching them is wasted
+    // work. This is what stops every refresh from re-downloading all the
+    // non-nostr mail in the window.
+    let already_examined = |uid: u32| match (stored.gap_examined_min_uid, stored.gap_examined_max_uid) {
+        (Some(lo), Some(hi)) => uid >= lo && uid <= hi,
+        _ => false,
+    };
     let candidates: Vec<u32> = claimed.into_iter()
-        .filter(|uid| *uid >= floor && *uid <= stored.last_seen_uid)
+        .filter(|uid| *uid >= floor && *uid <= stored.last_seen_uid && !already_examined(*uid))
         .collect();
     if candidates.is_empty() {
-        return Ok(vec![]);
+        return Ok(GapFillResult { emails: Vec::new(), examined });
     }
 
     // Resolve Message-IDs via ENVELOPE (server-side parse, no body fetch) and
@@ -6287,7 +6350,7 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
     }
 
     if missing.is_empty() {
-        return Ok(vec![]);
+        return Ok(GapFillResult { emails: Vec::new(), examined });
     }
     println!(
         "[RUST] gap_fill_in_folder: '{}' found {} missing UID(s) within [{}, {}]",
@@ -6309,7 +6372,7 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
             }
         }
     }
-    Ok(emails)
+    Ok(GapFillResult { emails, examined })
 }
 
 /// Read `sync_cutoff_days` for the active pubkey, defaulting to 30.


### PR DESCRIPTION
## Why

The refresh sync path (`refresh_inbox_emails_to_db` / `refresh_sent_emails_to_db`) runs `gap_fill_in_folder`, which re-scanned the **entire** `[min_seen_uid, last_seen_uid]` window of each folder on **every** refresh:

1. `UID FETCH (ENVELOPE)` + `db.get_email(mid)` for every message in the window.
2. A full `BODY.PEEK[]` re-fetch of every UID not found in the local DB.

The local DB only stores **nostr** mail, so every ordinary message (GitHub notifications, etc.) is permanently "missing" — each refresh re-downloaded all of them and flooded `get_email` with misses. For a notification-heavy inbox that was the bulk of sync cost.

## What

Track a per-folder contiguous **already-gap-examined** UID range and skip it. The scan window only grows (`min_seen_uid` falls via backward pagination, `last_seen_uid` rises via forward sync), so a contiguous `[gap_examined_min, gap_examined_max]` fully captures prior work. gap-fill now only examines the un-examined sub-ranges; with no new mail it does ~zero ENVELOPE/body fetches.

- **`database.rs`**: additive `gap_examined_{min,max}_uid` columns (nullable, migrated like `min_seen_uid`); `FolderSyncState` fields + read; `set_folder_sync_state` resets the range on a UIDVALIDITY change (preserves it otherwise); new grow-only `set_folder_gap_examined`. +2 unit tests.
- **`email.rs`**: `gap_fill_in_folder` skips the examined range and returns the window it covered; both sync callers commit it **after** a successful persist (same post-persist loop as the existing UID watermarks).

## Correctness

- A UID examined once is stable: `parse_fn`'s nostr-vs-not verdict depends only on the immutable message body, **not** on settings (`require_signature` is applied later in `persist_inbox_raw_emails`). Non-nostr stays non-nostr.
- A nostr UID is either persisted (found by `get_email` on any future pass) or, on persist failure, **not** marked examined — the examined range is committed only in the post-persist commit loop, so a persist failure leaves it unexamined and it's rescanned next run. No nostr message can be silently skipped.
- UIDVALIDITY change resets the range.

## Residual (intentional)

When `last_seen_uid` grows, the new upper sliver — already fetched once and non-redundantly by forward sync — is examined one more time by the next gap-fill, then marked. One-time per message, not the every-refresh repetition this fixes.

## Verification

- `cargo check --lib` (desktop) and `cargo check --target aarch64-linux-android --lib` pass.
- `cargo test --lib folder` → 12 passed (includes 2 new: grow-only recording; reset-on-UIDVALIDITY / no-op on mismatch).
- Runtime (with `NOSTR_MAIL_DEBUG=true`): first refresh logs `gap_fill_in_folder: found N missing`; a second refresh with no new mail logs no `found N missing` and near-zero gap-fill `get_email` calls.

Companion to the earlier `get_email` logging gate (`claude/gate-get-email-logging`), which addressed the *log noise*; this addresses the *redundant work* behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)