### PR TITLE
Unify per-folder scan window and surface scan depth on scroll

### DIFF
--- a/tauri-app/backend/src/database.rs
+++ b/tauri-app/backend/src/database.rs
@@ -1505,7 +1505,7 @@ impl Database {
                     subject_hash = COALESCE(?, subject_hash),
                     signature_valid = COALESCE(?, signature_valid),
                     signature_source = COALESCE(?, signature_source),
-                    transport_auth_verified = ?,
+                    transport_auth_verified = COALESCE(?, transport_auth_verified),
                     in_reply_to = ?, references_ = ?, thread_id = ?
                 WHERE id = ?",
                 params![

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -5357,7 +5357,6 @@ pub async fn refresh_inbox_emails_to_db(config: &EmailConfig, folders_arg: Optio
 
 async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option<&[String]>, active_pubkey: &str, db: &Database, include_gap_fill: bool) -> anyhow::Result<usize> {
     let account_key = config.email_address.trim().to_lowercase();
-    let max_scan = lookup_max_scan(db, active_pubkey);
     let require_signature = lookup_require_signature(db, active_pubkey);
     let spam_rescue = lookup_spam_rescue(db, active_pubkey);
     let auto_move_nostr = lookup_auto_move_nostr(db, active_pubkey);
@@ -5411,8 +5410,8 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
     }
 
     println!(
-        "[RUST] sync_nostr_emails_to_db: account={}, folders={:?}, max_scan={}",
-        account_key, folders, max_scan
+        "[RUST] sync_nostr_emails_to_db: account={}, folders={:?}",
+        account_key, folders
     );
 
     // Per-folder watermark updates, applied AFTER all per-message DB saves succeed.
@@ -5456,8 +5455,12 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
 
     println!("[RUST] sync_nostr_emails_to_db: folders to scan: {:?}", folders);
     for f in &folders {
-        let target_count = lookup_folder_count(db, active_pubkey, f);
-        match uid_sync_folder(&mut session, config, db, &account_key, f, target_count, max_scan,
+        // Bootstrap scans a window of `count` messages per folder ("Messages to
+        // Load Per Folder" / per-folder override), surfacing the nostr mail in
+        // it — same scan-window model as the scroll. Passing `count` as both the
+        // match target and the scan cap means the window is examined in full.
+        let count = lookup_folder_count(db, active_pubkey, f);
+        match uid_sync_folder(&mut session, config, db, &account_key, f, count, count,
                               parse_nostr_email_from_imap_body) {
             Ok(r) => {
                 if r.max_uid > 0 || !r.had_existing_state {
@@ -5546,6 +5549,11 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
 pub struct FetchOlderSummary {
     pub new_count: usize,
     pub hit_bottom: bool,
+    // INTERNALDATE of the oldest message scanned across all folders this call
+    // (the minimum over each folder's oldest-touched message). Serialized as an
+    // RFC3339 string for the UI; None when nothing was scanned. Lets the list
+    // status show how far back a "no matches in this batch" scan reached.
+    pub oldest_scanned: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// Backward UID pagination for the inbox. Walks UIDs back per folder past
@@ -5561,6 +5569,7 @@ pub async fn fetch_older_inbox_emails_to_db(
     let account_key = config.email_address.trim().to_lowercase();
     let sync_cutoff_days = lookup_sync_cutoff_days(db, active_pubkey);
     let require_signature = lookup_require_signature(db, active_pubkey);
+    let _ = page_size; // display page; scan window is the per-folder count below
 
     let folders: Vec<String> = match folder {
         Some(f) if !f.is_empty() => vec![f.to_string()],
@@ -5580,16 +5589,24 @@ pub async fn fetch_older_inbox_emails_to_db(
     // as "not exhausted" — the caller may want to retry.
     let mut any_folder_scanned = false;
     let mut all_folders_exhausted = true;
+    let mut oldest_scanned: Option<chrono::DateTime<chrono::Utc>> = None;
 
     let target = ImapTarget::from_config(config);
     let mut session = imap_pool::checkout(&target)?;
     for f in &folders {
+        // Same per-folder count the bootstrap uses ("Messages to Load Per
+        // Folder" / per-folder override): each scroll scans that many messages
+        // in this folder, surfacing the nostr mail found.
+        let scan_window = lookup_folder_count(db, active_pubkey, f);
         match fetch_older_in_folder(&mut session, config, db, &account_key, f,
-                                     page_size, sync_cutoff_days,
+                                     scan_window, sync_cutoff_days,
                                      parse_nostr_email_from_imap_body) {
             Ok(r) => {
                 any_folder_scanned = true;
                 if !r.hit_bottom { all_folders_exhausted = false; }
+                if let Some(d) = r.oldest_scanned {
+                    if oldest_scanned.map_or(true, |cur| d < cur) { oldest_scanned = Some(d); }
+                }
                 if let Some(new_floor) = r.new_floor_uid {
                     pending_floors.push((f.clone(), new_floor));
                 }
@@ -5624,7 +5641,7 @@ pub async fn fetch_older_inbox_emails_to_db(
         "[RUST] fetch_older_inbox_emails_to_db: completed, {} new emails saved, hit_bottom={}",
         new_count, hit_bottom
     );
-    Ok(FetchOlderSummary { new_count, hit_bottom })
+    Ok(FetchOlderSummary { new_count, hit_bottom, oldest_scanned })
 }
 
 /// Backward UID pagination for the sent folder. See `fetch_older_inbox_emails_to_db`.
@@ -5636,6 +5653,7 @@ pub async fn fetch_older_sent_emails_to_db(
 ) -> anyhow::Result<FetchOlderSummary> {
     let account_key = config.email_address.trim().to_lowercase();
     let sync_cutoff_days = lookup_sync_cutoff_days(db, active_pubkey);
+    let _ = page_size; // display page; scan window is the per-folder count below
 
     let is_gmail = config.imap_host.contains("gmail.com");
 
@@ -5643,18 +5661,23 @@ pub async fn fetch_older_sent_emails_to_db(
     let mut raw_emails: Vec<RawNostrEmail> = Vec::new();
     let mut any_folder_scanned = false;
     let mut all_folders_exhausted = true;
+    let mut oldest_scanned: Option<chrono::DateTime<chrono::Utc>> = None;
 
     let target = ImapTarget::from_config(config);
     let mut session = imap_pool::checkout(&target)?;
     let sent_folder = discover_sent_mailbox(&mut session)?
         .unwrap_or_else(|| if is_gmail { "[Gmail]/Sent Mail".to_string() } else { "Sent".to_string() });
     for f in [sent_folder.as_str(), "nostr-mail"] {
+        let scan_window = lookup_folder_count(db, active_pubkey, f);
         match fetch_older_in_folder(&mut session, config, db, &account_key, f,
-                                     page_size, sync_cutoff_days,
+                                     scan_window, sync_cutoff_days,
                                      parse_nostr_sent_email_from_imap_body) {
             Ok(r) => {
                 any_folder_scanned = true;
                 if !r.hit_bottom { all_folders_exhausted = false; }
+                if let Some(d) = r.oldest_scanned {
+                    if oldest_scanned.map_or(true, |cur| d < cur) { oldest_scanned = Some(d); }
+                }
                 if let Some(new_floor) = r.new_floor_uid {
                     pending_floors.push((f.to_string(), new_floor));
                 }
@@ -5691,7 +5714,7 @@ pub async fn fetch_older_sent_emails_to_db(
         "[RUST] fetch_older_sent_emails_to_db: completed, {} new emails saved, hit_bottom={}",
         new_count, hit_bottom
     );
-    Ok(FetchOlderSummary { new_count, hit_bottom })
+    Ok(FetchOlderSummary { new_count, hit_bottom, oldest_scanned })
 }
 
 pub async fn sync_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str, db: &Database) -> anyhow::Result<usize> {
@@ -5707,7 +5730,6 @@ pub async fn refresh_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str
 async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str, db: &Database, include_gap_fill: bool) -> anyhow::Result<usize> {
     debug_log!("[RUST] sync_sent_emails_to_db: Starting sync for email: {}", config.email_address);
     let account_key = config.email_address.trim().to_lowercase();
-    let max_scan = lookup_max_scan(db, active_pubkey);
 
     // See sync_nostr_emails_to_db for the meaning of the 4-tuple.
     let mut pending_state: Vec<(String, u32, u32, Option<u32>)> = Vec::new();
@@ -5722,8 +5744,9 @@ async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str,
     let sent_folder = discover_sent_mailbox(&mut session)?
         .unwrap_or_else(|| if is_gmail { "[Gmail]/Sent Mail".to_string() } else { "Sent".to_string() });
     for f in [sent_folder.as_str(), "nostr-mail"] {
-        let target_count = lookup_folder_count(db, active_pubkey, f);
-        match uid_sync_folder(&mut session, config, db, &account_key, f, target_count, max_scan,
+        // Scan a window of `count` messages per folder (see sync_nostr_emails_to_db).
+        let count = lookup_folder_count(db, active_pubkey, f);
+        match uid_sync_folder(&mut session, config, db, &account_key, f, count, count,
                               parse_nostr_sent_email_from_imap_body) {
             Ok(r) => {
                 if r.max_uid > 0 || !r.had_existing_state {
@@ -6231,6 +6254,9 @@ struct FetchOlderResult {
     // "real bottom of the folder" from "we exhausted this call's scan budget
     // and there might still be more older nostr mail further down".
     hit_bottom: bool,
+    // INTERNALDATE of the oldest message scanned in this folder this call.
+    // None when nothing was fetched (early return / empty candidate set).
+    oldest_scanned: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// Result of `walk_back_collecting`: the nostr emails found, the lowest UID we
@@ -6241,6 +6267,11 @@ struct CountWalk {
     lowest_scanned: u32,
     scanned: usize,
     hit_bottom: bool,
+    // INTERNALDATE of the oldest message touched during the walk (server
+    // arrival time of the lowest-UID candidate, nostr or not). Surfaced so the
+    // UI can tell the user how far back a "no matches in this batch" scan
+    // reached. None when no message was fetched.
+    oldest_scanned: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// Pure per-iteration decision for the backward count-walk: given how many
@@ -6291,6 +6322,7 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
     let mut emails: Vec<RawNostrEmail> = Vec::new();
     let mut scanned: usize = 0;
     let mut lowest_scanned: u32 = floor_init;
+    let mut oldest_scanned: Option<chrono::DateTime<chrono::Utc>> = None;
 
     // Cap each UID FETCH line at ~500 UIDs to stay under Gmail's ~8KB IMAP line
     // limit. `take` can be large on bootstrap (a deep count target), so split
@@ -6301,10 +6333,16 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
     {
         for chunk in uids_sorted[start..end].chunks(FETCH_BATCH) {
             let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
-            let msgs = session.uid_fetch(&uid_list, "(UID FLAGS BODY.PEEK[])")?;
+            let msgs = session.uid_fetch(&uid_list, "(UID FLAGS INTERNALDATE BODY.PEEK[])")?;
             for msg in msgs.iter() {
                 if let Some(uid) = msg.uid {
                     if uid < lowest_scanned { lowest_scanned = uid; }
+                }
+                if let Some(d) = msg.internal_date() {
+                    let d_utc = d.with_timezone(&chrono::Utc);
+                    if oldest_scanned.map_or(true, |cur| d_utc < cur) {
+                        oldest_scanned = Some(d_utc);
+                    }
                 }
                 if let Some(body) = msg.body() {
                     if let Some(mut parsed) = parse_fn(body, config) {
@@ -6318,7 +6356,47 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
     }
 
     let hit_bottom = scanned >= uids_sorted.len();
-    Ok(CountWalk { emails, lowest_scanned, scanned, hit_bottom })
+    Ok(CountWalk { emails, lowest_scanned, scanned, hit_bottom, oldest_scanned })
+}
+
+/// Enumerate a bounded window of existing UIDs just below `floor_uid`, large
+/// enough to hold at least `want` of them, without scanning the whole folder.
+///
+/// The naive `UID SEARCH UID 1:floor-1` returns every UID below the floor —
+/// 100k+ on a large Gmail INBOX — only for the caller to scan the newest
+/// `want`. Instead we search a numeric window `[lo, floor-1]` and widen it
+/// (doubling the span) until it contains `>= want` existing UIDs or `lo` hits
+/// UID 1. UID gaps from deletions mean the numeric span must exceed `want`;
+/// dense folders satisfy it in a single small SEARCH, sparse ones take a few
+/// cheap round-trips (their total message count is low, so each result is tiny).
+///
+/// Returns the candidate UIDs sorted ascending and whether the window reached
+/// UID 1 (i.e. there is nothing older than the returned set — the caller uses
+/// this to decide `hit_bottom`). The set may be smaller than `want` only when
+/// the window bottomed out at UID 1.
+fn search_uid_window_below<S: std::io::Read + std::io::Write>(
+    session: &mut imap::Session<S>,
+    floor_uid: u32,
+    want: usize,
+) -> anyhow::Result<(Vec<u32>, bool)> {
+    // Caller guarantees floor_uid > 1, so hi >= 1.
+    let hi = floor_uid.saturating_sub(1);
+    // Initial numeric span ~2x the desired count leaves headroom for moderate
+    // deletion gaps; doubling handles sparser folders.
+    let mut span: u32 = (want as u32).saturating_mul(2).max(64);
+    loop {
+        let lo = hi.saturating_sub(span.saturating_sub(1)).max(1);
+        let reached_bottom = lo == 1;
+        let set = session.uid_search(format!("UID {}:{}", lo, hi))?;
+        if set.len() >= want || reached_bottom {
+            let mut uids: Vec<u32> = set.into_iter().collect();
+            uids.sort_unstable();
+            return Ok((uids, reached_bottom));
+        }
+        // Not enough yet and room remains below the window — widen and retry.
+        // Saturating so the final pass forces lo down to UID 1.
+        span = span.checked_mul(2).unwrap_or(u32::MAX);
+    }
 }
 
 /// Pull older messages from one folder, walking UIDs backward.
@@ -6329,21 +6407,19 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
 /// seeds an approximate floor via the date-windowed SEARCH (`build_bootstrap_query`).
 ///
 /// Walks newest-to-oldest from `min_seen_uid - 1`, fetching full bodies and
-/// running `parse_fn`. Stops when either:
-///   * `page_size` nostr matches have accumulated, OR
-///   * `max(page_size, MIN_SCAN_PER_CALL)` UIDs have been scanned, OR
-///   * the candidate set is exhausted (`hit_bottom = true`).
-///
-/// Scanning more than `page_size` matters when the folder is mostly non-nostr
-/// mail — common for Sent. Without it, one batch of non-matches looks like
-/// "bottom hit" and the UI gives up prematurely.
+/// running `parse_fn`. One call examines a fixed window of `scan_window` raw
+/// messages — the per-folder count (`sync_initial_count` / per-folder override),
+/// the same value the bootstrap uses — surfacing every nostr match in it, and
+/// stops when either `scan_window` messages have been examined OR the folder is
+/// exhausted to UID 1 (`hit_bottom = true`). There is no early exit on a match
+/// count: each scroll digs a fixed depth and the next picks up below.
 fn fetch_older_in_folder<S: std::io::Read + std::io::Write>(
     session: &mut imap::Session<S>,
     config: &EmailConfig,
     db: &Database,
     account_key: &str,
     folder_name: &str,
-    page_size: usize,
+    scan_window: usize,
     sync_cutoff_days: i64,
     parse_fn: fn(&[u8], &EmailConfig) -> Option<RawNostrEmail>,
 ) -> anyhow::Result<FetchOlderResult> {
@@ -6355,14 +6431,14 @@ fn fetch_older_in_folder<S: std::io::Read + std::io::Write>(
         Some(s) => s,
         None => {
             debug_log!("[RUST] fetch_older_in_folder: '{}' has no sync state, run forward sync first", folder_name);
-            return Ok(FetchOlderResult { emails: vec![], new_floor_uid: None, hit_bottom: false });
+            return Ok(FetchOlderResult { emails: vec![], new_floor_uid: None, hit_bottom: false, oldest_scanned: None });
         }
     };
 
     if stored.uid_validity != uid_validity {
         debug_log!("[RUST] fetch_older_in_folder: '{}' UIDVALIDITY changed ({} -> {}), aborting backward fetch",
             folder_name, stored.uid_validity, uid_validity);
-        return Ok(FetchOlderResult { emails: vec![], new_floor_uid: None, hit_bottom: false });
+        return Ok(FetchOlderResult { emails: vec![], new_floor_uid: None, hit_bottom: false, oldest_scanned: None });
     }
 
     let floor_uid = match stored.min_seen_uid {
@@ -6373,7 +6449,7 @@ fn fetch_older_in_folder<S: std::io::Read + std::io::Write>(
                 folder_name, bootstrap_query);
             let set = session.uid_search(&bootstrap_query)?;
             if set.is_empty() {
-                return Ok(FetchOlderResult { emails: vec![], new_floor_uid: None, hit_bottom: false });
+                return Ok(FetchOlderResult { emails: vec![], new_floor_uid: None, hit_bottom: false, oldest_scanned: None });
             }
             let backfilled_min = set.into_iter().min().unwrap_or(0);
             db.set_folder_min_seen_uid(account_key, folder_name, backfilled_min)?;
@@ -6382,49 +6458,56 @@ fn fetch_older_in_folder<S: std::io::Read + std::io::Write>(
     };
 
     if floor_uid <= 1 {
-        return Ok(FetchOlderResult { emails: vec![], new_floor_uid: None, hit_bottom: true });
+        return Ok(FetchOlderResult { emails: vec![], new_floor_uid: None, hit_bottom: true, oldest_scanned: None });
     }
 
-    let query = format!("UID 1:{}", floor_uid - 1);
-    debug_log!("[RUST] fetch_older_in_folder: '{}' UID SEARCH {}", folder_name, query);
-    let uid_set = session.uid_search(&query)?;
-    if uid_set.is_empty() {
-        // Server has nothing below the floor — mark bottom so subsequent
-        // calls short-circuit (floor moves to 1, hit_bottom signals UI).
-        return Ok(FetchOlderResult { emails: vec![], new_floor_uid: Some(1), hit_bottom: true });
+    // One scroll examines a fixed window of `scan_window` raw messages per
+    // folder (the per-folder count, same as the bootstrap), surfacing every
+    // nostr match in it — no early exit on a match count. Next scroll continues
+    // below.
+    let scan_window = scan_window.max(1);
+
+    // Enumerate only a bounded UID window just below the floor instead of the
+    // entire history (`UID 1:floor-1`), which on a large INBOX returns 100k+
+    // UIDs every scroll just to scan the newest `scan_window`. The window
+    // expands until it holds at least `scan_window` existing UIDs or reaches UID 1.
+    let (uids, window_reached_bottom) = search_uid_window_below(session, floor_uid, scan_window)?;
+    debug_log!(
+        "[RUST] fetch_older_in_folder: '{}' windowed search below {} -> {} candidate UID(s), reached_bottom={}",
+        folder_name, floor_uid, uids.len(), window_reached_bottom
+    );
+    if uids.is_empty() {
+        // The window walked all the way to UID 1 with nothing below the floor —
+        // true bottom. Floor moves to 1 so subsequent calls short-circuit.
+        return Ok(FetchOlderResult { emails: vec![], new_floor_uid: Some(1), hit_bottom: true, oldest_scanned: None });
     }
 
-    let mut uids: Vec<u32> = uid_set.into_iter().collect();
-    uids.sort_unstable();
+    // Walk newest-to-oldest, fetching bodies in batches. Passing `scan_window`
+    // as both the match target and the scan cap makes the match-count stop
+    // condition unreachable (matches <= scanned), so the walk always examines
+    // the full window unless the folder bottoms out first. `floor_uid` seeds the
+    // lowest-UID tracker so a no-op call never raises the floor.
+    let walk = walk_back_collecting(session, config, &uids, floor_uid, scan_window, scan_window, parse_fn)?;
 
-    // Per-call scan budget. `page_size` of 5 with a folder dominated by
-    // non-nostr mail would otherwise terminate at the first batch of misses.
-    // Keep this generous enough to walk through the common pattern of a few
-    // non-nostr in between nostr matches, but small enough that one scroll
-    // trigger doesn't pull megabytes of unrelated bodies. 50 hits a
-    // reasonable middle.
-    const MIN_SCAN_PER_CALL: usize = 50;
-    let target_count = page_size.max(1);
-    let max_scan = target_count.max(MIN_SCAN_PER_CALL);
-
-    // Walk newest-to-oldest, fetching bodies in batches, stopping when we have
-    // enough matches or hit the per-call cap. `floor_uid` seeds the lowest-UID
-    // tracker so a no-op call never raises the floor.
-    let walk = walk_back_collecting(session, config, &uids, floor_uid, target_count, max_scan, parse_fn)?;
-
-    // When we've truly hit bottom, set floor to 1 so the next call
-    // short-circuits. Otherwise lower it to the lowest UID we touched.
-    let returned_floor = if walk.hit_bottom { 1 } else { walk.lowest_scanned };
+    // True bottom only when the search window reached UID 1 AND the walk
+    // consumed every candidate in it (didn't stop early on its scan budget).
+    // `walk.hit_bottom` alone now means only "exhausted this window", so it must
+    // be gated by `window_reached_bottom`.
+    let hit_bottom = window_reached_bottom && walk.hit_bottom;
+    // On true bottom set floor to 1 so the next call short-circuits; otherwise
+    // lower it to the lowest UID we touched.
+    let returned_floor = if hit_bottom { 1 } else { walk.lowest_scanned };
 
     debug_log!(
-        "[RUST] fetch_older_in_folder: '{}' scanned {}/{} UIDs, found {} nostr match(es), hit_bottom={}, new_floor={}",
-        folder_name, walk.scanned, uids.len(), walk.emails.len(), walk.hit_bottom, returned_floor
+        "[RUST] fetch_older_in_folder: '{}' scanned {}/{} windowed UIDs, found {} nostr match(es), hit_bottom={}, new_floor={}",
+        folder_name, walk.scanned, uids.len(), walk.emails.len(), hit_bottom, returned_floor
     );
 
     Ok(FetchOlderResult {
         emails: walk.emails,
         new_floor_uid: Some(returned_floor),
-        hit_bottom: walk.hit_bottom,
+        hit_bottom,
+        oldest_scanned: walk.oldest_scanned,
     })
 }
 
@@ -6613,10 +6696,6 @@ const DEFAULT_INITIAL_COUNT: usize = 50;
 /// (nearly) every message is nostr mail so a deep count is cheap and accurate.
 /// Overridable per-folder via `sync_folder_counts`.
 const DEFAULT_DENSE_COUNT: usize = 500;
-/// Default cap on raw messages examined per folder bootstrap. Bounds the cost
-/// on sparse mixed folders (e.g. a busy INBOX) where the target match count
-/// would otherwise force an unbounded backward walk.
-const DEFAULT_MAX_SCAN: usize = 2000;
 
 /// Pure resolution of a folder's bootstrap count. An explicit override in the
 /// user's `sync_folder_counts` map wins; otherwise the dedicated dense
@@ -6646,18 +6725,10 @@ fn lookup_initial_count(db: &Database, pubkey: &str) -> usize {
         .unwrap_or(DEFAULT_INITIAL_COUNT)
 }
 
-/// Cap on raw messages examined per folder bootstrap, defaulting to
-/// `DEFAULT_MAX_SCAN`.
-fn lookup_max_scan(db: &Database, pubkey: &str) -> usize {
-    db.get_setting(pubkey, "sync_max_scan")
-        .ok()
-        .flatten()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_MAX_SCAN)
-}
-
-/// Per-folder bootstrap count for the active pubkey: per-folder override →
-/// dense-folder default → global `sync_initial_count`.
+/// Per-folder scan window for the active pubkey: per-folder override →
+/// dense-folder default → global `sync_initial_count`. Used by both the initial
+/// bootstrap and each "load older" scroll — both scan this many messages in the
+/// folder and surface the nostr mail found.
 fn lookup_folder_count(db: &Database, pubkey: &str, folder: &str) -> usize {
     let json = db.get_setting(pubkey, "sync_folder_counts").ok().flatten();
     resolve_folder_count(folder, json.as_deref(), lookup_initial_count(db, pubkey))

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -5667,7 +5667,13 @@ pub async fn fetch_older_sent_emails_to_db(
     let mut session = imap_pool::checkout(&target)?;
     let sent_folder = discover_sent_mailbox(&mut session)?
         .unwrap_or_else(|| if is_gmail { "[Gmail]/Sent Mail".to_string() } else { "Sent".to_string() });
-    for f in [sent_folder.as_str(), "nostr-mail"] {
+    // Sent pass walks only the real Sent folder. `nostr-mail` is already
+    // covered by the inbox/nostr pass (verify_transport = true); scanning it
+    // again here adds no coverage (send is SMTP-only, nothing APPENDs to it),
+    // wastes body fetches, and lets both passes fight over its
+    // folder_sync_state watermark. Sent-vs-Inbox is decided at query time by
+    // from_address, not by which folder a row came from.
+    for f in [sent_folder.as_str()] {
         let scan_window = lookup_folder_count(db, active_pubkey, f);
         match fetch_older_in_folder(&mut session, config, db, &account_key, f,
                                      scan_window, sync_cutoff_days,
@@ -5743,7 +5749,13 @@ async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str,
     let mut session = imap_pool::checkout(&target)?;
     let sent_folder = discover_sent_mailbox(&mut session)?
         .unwrap_or_else(|| if is_gmail { "[Gmail]/Sent Mail".to_string() } else { "Sent".to_string() });
-    for f in [sent_folder.as_str(), "nostr-mail"] {
+    // Sent pass walks only the real Sent folder. `nostr-mail` is already
+    // covered by the inbox/nostr pass (verify_transport = true); scanning it
+    // again here adds no coverage (send is SMTP-only, nothing APPENDs to it),
+    // wastes body fetches, and lets both passes fight over its
+    // folder_sync_state watermark. Sent-vs-Inbox is decided at query time by
+    // from_address, not by which folder a row came from.
+    for f in [sent_folder.as_str()] {
         // Scan a window of `count` messages per folder (see sync_nostr_emails_to_db).
         let count = lookup_folder_count(db, active_pubkey, f);
         match uid_sync_folder(&mut session, config, db, &account_key, f, count, count,

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -6738,9 +6738,16 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
     // Candidates: UIDs inside our synced range [floor, last_seen] to (re)check.
     // Below `floor` is fetch_older territory; above `last_seen_uid` is forward
     // sync territory. Both have their own paths and shouldn't be re-touched here.
-    // We always scan the full range by UID (no date window) — the count-based
-    // bootstrap keeps [floor, last_seen] bounded, and the ENVELOPE pass below is
-    // cheap (no bodies until a genuine gap is found).
+    //
+    // Candidates are NOT every UID in [floor, last_seen] — that's the whole
+    // inbox, and since only nostr mail is ever stored, every non-nostr message
+    // (the vast majority) would look "missing" and get body-fetched. A deeply
+    // scrolled floor made this catastrophic: an 11k-wide range meant ~11k bogus
+    // gaps and an 11k-body download. Instead we ask the server for just the
+    // nostr-marked UIDs in the range (same prefilter as the scroll/bootstrap
+    // walk; see `search_nostr_uids_in_range`) and only those can be gaps. The
+    // examined marker below still covers the full range — the SEARCH examined
+    // all of it, just cheaply.
     //
     // Steady state (recover_dropped = false): skip the already-examined
     // sub-range [gap_examined_min, gap_examined_max] — those UIDs' nostr-ness
@@ -6757,8 +6764,24 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
         (Some(lo), Some(hi)) => uid >= lo && uid <= hi,
         _ => false,
     };
-    let candidates: Vec<u32> = session
-        .uid_search(&format!("UID {}:{}", floor, stored.last_seen_uid))?
+
+    // Steady-state short-circuit: if the filter is unchanged and the examined
+    // marker already covers the whole [floor, last_seen] range, every candidate
+    // would be filtered out below — skip the range-wide SEARCH entirely (it
+    // scans every message in the range server-side, multi-second on a deeply
+    // scrolled inbox). Re-commit the same marker so nothing regresses.
+    if !recover_dropped {
+        if let (Some(lo), Some(hi)) = (stored.gap_examined_min_uid, stored.gap_examined_max_uid) {
+            if lo <= floor && hi >= stored.last_seen_uid {
+                debug_log!("[RUST-PERF] gap_fill_in_folder '{}': skipped — [{}, {}] already examined",
+                    folder_name, floor, stored.last_seen_uid);
+                return Ok(GapFillResult { emails: Vec::new(), examined });
+            }
+        }
+    }
+
+    let t_search = std::time::Instant::now();
+    let mut candidates: Vec<u32> = search_nostr_uids_in_range(session, floor, stored.last_seen_uid)?
         .into_iter()
         .filter(|uid| {
             *uid >= floor
@@ -6766,7 +6789,11 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
                 && (recover_dropped || !already_examined(*uid))
         })
         .collect();
+    candidates.sort_unstable();
+    let search_ms = t_search.elapsed().as_millis();
     if candidates.is_empty() {
+        debug_log!("[RUST-PERF] gap_fill_in_folder '{}': nostr_search={}ms, 0 nostr candidates in [{}, {}]",
+            folder_name, search_ms, floor, stored.last_seen_uid);
         return Ok(GapFillResult { emails: Vec::new(), examined });
     }
 
@@ -6776,6 +6803,7 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
     // gaps and pulled in the next step.
     const FETCH_BATCH: usize = 500;
     let mut missing: Vec<u32> = Vec::new();
+    let t_env = std::time::Instant::now();
     for chunk in candidates.chunks(FETCH_BATCH) {
         let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
         let msgs = session.uid_fetch(&uid_list, "(UID ENVELOPE)")?;
@@ -6798,7 +6826,10 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
         }
     }
 
+    let env_ms = t_env.elapsed().as_millis();
     if missing.is_empty() {
+        debug_log!("[RUST-PERF] gap_fill_in_folder '{}': nostr_search={}ms, envelope+lookup={}ms ({} nostr candidates, 0 missing)",
+            folder_name, search_ms, env_ms, candidates.len());
         return Ok(GapFillResult { emails: Vec::new(), examined });
     }
     println!(
@@ -6807,6 +6838,7 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
     );
 
     let mut emails: Vec<RawNostrEmail> = Vec::new();
+    let t_body = std::time::Instant::now();
     for chunk in missing.chunks(FETCH_BATCH) {
         let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
         // BODY.PEEK[] so gap-fill backfill doesn't *set* \Seen; FLAGS so we can
@@ -6821,6 +6853,8 @@ fn gap_fill_in_folder<S: std::io::Read + std::io::Write>(
             }
         }
     }
+    debug_log!("[RUST-PERF] gap_fill_in_folder '{}': nostr_search={}ms, envelope+lookup={}ms, body_fetch={}ms ({} nostr candidates, {} missing, {} match)",
+        folder_name, search_ms, env_ms, t_body.elapsed().as_millis(), candidates.len(), missing.len(), emails.len());
     Ok(GapFillResult { emails, examined })
 }
 

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -6375,15 +6375,53 @@ fn next_back_batch(
     Some((start, end))
 }
 
-/// Walk a pre-sorted (ascending) UID list newest→oldest, fetching bodies in
-/// batches and running `parse_fn`, until either `target_count` nostr matches
-/// accumulate, `max_scan` UIDs have been examined, or the list is exhausted.
+/// Server-side narrow: of the existing UIDs in `[lo, hi]`, which carry a nostr
+/// marker? Mirrors the detection gate in `parse_nostr_email_from_imap_body_inner`
+/// (an `X-Nostr-Pubkey` header OR a `BEGIN NOSTR NIP-` armor block — the `NIP-`
+/// prefix covers every NIP-04/44 ENCRYPTED MESSAGE/BODY variant the gate checks)
+/// but lets the IMAP server filter so non-nostr bodies are never downloaded.
+///
+/// One combined `SEARCH` (range AND (header OR body-marker)). A weak server BODY
+/// index could under-return armor-only mail; the caller's local parse still
+/// re-confirms every hit, so over-returning is harmless. Returns the matching
+/// UIDs (unordered).
+fn search_nostr_uids_in_range<S: std::io::Read + std::io::Write>(
+    session: &mut imap::Session<S>,
+    lo: u32,
+    hi: u32,
+) -> anyhow::Result<std::collections::HashSet<u32>> {
+    let query = format!(
+        "UID {}:{} OR HEADER X-Nostr-Pubkey \"\" BODY \"BEGIN NOSTR NIP-\"",
+        lo, hi
+    );
+    let set = session.uid_search(&query)?;
+    Ok(set.into_iter().collect())
+}
+
+/// Examine the newest `max_scan` UIDs of a pre-sorted (ascending) candidate
+/// list, returning the nostr matches among them.
+///
+/// Rather than download every body in the window and parse it locally (~50ms
+/// per message of pure network on a dense INBOX — most of it non-nostr mail we
+/// immediately discard), we let the IMAP server do the filtering: one
+/// `SEARCH` narrows the window to UIDs that carry a nostr marker, and we
+/// BODY.PEEK[] only those (usually 0–2). The local `parse_fn` still re-confirms
+/// each candidate, so an over-returning server is harmless. The trade-off is a
+/// server with a weak BODY index could miss an armor-only message (no
+/// `X-Nostr-Pubkey` header) — acceptable on Gmail, the primary target. See
+/// `search_nostr_uids_in_range`.
+///
+/// Floor/scan-depth bookkeeping (`lowest_scanned`, `oldest_scanned`, `scanned`)
+/// covers the WHOLE examined window, independent of which bodies were fetched:
+/// the lowest window UID lowers the floor, and a cheap INTERNALDATE-only fetch
+/// (no bodies) over the window gives the scan-depth date. `target_count` is now
+/// only a window-size hint — the match-count early-exit is retired (every
+/// caller passes target == max_scan; see PR #88: "each scroll digs a fixed
+/// depth"), so the full window is always examined.
 ///
 /// `floor_init` seeds `lowest_scanned` so a no-op call never raises the floor.
-/// Shared by `fetch_older_in_folder` (and, later, the count-based bootstrap):
-/// the only thing that differs between callers is which candidate UIDs they
-/// feed in. BODY.PEEK[] keeps reads from setting \Seen; FLAGS lets us seed
-/// local read state for newly-imported rows.
+/// BODY.PEEK[] keeps reads from setting \Seen; FLAGS lets us seed local read
+/// state for newly-imported rows.
 fn walk_back_collecting<S: std::io::Read + std::io::Write>(
     session: &mut imap::Session<S>,
     config: &EmailConfig,
@@ -6394,38 +6432,66 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
     parse_fn: fn(&[u8], &EmailConfig) -> Option<RawNostrEmail>,
 ) -> anyhow::Result<CountWalk> {
     let mut emails: Vec<RawNostrEmail> = Vec::new();
-    let mut scanned: usize = 0;
     let mut lowest_scanned: u32 = floor_init;
     let mut oldest_scanned: Option<chrono::DateTime<chrono::Utc>> = None;
-    // IMAP body-download time vs in-process parse time, summed across batches
-    // (see uid_sync_folder). Drives the [RUST-PERF] line so a slow backward
-    // walk can be pinned on the network or the CPU.
-    let mut fetch_ms: u128 = 0;
-    let mut parse_ms: u128 = 0;
 
-    // Cap each UID FETCH line at ~500 UIDs to stay under Gmail's ~8KB IMAP line
-    // limit. `take` can be large on bootstrap (a deep count target), so split
-    // the slice even though a single batch is logically one walk step.
-    const FETCH_BATCH: usize = 500;
+    // Enumerate the examined window — the newest `max_scan` candidate UIDs —
+    // reusing the (unit-tested) boundary logic. Passing matches=0 keeps the
+    // retired match-count early-exit from truncating enumeration; with
+    // target == max_scan this yields exactly the newest `max_scan` UIDs.
+    let mut window: Vec<u32> = Vec::new();
+    let mut scanned: usize = 0;
     while let Some((start, end)) =
-        next_back_batch(scanned, uids_sorted.len(), emails.len(), target_count, max_scan)
+        next_back_batch(scanned, uids_sorted.len(), 0, target_count, max_scan)
     {
-        for chunk in uids_sorted[start..end].chunks(FETCH_BATCH) {
+        window.extend_from_slice(&uids_sorted[start..end]);
+        scanned += end - start;
+    }
+    window.sort_unstable();
+
+    // Cap each UID FETCH line at ~500 UIDs to stay under Gmail's ~8KB IMAP line limit.
+    const FETCH_BATCH: usize = 500;
+    if let (Some(&win_min), Some(&win_max)) = (window.first(), window.last()) {
+        // Phase timings for the [RUST-PERF] line: the cheap window meta + nostr
+        // SEARCH vs the (now tiny) candidate body download vs local parse.
+        let mut fetch_ms: u128 = 0;
+        let mut parse_ms: u128 = 0;
+        // The lowest examined UID lowers the floor regardless of nostr matches.
+        if win_min < lowest_scanned { lowest_scanned = win_min; }
+
+        // Scan-depth date: INTERNALDATE-only fetch over the whole window. No
+        // bodies, so this stays tiny even at 500. Min over the window matches
+        // the old per-fetched-message minimum.
+        let t_meta = std::time::Instant::now();
+        for chunk in window.chunks(FETCH_BATCH) {
+            let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
+            if let Ok(msgs) = session.uid_fetch(&uid_list, "(UID INTERNALDATE)") {
+                for msg in msgs.iter() {
+                    if let Some(d) = msg.internal_date() {
+                        let d_utc = d.with_timezone(&chrono::Utc);
+                        if oldest_scanned.map_or(true, |cur| d_utc < cur) {
+                            oldest_scanned = Some(d_utc);
+                        }
+                    }
+                }
+            }
+        }
+        // Server-side narrow: which window UIDs are nostr mail? Intersect with
+        // the window (the range SEARCH may include UIDs the window excludes).
+        let candidates = search_nostr_uids_in_range(session, win_min, win_max)?;
+        let meta_ms = t_meta.elapsed().as_millis();
+        let win_set: std::collections::HashSet<u32> = window.iter().copied().collect();
+        let mut cand: Vec<u32> = candidates.into_iter().filter(|u| win_set.contains(u)).collect();
+        cand.sort_unstable();
+
+        // Body-fetch ONLY the nostr candidates.
+        for chunk in cand.chunks(FETCH_BATCH) {
             let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
             let t_fetch = std::time::Instant::now();
-            let msgs = session.uid_fetch(&uid_list, "(UID FLAGS INTERNALDATE BODY.PEEK[])")?;
+            let msgs = session.uid_fetch(&uid_list, "(UID FLAGS BODY.PEEK[])")?;
             fetch_ms += t_fetch.elapsed().as_millis();
             let t_parse = std::time::Instant::now();
             for msg in msgs.iter() {
-                if let Some(uid) = msg.uid {
-                    if uid < lowest_scanned { lowest_scanned = uid; }
-                }
-                if let Some(d) = msg.internal_date() {
-                    let d_utc = d.with_timezone(&chrono::Utc);
-                    if oldest_scanned.map_or(true, |cur| d_utc < cur) {
-                        oldest_scanned = Some(d_utc);
-                    }
-                }
                 if let Some(body) = msg.body() {
                     if let Some(mut parsed) = parse_fn(body, config) {
                         parsed.seen = Some(msg.flags().iter().any(|f| matches!(f, imap::types::Flag::Seen)));
@@ -6435,12 +6501,11 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
             }
             parse_ms += t_parse.elapsed().as_millis();
         }
-        scanned += end - start;
+        debug_log!("[RUST-PERF] walk_back_collecting: meta+search={}ms, body_fetch={}ms, parse={}ms ({} examined, {} nostr-candidate, {} match)",
+            meta_ms, fetch_ms, parse_ms, scanned, cand.len(), emails.len());
     }
 
     let hit_bottom = scanned >= uids_sorted.len();
-    debug_log!("[RUST-PERF] walk_back_collecting: fetch={}ms, parse={}ms ({} scanned, {} match)",
-        fetch_ms, parse_ms, scanned, emails.len());
     Ok(CountWalk { emails, lowest_scanned, scanned, hit_bottom, oldest_scanned })
 }
 

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -5215,12 +5215,22 @@ fn persist_inbox_raw_emails(
         });
     }
 
+    // DB-lookup time vs DB-write time, plus insert/update split, so a slow
+    // persist phase ([RUST-PERF] sync_nostr) can be attributed. This loop is
+    // pure SQLite I/O — decryption is on-demand at read time, not here.
+    let candidate_count = emails.len();
+    let mut lookup_ms: u128 = 0;
+    let mut write_ms: u128 = 0;
+    let mut update_count = 0usize;
     let mut new_count = 0;
     for email in emails {
+        let t_lookup = std::time::Instant::now();
         let existing_email = db
             .get_email(&email.message_id)
             .map_err(|e| anyhow::anyhow!("Failed to check email {} in DB: {}", email.message_id, e))?;
+        lookup_ms += t_lookup.elapsed().as_millis();
 
+        let t_write = std::time::Instant::now();
         if let Some(existing_email) = existing_email {
             let updated_email = DbEmail {
                 id: existing_email.id,
@@ -5249,6 +5259,7 @@ fn persist_inbox_raw_emails(
                 thread_id: None,
             };
             db.save_email(&updated_email)?;
+            update_count += 1;
         } else {
             let db_email = DbEmail {
                 id: None,
@@ -5284,7 +5295,10 @@ fn persist_inbox_raw_emails(
             persist_attachments_for_email(db, &email, email_id);
             new_count += 1;
         }
+        write_ms += t_write.elapsed().as_millis();
     }
+    debug_log!("[RUST-PERF] persist_inbox_raw_emails: {} candidates, lookup={}ms, write={}ms ({} new, {} updated)",
+        candidate_count, lookup_ms, write_ms, new_count, update_count);
     Ok(new_count)
 }
 
@@ -5425,8 +5439,12 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
     let mut pending_gap_examined: Vec<(String, u32, u32, u32)> = Vec::new();
     let mut raw_nostr_emails: Vec<RawNostrEmail> = Vec::new();
 
+    let t_total = std::time::Instant::now();
     let target = ImapTarget::from_config(config);
+    let t_checkout = std::time::Instant::now();
     let mut session = imap_pool::checkout(&target)?;
+    let checkout_ms = t_checkout.elapsed().as_millis();
+    let t_moves = std::time::Instant::now();
     if spam_rescue {
         let moved = rescue_nostr_emails_from_spam(&mut session, &rescue_target, /* unseen_only = */ true);
         if moved > 0 {
@@ -5453,8 +5471,14 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
         }
     }
 
+    let moves_ms = t_moves.elapsed().as_millis();
+
     println!("[RUST] sync_nostr_emails_to_db: folders to scan: {:?}", folders);
+    // Per-folder scan time, accumulated so the [RUST-PERF] summary can show
+    // which folder (or the persist/move phase) dominates a slow sync.
+    let t_scan = std::time::Instant::now();
     for f in &folders {
+        let t_folder = std::time::Instant::now();
         // Bootstrap scans a window of `count` messages per folder ("Messages to
         // Load Per Folder" / per-folder override), surfacing the nostr mail in
         // it — same scan-window model as the scroll. Passing `count` as both the
@@ -5490,10 +5514,17 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
                 Err(e) => debug_log!("[RUST] sync_nostr_emails_to_db: gap_fill folder '{}' failed: {}", f, e),
             }
         }
+        debug_log!("[RUST-PERF] sync_nostr: folder '{}' scan+gapfill={}ms (running total {} raw match)",
+            f, t_folder.elapsed().as_millis(), raw_nostr_emails.len());
     }
+    let scan_ms = t_scan.elapsed().as_millis();
     imap_pool::checkin(&target, session);
 
+    let raw_match_count = raw_nostr_emails.len();
+    let t_persist = std::time::Instant::now();
     let new_count = persist_inbox_raw_emails(raw_nostr_emails, db, require_signature)?;
+    let persist_ms = t_persist.elapsed().as_millis();
+    let t_commit = std::time::Instant::now();
 
     // Commit per-folder UID watermarks now that the DB writes have all succeeded.
     // A partial-batch failure earlier returned Err and we never reach here, so
@@ -5535,7 +5566,11 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
         }
     }
 
+    let commit_ms = t_commit.elapsed().as_millis();
     debug_log!("[RUST] sync_nostr_emails_to_db: Completed sync, {} new emails saved", new_count);
+    debug_log!("[RUST-PERF] sync_nostr TOTAL={}ms = checkout={}ms + moves={}ms + scan={}ms + persist={}ms + commit={}ms ({} folders, {} raw match, {} new, gap_fill={})",
+        t_total.elapsed().as_millis(), checkout_ms, moves_ms, scan_ms, persist_ms, commit_ms,
+        folders.len(), raw_match_count, new_count, include_gap_fill);
     Ok(new_count)
 }
 
@@ -5735,6 +5770,7 @@ pub async fn refresh_sent_emails_to_db(config: &EmailConfig, active_pubkey: &str
 
 async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str, db: &Database, include_gap_fill: bool) -> anyhow::Result<usize> {
     debug_log!("[RUST] sync_sent_emails_to_db: Starting sync for email: {}", config.email_address);
+    let t_total = std::time::Instant::now();
     let account_key = config.email_address.trim().to_lowercase();
 
     // See sync_nostr_emails_to_db for the meaning of the 4-tuple.
@@ -5755,6 +5791,7 @@ async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str,
     // wastes body fetches, and lets both passes fight over its
     // folder_sync_state watermark. Sent-vs-Inbox is decided at query time by
     // from_address, not by which folder a row came from.
+    let t_scan = std::time::Instant::now();
     for f in [sent_folder.as_str()] {
         // Scan a window of `count` messages per folder (see sync_nostr_emails_to_db).
         let count = lookup_folder_count(db, active_pubkey, f);
@@ -5787,10 +5824,13 @@ async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str,
             }
         }
     }
+    let scan_ms = t_scan.elapsed().as_millis();
     imap_pool::checkin(&target, session);
 
     debug_log!("[RUST] sync_sent_emails_to_db: Fetched {} emails from IMAP", raw_sent_emails.len());
 
+    let raw_match_count = raw_sent_emails.len();
+    let t_persist = std::time::Instant::now();
     let mut new_count = 0;
     debug_log!("[RUST] sync_sent_emails_to_db: Processing {} emails for saving", raw_sent_emails.len());
     for (idx, email) in raw_sent_emails.iter().enumerate() {
@@ -5950,6 +5990,7 @@ async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str,
             }
         }
     }
+    let persist_ms = t_persist.elapsed().as_millis();
     // Commit per-folder UID watermarks after all per-message DB writes succeeded.
     for (folder_name, uid_validity, max_uid, bootstrap_min) in pending_state {
         if let Err(e) = db.set_folder_sync_state(&account_key, &folder_name, uid_validity, max_uid) {
@@ -5986,6 +6027,8 @@ async fn sync_sent_emails_to_db_inner(config: &EmailConfig, active_pubkey: &str,
     }
 
     debug_log!("[RUST] sync_sent_emails_to_db: Completed sync, {} new emails saved", new_count);
+    debug_log!("[RUST-PERF] sync_sent TOTAL={}ms = scan={}ms + persist={}ms (folder '{}', {} raw match, {} new, gap_fill={})",
+        t_total.elapsed().as_millis(), scan_ms, persist_ms, sent_folder, raw_match_count, new_count, include_gap_fill);
     Ok(new_count)
 }
 
@@ -6179,8 +6222,12 @@ fn uid_sync_folder<S: std::io::Read + std::io::Write>(
         let next = stored.as_ref().unwrap().last_seen_uid.saturating_add(1);
         let query = format!("UID {}:*", next);
         debug_log!("[RUST] uid_sync_folder: '{}' UID SEARCH {}", folder_name, query);
+        let t_search = std::time::Instant::now();
         let uid_set = session.uid_search(&query)?;
+        let search_ms = t_search.elapsed().as_millis();
         if uid_set.is_empty() {
+            debug_log!("[RUST-PERF] uid_sync_folder '{}' incremental: search={}ms, 0 new UIDs",
+                folder_name, search_ms);
             return Ok(UidSyncResult {
                 emails: vec![], uid_validity, max_uid: 0, min_uid: 0, had_existing_state,
             });
@@ -6195,11 +6242,19 @@ fn uid_sync_folder<S: std::io::Read + std::io::Write>(
         const FETCH_BATCH: usize = 500;
         let mut emails: Vec<RawNostrEmail> = Vec::new();
         let mut max_uid: u32 = 0;
+        // IMAP body-download time vs in-process parse time, summed across
+        // batches. Surfaced via [RUST-PERF] so a slow sync can be attributed
+        // to the network (fetch) or the CPU (parse/detection).
+        let mut fetch_ms: u128 = 0;
+        let mut parse_ms: u128 = 0;
         for chunk in uids.chunks(FETCH_BATCH) {
             let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
             // BODY.PEEK[] (not RFC822) so reading a message body never *sets* \Seen.
             // FLAGS lets us read the server's \Seen and seed local read state.
+            let t_fetch = std::time::Instant::now();
             let messages = session.uid_fetch(&uid_list, "(UID FLAGS BODY.PEEK[])")?;
+            fetch_ms += t_fetch.elapsed().as_millis();
+            let t_parse = std::time::Instant::now();
             for msg in messages.iter() {
                 if let Some(uid) = msg.uid {
                     if uid > max_uid { max_uid = uid; }
@@ -6211,7 +6266,10 @@ fn uid_sync_folder<S: std::io::Read + std::io::Write>(
                     }
                 }
             }
+            parse_ms += t_parse.elapsed().as_millis();
         }
+        debug_log!("[RUST-PERF] uid_sync_folder '{}' incremental: search={}ms, fetch={}ms, parse={}ms ({} UIDs, {} match)",
+            folder_name, search_ms, fetch_ms, parse_ms, uids.len(), emails.len());
         return Ok(UidSyncResult { emails, uid_validity, max_uid, min_uid, had_existing_state });
     }
 
@@ -6225,7 +6283,9 @@ fn uid_sync_folder<S: std::io::Read + std::io::Write>(
         println!("[RUST] uid_sync_folder: no stored state for '{}', bootstrapping", folder_name);
     }
 
+    let t_search = std::time::Instant::now();
     let uid_set = session.uid_search("UID 1:*")?;
+    let search_ms = t_search.elapsed().as_millis();
     if uid_set.is_empty() {
         return Ok(UidSyncResult {
             emails: vec![], uid_validity, max_uid: 0, min_uid: 0, had_existing_state,
@@ -6239,6 +6299,8 @@ fn uid_sync_folder<S: std::io::Read + std::io::Write>(
     let target = target_count.max(1);
     println!("[RUST] uid_sync_folder: '{}' bootstrap — {} UIDs in folder, target {} match(es), max_scan {}",
         folder_name, uids.len(), target, max_scan);
+    debug_log!("[RUST-PERF] uid_sync_folder '{}' bootstrap: search(UID 1:*)={}ms ({} UIDs)",
+        folder_name, search_ms, uids.len());
 
     // Seed `lowest_scanned` at the watermark so a no-op walk never claims to
     // have scanned below it; the walk lowers it to the oldest UID it touches,
@@ -6335,6 +6397,11 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
     let mut scanned: usize = 0;
     let mut lowest_scanned: u32 = floor_init;
     let mut oldest_scanned: Option<chrono::DateTime<chrono::Utc>> = None;
+    // IMAP body-download time vs in-process parse time, summed across batches
+    // (see uid_sync_folder). Drives the [RUST-PERF] line so a slow backward
+    // walk can be pinned on the network or the CPU.
+    let mut fetch_ms: u128 = 0;
+    let mut parse_ms: u128 = 0;
 
     // Cap each UID FETCH line at ~500 UIDs to stay under Gmail's ~8KB IMAP line
     // limit. `take` can be large on bootstrap (a deep count target), so split
@@ -6345,7 +6412,10 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
     {
         for chunk in uids_sorted[start..end].chunks(FETCH_BATCH) {
             let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
+            let t_fetch = std::time::Instant::now();
             let msgs = session.uid_fetch(&uid_list, "(UID FLAGS INTERNALDATE BODY.PEEK[])")?;
+            fetch_ms += t_fetch.elapsed().as_millis();
+            let t_parse = std::time::Instant::now();
             for msg in msgs.iter() {
                 if let Some(uid) = msg.uid {
                     if uid < lowest_scanned { lowest_scanned = uid; }
@@ -6363,11 +6433,14 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
                     }
                 }
             }
+            parse_ms += t_parse.elapsed().as_millis();
         }
         scanned += end - start;
     }
 
     let hit_bottom = scanned >= uids_sorted.len();
+    debug_log!("[RUST-PERF] walk_back_collecting: fetch={}ms, parse={}ms ({} scanned, {} match)",
+        fetch_ms, parse_ms, scanned, emails.len());
     Ok(CountWalk { emails, lowest_scanned, scanned, hit_bottom, oldest_scanned })
 }
 
@@ -6483,11 +6556,14 @@ fn fetch_older_in_folder<S: std::io::Read + std::io::Write>(
     // entire history (`UID 1:floor-1`), which on a large INBOX returns 100k+
     // UIDs every scroll just to scan the newest `scan_window`. The window
     // expands until it holds at least `scan_window` existing UIDs or reaches UID 1.
+    let t_window = std::time::Instant::now();
     let (uids, window_reached_bottom) = search_uid_window_below(session, floor_uid, scan_window)?;
     debug_log!(
         "[RUST] fetch_older_in_folder: '{}' windowed search below {} -> {} candidate UID(s), reached_bottom={}",
         folder_name, floor_uid, uids.len(), window_reached_bottom
     );
+    debug_log!("[RUST-PERF] fetch_older_in_folder '{}': window_search={}ms ({} candidates, floor {})",
+        folder_name, t_window.elapsed().as_millis(), uids.len(), floor_uid);
     if uids.is_empty() {
         // The window walked all the way to UID 1 with nothing below the floor —
         // true bottom. Floor moves to 1 so subsequent calls short-circuit.

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -6459,27 +6459,26 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
         // The lowest examined UID lowers the floor regardless of nostr matches.
         if win_min < lowest_scanned { lowest_scanned = win_min; }
 
-        // Scan-depth date: INTERNALDATE-only fetch over the whole window. No
-        // bodies, so this stays tiny even at 500. Min over the window matches
-        // the old per-fetched-message minimum.
-        let t_meta = std::time::Instant::now();
-        for chunk in window.chunks(FETCH_BATCH) {
-            let uid_list = chunk.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
-            if let Ok(msgs) = session.uid_fetch(&uid_list, "(UID INTERNALDATE)") {
-                for msg in msgs.iter() {
-                    if let Some(d) = msg.internal_date() {
-                        let d_utc = d.with_timezone(&chrono::Utc);
-                        if oldest_scanned.map_or(true, |cur| d_utc < cur) {
-                            oldest_scanned = Some(d_utc);
-                        }
-                    }
+        // Scan-depth date: INTERNALDATE of the single oldest window UID
+        // (`win_min`). Earlier this fetched all N dates just to take the min —
+        // wasteful at a 500 window. The floor advances by UID, so anchoring the
+        // "scanned back to <date>" indicator to the floor UID is both cheap (one
+        // tiny fetch) and consistent with how far back the floor actually moved.
+        let t_idate = std::time::Instant::now();
+        if let Ok(msgs) = session.uid_fetch(win_min.to_string(), "(UID INTERNALDATE)") {
+            for msg in msgs.iter() {
+                if let Some(d) = msg.internal_date() {
+                    oldest_scanned = Some(d.with_timezone(&chrono::Utc));
                 }
             }
         }
+        let idate_ms = t_idate.elapsed().as_millis();
+
         // Server-side narrow: which window UIDs are nostr mail? Intersect with
         // the window (the range SEARCH may include UIDs the window excludes).
+        let t_search = std::time::Instant::now();
         let candidates = search_nostr_uids_in_range(session, win_min, win_max)?;
-        let meta_ms = t_meta.elapsed().as_millis();
+        let search_ms = t_search.elapsed().as_millis();
         let win_set: std::collections::HashSet<u32> = window.iter().copied().collect();
         let mut cand: Vec<u32> = candidates.into_iter().filter(|u| win_set.contains(u)).collect();
         cand.sort_unstable();
@@ -6501,8 +6500,8 @@ fn walk_back_collecting<S: std::io::Read + std::io::Write>(
             }
             parse_ms += t_parse.elapsed().as_millis();
         }
-        debug_log!("[RUST-PERF] walk_back_collecting: meta+search={}ms, body_fetch={}ms, parse={}ms ({} examined, {} nostr-candidate, {} match)",
-            meta_ms, fetch_ms, parse_ms, scanned, cand.len(), emails.len());
+        debug_log!("[RUST-PERF] walk_back_collecting: idate={}ms, nostr_search={}ms, body_fetch={}ms, parse={}ms ({} examined, {} nostr-candidate, {} match)",
+            idate_ms, search_ms, fetch_ms, parse_ms, scanned, cand.len(), emails.len());
     }
 
     let hit_bottom = scanned >= uids_sorted.len();

--- a/tauri-app/frontend/index.html
+++ b/tauri-app/frontend/index.html
@@ -779,17 +779,11 @@
                         </div>
                         
                         <div class="form-group">
-                            <label for="sync-initial-count">Messages to Load Per Folder:</label>
+                            <label for="sync-initial-count">Messages Scanned Per Folder:</label>
                             <input type="number" id="sync-initial-count" placeholder="50" min="1" max="100000" value="50">
-                            <small class="form-text text-muted">How many nostr emails to load per folder on first sync. The dedicated <code>nostr-mail</code> folder loads deeper by default. Scroll up to load more. Default: 50.</small>
+                            <small class="form-text text-muted">How many messages to scan per folder — both on first sync and each time you scroll to load older mail — surfacing any nostr mail found. The dedicated <code>nostr-mail</code> folder scans deeper by default. Default: 50.</small>
                         </div>
 
-                        <div class="form-group">
-                            <label for="sync-max-scan">Max Messages to Scan (mixed folders):</label>
-                            <input type="number" id="sync-max-scan" placeholder="2000" min="50" max="1000000" value="2000">
-                            <small class="form-text text-muted">Upper bound on raw messages examined per folder when finding nostr mail. Caps the cost on sparse folders like a busy INBOX. Default: 2000.</small>
-                        </div>
-                        
                         <div class="form-group">
                             <label for="emails-per-page">Emails Per Page:</label>
                             <input type="number" id="emails-per-page" placeholder="50" min="10" max="500" value="50">

--- a/tauri-app/frontend/js/app.js
+++ b/tauri-app/frontend/js/app.js
@@ -269,8 +269,7 @@ NostrMailApp.prototype.loadSettings = async function() {
                         use_tls: dbSettings.use_tls === 'true',
                         email_filter: dbSettings.email_filter || 'nostr',
                         send_matching_dm: dbSettings.send_matching_dm !== 'false', // Default to true if not set
-                        sync_initial_count: parseInt(dbSettings.sync_initial_count) || 50, // Messages to load per folder
-                        sync_max_scan: parseInt(dbSettings.sync_max_scan) || 2000, // Raw-message scan cap for sparse folders
+                        sync_initial_count: parseInt(dbSettings.sync_initial_count) || 50, // Messages scanned per folder
                         emails_per_page: parseInt(dbSettings.emails_per_page) || 50, // Default to 50
                         inbox_folder: dbSettings.inbox_folder || '',
                         require_signature: dbSettings.require_signature !== 'false', // Default to true if not set
@@ -331,7 +330,6 @@ NostrMailApp.prototype.resetSettingsToDefaults = async function() {
         email_filter: 'nostr',
         send_matching_dm: true,
         sync_initial_count: 50,
-        sync_max_scan: 2000,
         emails_per_page: 50,
         inbox_folder: '',
         require_signature: true,
@@ -383,8 +381,7 @@ NostrMailApp.prototype.resetSettingsToDefaultsForPubkey = function(pubkey) {
         use_tls: true,
         email_filter: 'nostr',
         send_matching_dm: true,
-        sync_initial_count: 50, // Messages to load per folder (matching loadSettingsForPubkey)
-        sync_max_scan: 2000, // Raw-message scan cap for sparse folders
+        sync_initial_count: 50, // Messages scanned per folder (matching loadSettingsForPubkey)
         emails_per_page: 50,
         inbox_folder: '',
         require_signature: true,
@@ -449,8 +446,7 @@ NostrMailApp.prototype.loadSettingsForPubkey = async function(pubkey) {
                 use_tls: dbSettings.use_tls === 'true',
                 email_filter: dbSettings.email_filter || 'nostr',
                 send_matching_dm: dbSettings.send_matching_dm !== 'false', // Default to true if not set
-                sync_initial_count: parseInt(dbSettings.sync_initial_count) || 50, // Messages to load per folder
-                sync_max_scan: parseInt(dbSettings.sync_max_scan) || 2000, // Raw-message scan cap for sparse folders
+                sync_initial_count: parseInt(dbSettings.sync_initial_count) || 50, // Messages scanned per folder
                 emails_per_page: parseInt(dbSettings.emails_per_page) || 50, // Default to 50
                 inbox_folder: dbSettings.inbox_folder || '',
                 require_signature: dbSettings.require_signature !== 'false', // Default to true if not set
@@ -3116,7 +3112,6 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
                 email_filter: (loadedSettings && loadedSettings.email_filter) ? loadedSettings.email_filter : (domManager.getValue('emailFilterPreference') || 'nostr'),
                 send_matching_dm: (loadedSettings && loadedSettings.send_matching_dm !== undefined) ? loadedSettings.send_matching_dm : (domManager.get('send-matching-dm-preference')?.checked !== false),
                 sync_initial_count: (loadedSettings && loadedSettings.sync_initial_count) ? loadedSettings.sync_initial_count : (parseInt(domManager.getValue('syncInitialCount')) || 50),
-                sync_max_scan: (loadedSettings && loadedSettings.sync_max_scan) ? loadedSettings.sync_max_scan : (parseInt(domManager.getValue('syncMaxScan')) || 2000),
                 emails_per_page: (loadedSettings && loadedSettings.emails_per_page) ? loadedSettings.emails_per_page : (parseInt(domManager.getValue('emailsPerPage')) || 50),
                 inbox_folder: (loadedSettings && loadedSettings.inbox_folder !== undefined) ? loadedSettings.inbox_folder : readInboxFolderSelection(),
                 require_signature: (loadedSettings && loadedSettings.require_signature !== undefined) ? loadedSettings.require_signature : (domManager.get('require-signature-preference')?.checked !== false),
@@ -3158,8 +3153,7 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
                 use_tls: domManager.get('use-tls')?.checked || false,
                 email_filter: domManager.getValue('emailFilterPreference') || 'nostr',
                 send_matching_dm: domManager.get('send-matching-dm-preference')?.checked !== false, // Default to true
-                sync_initial_count: parseInt(domManager.getValue('syncInitialCount')) || 50, // Messages to load per folder
-                sync_max_scan: parseInt(domManager.getValue('syncMaxScan')) || 2000, // Raw-message scan cap for sparse folders
+                sync_initial_count: parseInt(domManager.getValue('syncInitialCount')) || 50, // Messages scanned per folder
                 emails_per_page: parseInt(domManager.getValue('emailsPerPage')) || 50, // Default to 50
                 inbox_folder: readInboxFolderSelection(),
                 require_signature: domManager.get('require-signature-preference')?.checked !== false, // Default to true
@@ -3208,7 +3202,6 @@ NostrMailApp.prototype.saveSettings = async function(showNotification = false) {
             settingsMap.set('email_filter', settings.email_filter);
             settingsMap.set('send_matching_dm', settings.send_matching_dm.toString());
             settingsMap.set('sync_initial_count', settings.sync_initial_count.toString());
-            settingsMap.set('sync_max_scan', settings.sync_max_scan.toString());
             settingsMap.set('emails_per_page', settings.emails_per_page.toString());
             settingsMap.set('inbox_folder', settings.inbox_folder || '');
             settingsMap.set('require_signature', settings.require_signature.toString());
@@ -3328,7 +3321,6 @@ NostrMailApp.prototype.setupAutoSaveSettings = function() {
         'include-sig-header-preference',
         'include-recipient-header-preference',
         'syncInitialCount',
-        'syncMaxScan',
         'emailsPerPage',
         'inboxFolderPreference',
         'glossiaEncodingBody',
@@ -3597,7 +3589,6 @@ NostrMailApp.prototype.populateSettingsForm = async function() {
         domManager.get('use-tls').checked = settings.use_tls || false;
         domManager.setValue('emailFilterPreference', settings.email_filter || 'nostr');
         domManager.setValue('syncInitialCount', settings.sync_initial_count || 50);
-        domManager.setValue('syncMaxScan', settings.sync_max_scan || 2000);
         domManager.setValue('emailsPerPage', settings.emails_per_page || 50);
         // Inbox folders: the <option> list is per-account (driven by the
         // active user's IMAP server). Seed Tom Select with the persisted

--- a/tauri-app/frontend/js/dom-manager.js
+++ b/tauri-app/frontend/js/dom-manager.js
@@ -116,7 +116,6 @@ class DOMManager {
             'include-sig-header-preference': this.getElement('include-sig-header-preference'),
             'include-recipient-header-preference': this.getElement('include-recipient-header-preference'),
             syncInitialCount: this.getElement('sync-initial-count'),
-            syncMaxScan: this.getElement('sync-max-scan'),
             emailsPerPage: this.getElement('emails-per-page'),
             inboxFolderPreference: this.getElement('inbox-folder-preference'),
             testEmailConnectionBtn: this.getElement('test-email-connection-btn'),

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -3029,15 +3029,18 @@ class EmailService {
             // rather than declaring the server empty.
             const newCount = result?.new_count ?? 0;
             const hitBottom = result?.hit_bottom === true;
-            console.log(`[JS] Infinite scroll: fetch_older_inbox_emails newCount=${newCount}, hitBottom=${hitBottom}`);
+            const oldest = this._formatScanDate(result?.oldest_scanned);
+            console.log(`[JS] Infinite scroll: fetch_older_inbox_emails newCount=${newCount}, hitBottom=${hitBottom}, oldest=${result?.oldest_scanned ?? 'n/a'}`);
             if (newCount > 0) {
                 this.inboxHasMoreInDb = true;
                 this.inboxServerFetchTried = false;
                 await this.loadEmails('', true);
             } else if (hitBottom) {
-                this._setListStatus('email-list', 'No older emails on server');
+                const back = oldest ? ` (oldest ${oldest})` : '';
+                this._setListStatus('email-list', `No older emails on server${back}`);
             } else {
-                this._setListStatus('email-list', 'No nostr matches in this batch — scroll for more');
+                const back = oldest ? ` back to ${oldest}` : ' in this batch';
+                this._setListStatus('email-list', `No nostr matches${back} — scroll for more`);
                 this.inboxServerFetchTried = false;
             }
         } catch (e) {
@@ -3053,21 +3056,38 @@ class EmailService {
             const result = await TauriService.fetchOlderSentEmails(pageSize);
             const newCount = result?.new_count ?? 0;
             const hitBottom = result?.hit_bottom === true;
-            console.log(`[JS] Infinite scroll: fetch_older_sent_emails newCount=${newCount}, hitBottom=${hitBottom}`);
+            const oldest = this._formatScanDate(result?.oldest_scanned);
+            console.log(`[JS] Infinite scroll: fetch_older_sent_emails newCount=${newCount}, hitBottom=${hitBottom}, oldest=${result?.oldest_scanned ?? 'n/a'}`);
             if (newCount > 0) {
                 this.sentHasMoreInDb = true;
                 this.sentServerFetchTried = false;
                 await this.loadSentEmails('', true);
             } else if (hitBottom) {
-                this._setListStatus('sent-list', 'No older emails on server');
+                const back = oldest ? ` (oldest ${oldest})` : '';
+                this._setListStatus('sent-list', `No older emails on server${back}`);
             } else {
-                this._setListStatus('sent-list', 'No nostr matches in this batch — scroll for more');
+                const back = oldest ? ` back to ${oldest}` : ' in this batch';
+                this._setListStatus('sent-list', `No nostr matches${back} — scroll for more`);
                 this.sentServerFetchTried = false;
             }
         } catch (e) {
             console.error('[JS] Infinite scroll sent server fetch failed:', e);
             this._setListStatus('sent-list', 'Failed to fetch older emails');
         }
+    }
+
+    // Format a backend `oldest_scanned` value (RFC3339 string from the server's
+    // INTERNALDATE, or null) as a local YYYY-MM-DD date for the scroll status.
+    // Tells the user how far back a "no matches in this batch" scan reached.
+    // Returns '' when the input is missing or unparseable.
+    _formatScanDate(isoString) {
+        if (!isoString) return '';
+        const d = new Date(isoString);
+        if (isNaN(d.getTime())) return '';
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
     }
 
     _setListStatus(listId, htmlMessage) {


### PR DESCRIPTION
## Summary

Backward "load older" pagination and the initial bootstrap sync now share **one model and one setting**, and each scroll reports **how far back it reached**.

## Changes

- **Scroll reports scan depth** — the infinite-scroll fetch returns the oldest `INTERNALDATE` it examined (`oldest_scanned`), threaded through `CountWalk → FetchOlderResult → FetchOlderSummary`. The list status now shows e.g. *"No nostr matches back to 2024-03-14 — scroll for more"* and *"No older emails on server (oldest …)"*.
- **Bounded-window UID search** — replaces the unbounded `UID 1:floor` enumeration with an expanding window search (`search_uid_window_below`). A dense INBOX resolves in one small `SEARCH` instead of returning 100k+ UIDs per scroll. `hit_bottom` is computed correctly (`window_reached_bottom && walk.hit_bottom`).
- **Single-knob scroll** — each scroll scans a fixed window of N messages per folder and surfaces every nostr match (no match-count early exit).
- **Unified setting** — bootstrap *and* scroll both use the per-folder count (`sync_initial_count` / per-folder override, deeper for `nostr-mail`) as the scan window.
- **Removed `sync_max_scan`** — UI field, dom-manager mapping, all `app.js` refs, and backend `lookup_scan_window` / `DEFAULT_SCROLL_SCAN_WINDOW` / `BOOTSTRAP_MAX_SCAN`. The surviving field is relabeled **"Messages Scanned Per Folder"** with updated help text.

## Migration note

Any value previously saved under the `sync_max_scan` DB key is now ignored (orphaned, harmless). Scroll depth follows `sync_initial_count`. Both defaulted to 50, so most users see no change.

## Testing

- Backend compiles clean (`cargo build`); `next_back_batch` unit tests pass.
- Frontend JS syntax-checked (`node --check`).
- `search_uid_window_below` has no unit test (needs a live IMAP session); logic verified by inspection.
- ⚠️ Verified on desktop (imap 2.4.1) only. Android uses imap 3.0-alpha.15 with the identical `internal_date()` API — worth a sanity APK build before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)