### PR TITLE
Gate verbose get_email logging behind NOSTR_MAIL_DEBUG

### DIFF
--- a/tauri-app/backend/src/database.rs
+++ b/tauri-app/backend/src/database.rs
@@ -1613,12 +1613,15 @@ impl Database {
     }
 
     pub fn get_email(&self, message_id: &str) -> Result<Option<Email>> {
-        println!("[DB] get_email: Checking for message_id={}", message_id);
+        // These traces fire once per message during sync/gap-fill (one call per
+        // server Message-ID in the scanned window), so they're gated behind
+        // NOSTR_MAIL_DEBUG via debug_log! rather than unconditional println!.
+        crate::debug_log!("[DB] get_email: Checking for message_id={}", message_id);
         let conn = self.conn.lock().unwrap();
-        println!("[DB] get_email: Acquired database lock");
+        crate::debug_log!("[DB] get_email: Acquired database lock");
         // Normalize message_id for comparison
         let normalized_id = Self::normalize_message_id(message_id);
-        println!("[DB] get_email: Normalized message_id={}", normalized_id);
+        crate::debug_log!("[DB] get_email: Normalized message_id={}", normalized_id);
         
         // Use SQL query with normalization to find matching email efficiently
         // SQLite's TRIM and REPLACE can handle the normalization
@@ -1629,7 +1632,7 @@ impl Database {
              WHERE TRIM(REPLACE(REPLACE(message_id, '<', ''), '>', '')) = ?
              ORDER BY received_at DESC"
         )?;
-        println!("[DB] get_email: Prepared optimized query with normalization");
+        crate::debug_log!("[DB] get_email: Prepared optimized query with normalization");
         
         let mut rows = stmt.query(params![normalized_id])?;
         
@@ -1661,11 +1664,11 @@ impl Database {
                 references: row.get(21)?,
                 thread_id: row.get(22)?,
             };
-            println!("[DB] get_email: Found matching email, id={:?}", email.id);
+            crate::debug_log!("[DB] get_email: Found matching email, id={:?}", email.id);
             return Ok(Some(email));
         }
-        
-        println!("[DB] get_email: No matching email found");
+
+        crate::debug_log!("[DB] get_email: No matching email found");
         Ok(None)
     }
 


### PR DESCRIPTION
## Why

`Database::get_email` emitted **five unconditional `println!` lines per call** (`Checking` / `Acquired lock` / `Normalized` / `Prepared query` / found-or-`No matching email found`). During sync and gap-fill this runs once per server Message-ID in the scanned window, and since the local DB only holds nostr mail, every ordinary message (GitHub notifications, etc.) is a guaranteed miss — flooding stdout with `[DB] get_email: No matching email found` in **every build**, regardless of `NOSTR_MAIL_DEBUG`.

## What

Convert those `println!`s to `crate::debug_log!`, matching the rest of the hot-path tracing, so they only print when `NOSTR_MAIL_DEBUG` is set. No behavior change.

## Notes

- Independent of the gap-fill *work* reduction in #79 (different file region); this PR only quiets the logging. With both, normal builds are silent and the redundant scanning is gone.
- Verified: `cargo check --lib` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)