### PR TITLE
Default Auto-file Nostr Mail to off (opt-in)

### DIFF
--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -6680,14 +6680,16 @@ pub(crate) fn lookup_spam_rescue(db: &Database, pubkey: &str) -> bool {
     true
 }
 
-/// Read `auto_move_nostr` for the active pubkey, defaulting to true. When on,
-/// each sync moves nostr mail found in the regular inbox folders into the
-/// rescue/nostr-mail folder, consolidating all nostr mail in one place.
+/// Read `auto_move_nostr` for the active pubkey, defaulting to false (opt-in).
+/// When on, each sync moves nostr mail found in the regular inbox folders into
+/// the rescue/nostr-mail folder, consolidating all nostr mail in one place.
+/// Off by default because it mutates the user's mailbox server-side (visible in
+/// every other mail client), so it's surfaced as an explicit opt-in.
 pub(crate) fn lookup_auto_move_nostr(db: &Database, pubkey: &str) -> bool {
     if let Ok(Some(value)) = db.get_setting(pubkey, "auto_move_nostr") {
-        return value != "false";
+        return value == "true";
     }
-    true
+    false
 }
 
 /// Read the folder spam-rescued nostr mail should be moved into, defaulting to

--- a/tauri-app/frontend/index.html
+++ b/tauri-app/frontend/index.html
@@ -700,7 +700,7 @@
                                     <div class="toggle-setting">
                                         <label for="auto-move-nostr-preference">Auto-file Nostr Mail</label>
                                         <label class="toggle-switch">
-                                            <input type="checkbox" id="auto-move-nostr-preference" checked>
+                                            <input type="checkbox" id="auto-move-nostr-preference">
                                         </label>
                                     </div>
                                     <small class="form-text text-muted">On each sync, automatically move Nostr-encrypted messages found in your Inbox into your rescue folder, consolidating all Nostr mail in one place. Only the Inbox is affected. Uses the same destination as Spam Rescue above.</small>

--- a/tauri-app/frontend/js/app.js
+++ b/tauri-app/frontend/js/app.js
@@ -275,7 +275,7 @@ NostrMailApp.prototype.loadSettings = async function() {
                         inbox_folder: dbSettings.inbox_folder || '',
                         require_signature: dbSettings.require_signature !== 'false', // Default to true if not set
                         spam_rescue: dbSettings.spam_rescue !== 'false', // Default to true (on by default)
-                        auto_move_nostr: dbSettings.auto_move_nostr !== 'false', // Default to true (on by default)
+                        auto_move_nostr: dbSettings.auto_move_nostr === 'true', // Default to false (opt-in)
                         spam_rescue_target: dbSettings.spam_rescue_target || 'nostr-mail',
                         hide_undecryptable_emails: dbSettings.hide_undecryptable_emails !== 'false', // Default to true if not set
                         automatically_encrypt: dbSettings.automatically_encrypt !== 'false', // Default to true if not set
@@ -336,7 +336,7 @@ NostrMailApp.prototype.resetSettingsToDefaults = async function() {
         inbox_folder: '',
         require_signature: true,
         spam_rescue: true,
-        auto_move_nostr: true,
+        auto_move_nostr: false,
         spam_rescue_target: 'nostr-mail',
         glossia_encoding_body: 'latin',
         glossia_encoding_signature: 'latin',
@@ -389,7 +389,7 @@ NostrMailApp.prototype.resetSettingsToDefaultsForPubkey = function(pubkey) {
         inbox_folder: '',
         require_signature: true,
         spam_rescue: true,
-        auto_move_nostr: true,
+        auto_move_nostr: false,
         spam_rescue_target: 'nostr-mail',
         hide_undecryptable_emails: true,
         automatically_encrypt: true,
@@ -455,7 +455,7 @@ NostrMailApp.prototype.loadSettingsForPubkey = async function(pubkey) {
                 inbox_folder: dbSettings.inbox_folder || '',
                 require_signature: dbSettings.require_signature !== 'false', // Default to true if not set
                 spam_rescue: dbSettings.spam_rescue !== 'false', // Default to true (on by default)
-                auto_move_nostr: dbSettings.auto_move_nostr !== 'false', // Default to true (on by default)
+                auto_move_nostr: dbSettings.auto_move_nostr === 'true', // Default to false (opt-in)
                 spam_rescue_target: dbSettings.spam_rescue_target || 'nostr-mail',
                 hide_undecryptable_emails: dbSettings.hide_undecryptable_emails !== 'false', // Default to true if not set
                 automatically_encrypt: dbSettings.automatically_encrypt !== 'false', // Default to true if not set
@@ -3121,7 +3121,7 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
                 inbox_folder: (loadedSettings && loadedSettings.inbox_folder !== undefined) ? loadedSettings.inbox_folder : readInboxFolderSelection(),
                 require_signature: (loadedSettings && loadedSettings.require_signature !== undefined) ? loadedSettings.require_signature : (domManager.get('require-signature-preference')?.checked !== false),
                 spam_rescue: (loadedSettings && loadedSettings.spam_rescue !== undefined) ? loadedSettings.spam_rescue : (domManager.get('spam-rescue-preference')?.checked !== false),
-                auto_move_nostr: (loadedSettings && loadedSettings.auto_move_nostr !== undefined) ? loadedSettings.auto_move_nostr : (domManager.get('auto-move-nostr-preference')?.checked !== false),
+                auto_move_nostr: (loadedSettings && loadedSettings.auto_move_nostr !== undefined) ? loadedSettings.auto_move_nostr : (domManager.get('auto-move-nostr-preference')?.checked === true),
                 spam_rescue_target: (loadedSettings && loadedSettings.spam_rescue_target !== undefined) ? loadedSettings.spam_rescue_target : ((domManager.get('spam-rescue-target-preference')?.value || '').trim() || 'nostr-mail'),
                 hide_undecryptable_emails: (loadedSettings && loadedSettings.hide_undecryptable_emails !== undefined) ? loadedSettings.hide_undecryptable_emails : (domManager.get('hide-undecryptable-emails-preference')?.checked !== false),
                 automatically_encrypt: (loadedSettings && loadedSettings.automatically_encrypt !== undefined) ? loadedSettings.automatically_encrypt : (domManager.get('automatically-encrypt-preference')?.checked !== false),
@@ -3164,7 +3164,7 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
                 inbox_folder: readInboxFolderSelection(),
                 require_signature: domManager.get('require-signature-preference')?.checked !== false, // Default to true
                 spam_rescue: domManager.get('spam-rescue-preference')?.checked !== false, // Default to true (on by default)
-                auto_move_nostr: domManager.get('auto-move-nostr-preference')?.checked !== false, // Default to true (on by default)
+                auto_move_nostr: domManager.get('auto-move-nostr-preference')?.checked === true, // Default to false (opt-in)
                 spam_rescue_target: (domManager.get('spam-rescue-target-preference')?.value || '').trim() || 'nostr-mail',
                 hide_undecryptable_emails: domManager.get('hide-undecryptable-emails-preference')?.checked !== false, // Default to true
                 automatically_encrypt: autoEncryptEnabled,
@@ -3213,7 +3213,7 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
             settingsMap.set('inbox_folder', settings.inbox_folder || '');
             settingsMap.set('require_signature', settings.require_signature.toString());
             settingsMap.set('spam_rescue', (settings.spam_rescue !== false).toString());
-            settingsMap.set('auto_move_nostr', (settings.auto_move_nostr !== false).toString());
+            settingsMap.set('auto_move_nostr', (settings.auto_move_nostr === true).toString());
             settingsMap.set('spam_rescue_target', settings.spam_rescue_target || 'nostr-mail');
             settingsMap.set('hide_undecryptable_emails', (settings.hide_undecryptable_emails || false).toString());
             settingsMap.set('automatically_encrypt', (settings.automatically_encrypt !== undefined ? settings.automatically_encrypt : true).toString());
@@ -3648,10 +3648,10 @@ NostrMailApp.prototype.populateSettingsForm = async function() {
         }
         this.populateSpamRescueTargetOptions(settings);
 
-        // Set auto-file Nostr mail preference (default to true if not set)
+        // Set auto-file Nostr mail preference (default to false — opt-in)
         const autoMoveNostrPref = domManager.get('auto-move-nostr-preference');
         if (autoMoveNostrPref) {
-            autoMoveNostrPref.checked = settings.auto_move_nostr !== false;
+            autoMoveNostrPref.checked = settings.auto_move_nostr === true;
         }
 
         // Set hide undecryptable emails preference (default to true if not set)


### PR DESCRIPTION
Auto-file moves nostr mail out of the INBOX server-side on every sync, which is visible across all of the user's other mail clients. A cross-device, mailbox-mutating action shouldn't be on without the user choosing it, so flip the default from on to off and surface it as an explicit opt-in.

- Backend `lookup_auto_move_nostr` now defaults `false` (an explicit `"true"` is required to enable).
- Frontend default object, both DB-load paths, the save path, and the settings toggle all default unchecked.
- Existing users who already toggled it keep their stored choice — only the unset default changes.

Stacked on the #86 merge; base is `fix/require-signature-recoverable-sync` so the diff is just the one commit.

https://claude.ai/code/session_015qtPbhswzbe552CgiKNjcq