### PR TITLE
Fix forgeable transport-auth verdict; add SECURITY.md (#101)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,160 @@
+# Security Policy
+
+This document states nostr-mail's threat model and trust model, and records
+what each authentication signal in the app does and does not prove. It is meant
+to be read alongside the protocol spec; where the two disagree, the spec's
+normative sections win, but the trust framing here is authoritative.
+
+## Reporting a vulnerability
+
+Please report security issues privately to the maintainer rather than opening a
+public issue:
+
+- Email the project owner (see the repository's primary contact), or
+- Open a [GitHub security advisory](https://github.com/asherp/nostr-mail/security/advisories/new).
+
+Include a description, affected version/commit, and a proof-of-concept if you
+have one. We will acknowledge receipt and coordinate a fix and disclosure
+timeline with you.
+
+## Threat model
+
+nostr-mail carries end-to-end encrypted, signed mail over ordinary email
+transport (SMTP/IMAP) while rooting identity in Nostr keys. We assume the
+following adversaries are *in scope* — the design must remain safe against them:
+
+- **A malicious or compromised mail server (the user's own provider included).**
+  An IMAP/SMTP server can read, drop, delay, reorder, duplicate, or inject
+  messages and headers in either direction. It can fabricate transport metadata
+  (including `Authentication-Results`, `Received`, and other trace headers). It
+  must not be able to forge a contact's Nostr signature or learn plaintext of
+  end-to-end encrypted content.
+- **A network / header-injection adversary.** Anyone who can place bytes into a
+  message we receive — a sender, an intermediate relay, or an on-path attacker —
+  can add or alter headers. Any control decision we make from cleartext headers
+  must assume those headers are attacker-chosen unless they are cryptographically
+  bound or were stamped inside our own trust boundary.
+- **A malicious sender / spoofer.** A sender may lie in the SMTP envelope, the
+  `From:` header, the body, and any self-asserted Nostr metadata
+  (`X-Nostr-Pubkey`, profile fields). Self-assertion is never proof.
+
+Out of scope (mitigated by other means or accepted): a fully compromised local
+device / OS keystore, a malicious build of the app, denial of service (a hostile
+provider can always refuse to deliver), and traffic-analysis metadata inherent to
+using email transport (sender/recipient addresses, timing, sizes).
+
+### Lesson incorporated
+
+The transport-auth hardening in this codebase follows the header-precedence
+finding in [*Cryptographic Analysis of Delta Chat*, USENIX Security '24
+(ePrint 2024/918)](https://eprint.iacr.org/2024/918): **do not trust cleartext
+control data that has an authenticated counterpart, and when you must read a
+provider-added header, select and verify the one your own trust boundary added —
+not whichever copy an attacker could inject.**
+
+## Trust model: npub ↔ email
+
+The durable identity in nostr-mail is the **Nostr public key (npub)**, not the
+email address.
+
+- A Nostr profile's `email` field and an SMTP `From:` address are **both
+  unauthenticated self-assertions**. Neither proves control of the mailbox, and
+  neither proves which key owns that mailbox.
+- **Trust is rooted in the npub the user deliberately follows or verifies.**
+  Email is a *derived attribute* of a trusted contact (key), not the other way
+  around.
+- **Never resolve `email → key` from arbitrary profiles to choose an encryption
+  target.** Picking "whatever key claims this email" lets any profile that
+  asserts a victim's address hijack the encryption target. Resolution must go
+  `trusted npub → its asserted email`, and the email attribute is only as
+  trustworthy as the binding that produced it (see *Email-ownership binding*).
+
+### Trust states (must be distinguished in the UI)
+
+These are not interchangeable and must not be collapsed into a single
+"signed / not signed" indicator:
+
+| State | Meaning |
+| --- | --- |
+| **verified** | Signed by the **pinned key for this contact** — the key the user anchored to this npub. |
+| **signed-but-unverified** | Carries a valid signature, but from a key **not anchored to this contact**. Cryptographically intact, identity unproven. |
+| **unsigned** | No usable signature. |
+
+`signed-but-unverified` must never be presented as `verified`. Promotion to
+`verified` happens only when the signing key is pinned to the contact — e.g. via
+the email-ownership binding below.
+
+## What transport authentication (DKIM/DMARC/SPF) does and does not prove
+
+nostr-mail reads the `Authentication-Results` (A-R) header to obtain a
+**send-side, domain-attested** signal about the visible `From:` domain. This is
+a legitimate MUA approach (RFC 8601) **only** under strict conditions, which this
+codebase now enforces (issue #101):
+
+- **Select the trusted header.** We take the **first/top-most** A-R header — the
+  one stamped by the closest hop, i.e. the user's own receiving provider — not
+  the last. Relays *prepend* trace headers, so a sender-injected A-R sits at the
+  bottom; the previous code's `.pop()` selected exactly that forgeable line.
+- **Verify the `authserv-id`.** An A-R header is honored only when its
+  authserv-id's organizational domain matches the user's configured/derived
+  provider (e.g. `mx.google.com` for Gmail). If our provider added no A-R header,
+  a sender-forged one is **not** trusted by position alone — it is rejected.
+- **SPF ≠ From-authentication.** SPF authenticates the envelope `MAIL FROM`
+  (Return-Path), not the visible `From:` header. An SPF-only pass does **not**
+  set the transport-verified flag.
+- **Relaxed DMARC alignment.** DKIM alignment is checked at the organizational-
+  domain level (RFC 7489 relaxed), so a legitimate subdomain signature
+  (`From: example.com`, `header.d: mail.example.com`) is not a false negative.
+
+What it **does not** prove:
+
+- It is **not a read-access proof** and not an ownership proof. It says a domain
+  authorized the message, not that any particular key controls the mailbox.
+- It is **not trustless against a malicious sending domain**: a domain that
+  controls its own DKIM keys can produce aligned, passing mail it fully
+  authored.
+- It **depends on trusting the receiving provider + DNS** at receipt time. It is
+  not a self-validating artifact: nothing is checked against the raw bytes
+  (no DKIM signature is cryptographically verified in-app yet, no key captured),
+  so a stored verdict is only as trustworthy as the live pipeline that produced
+  it and **cannot be re-verified offline/archivally**.
+
+Treat transport-auth as a **secondary, provider/domain-attested hint** — useful
+for filtering and spam-rescue gating — never as the identity root.
+
+## Email-ownership binding (planned)
+
+The durable, npub-rooted way to bind a key to a mailbox is a **SecureJoin-style
+quote-and-sign handshake**, building on the same signed-over-quoted-content
+primitive the reply/CONSENT mechanism already provides:
+
+1. **Challenge.** To verify `K_B ↔ bob@example.com`, Alice emails a fresh nonce
+   `N` **only** to `bob@example.com`, inside a body signed under her key `K_A`,
+   binding both `K_B` and the asserted address.
+2. **Response.** Bob replies, nesting Alice's challenge and signing over it with
+   `K_B` (equivalently, a `CONSENT` block over `H = hash(assertion)`).
+3. **Pin.** Alice verifies `K_B`'s signature covers the quoted nonce + asserted
+   address, then pins `K_B ↔ bob@example.com` — promoting the contact from
+   `signed-but-unverified` to `verified` with an email attribute attached.
+
+Properties and limits, stated honestly:
+
+- **A single message is never a self-sufficient ownership proof.** The proof is
+  the **request + response pair**, conditioned on delivery: Alice sent `N`
+  exclusively to the address; a `K_B`-signed message quoting `N` came back ⇒ the
+  holder of `K_B` had **read** access to that mailbox.
+- It is **npub-rooted, not provider-rooted**: a malicious/compromised server can
+  *block or delay* the handshake but cannot *forge* `K_B`'s signature over a
+  fresh nonce. Unlike the A-R verdict, the signed pair is **re-verifiable offline
+  and archivally**.
+- It proves *receive* control, **not** send control (the reply's SMTP `From` is
+  spoofable and irrelevant). Use fresh nonces, short expiry, and bind both `K`
+  and `E` into the signed bytes.
+
+## References
+
+- *Cryptographic Analysis of Delta Chat* — USENIX Security '24
+  ([ePrint 2024/918](https://eprint.iacr.org/2024/918)),
+  [hardening writeup](https://delta.chat/en/2024-03-25-crypto-analysis-securejoin)
+- RFC 8601 (Authentication-Results), RFC 7489 (DMARC alignment),
+  RFC 6376 (DKIM)

--- a/tauri-app/backend/src/email.rs
+++ b/tauri-app/backend/src/email.rs
@@ -3779,16 +3779,113 @@ fn extract_domain_from_email_address(from_header: &str) -> Option<String> {
     None
 }
 
-/// Get the last Authentication-Results header (trusted final MTA)
-fn get_last_authentication_results_header(email: &mailparse::ParsedMail) -> Option<String> {
-    // Get all Authentication-Results headers
-    let mut auth_results_headers: Vec<String> = email.headers
-        .get_all_values("Authentication-Results")
-        .into_iter()
-        .collect();
-    
-    // Return the last one (most recent/final MTA)
-    auth_results_headers.pop()
+/// Extract the organizational (registrable) domain from a hostname or domain.
+///
+/// Heuristic, not a full Public Suffix List: handles a small set of common
+/// multi-label suffixes (e.g. `co.uk`) and otherwise returns the last two
+/// labels. Used for DMARC relaxed alignment and for comparing an A-R header's
+/// authserv-id against the user's provider. `mx.google.com` -> `google.com`,
+/// `imap.gmail.com` -> `gmail.com`, `mail.example.co.uk` -> `example.co.uk`.
+fn organizational_domain(domain: &str) -> String {
+    let d = domain.trim().trim_end_matches('.').to_lowercase();
+    let labels: Vec<&str> = d.split('.').filter(|l| !l.is_empty()).collect();
+    if labels.len() <= 2 {
+        return labels.join(".");
+    }
+    // Two-label public suffixes where the registrable domain is the last three
+    // labels. Small curated list; extend as needed (this is not a full PSL).
+    const MULTI_SUFFIXES: &[&str] = &[
+        "co.uk", "org.uk", "gov.uk", "ac.uk", "co.jp", "co.nz", "co.za",
+        "com.au", "net.au", "org.au", "com.br", "co.in", "co.kr",
+    ];
+    let last_two = format!("{}.{}", labels[labels.len() - 2], labels[labels.len() - 1]);
+    if labels.len() >= 3 && MULTI_SUFFIXES.contains(&last_two.as_str()) {
+        return format!("{}.{}", labels[labels.len() - 3], last_two);
+    }
+    last_two
+}
+
+/// Derive the set of trusted authserv-id organizational domains for a user's
+/// provider. An `Authentication-Results` header is only honored when its
+/// authserv-id's organizational domain is in this set.
+///
+/// Seeded from the user's email domain and IMAP host (covers self-hosted /
+/// vanity-domain providers whose authserv-id shares their org domain), plus
+/// provider-specific values for major providers whose receiving MTA stamps a
+/// different org domain than the mailbox domain (e.g. Gmail's `mx.google.com`
+/// vs `gmail.com`).
+fn trusted_authserv_org_domains(email_domain: &str, imap_host: &str) -> Vec<String> {
+    let mut set: Vec<String> = Vec::new();
+    let mut push = |d: String| {
+        if !d.is_empty() && !set.contains(&d) {
+            set.push(d);
+        }
+    };
+    let email_org = organizational_domain(email_domain);
+    let imap_org = organizational_domain(imap_host);
+    for org in [email_org.as_str(), imap_org.as_str()] {
+        match org {
+            "gmail.com" | "googlemail.com" | "google.com" => push("google.com".to_string()),
+            "outlook.com" | "hotmail.com" | "live.com" | "msn.com" | "office365.com"
+            | "microsoft.com" => {
+                push("outlook.com".to_string());
+                push("microsoft.com".to_string());
+            }
+            "yahoo.com" | "ymail.com" | "yahoodns.net" => push("yahoo.com".to_string()),
+            "icloud.com" | "me.com" | "mac.com" => push("icloud.com".to_string()),
+            "proton.me" | "protonmail.com" | "pm.me" => {
+                push("proton.me".to_string());
+                push("protonmail.ch".to_string());
+            }
+            "fastmail.com" => {
+                push("fastmail.com".to_string());
+                push("messagingengine.com".to_string());
+            }
+            _ => {}
+        }
+    }
+    push(email_org);
+    push(imap_org);
+    set
+}
+
+/// Extract the authserv-id from an `Authentication-Results` header value: the
+/// token before the first `;`, with any optional trailing version number
+/// dropped. Returns it lower-cased.
+fn parse_authserv_id(header_value: &str) -> Option<String> {
+    let first = header_value.split(';').next()?.trim();
+    let id = first.split_whitespace().next()?.trim();
+    if id.is_empty() {
+        None
+    } else {
+        Some(id.to_lowercase())
+    }
+}
+
+/// Select the `Authentication-Results` header to trust: the FIRST (top-most —
+/// the closest/most-recently-prepended MTA, i.e. the user's own receiving
+/// provider) header whose authserv-id's organizational domain is in
+/// `trusted_org_domains`. Headers below it — including any an upstream relay or
+/// the *sender* injected — are ignored.
+///
+/// Position alone is insufficient: if our provider added no A-R header at all, a
+/// sender-forged header would be first, so the authserv-id gate is what actually
+/// anchors trust. Relays prepend trace headers, so the trusted provider's A-R is
+/// at the top; the previous `.pop()` selected the bottom-most (sender-injectable)
+/// header, which is forgeable (see issue #101).
+fn select_trusted_authentication_results(
+    email: &mailparse::ParsedMail,
+    trusted_org_domains: &[String],
+) -> Option<String> {
+    for value in email.headers.get_all_values("Authentication-Results") {
+        if let Some(authserv) = parse_authserv_id(&value) {
+            let authserv_org = organizational_domain(&authserv);
+            if trusted_org_domains.iter().any(|t| *t == authserv_org) {
+                return Some(value);
+            }
+        }
+    }
+    None
 }
 
 /// Parsed authentication results from Authentication-Results header
@@ -3862,16 +3959,33 @@ fn parse_authentication_results(header_value: &str) -> AuthResults {
     auth_results
 }
 
-/// Check DKIM alignment: header.from domain must match DKIM header.d domain
+/// Check DKIM alignment under DMARC *relaxed* mode: the header.from domain and
+/// the DKIM header.d domain must share an organizational domain (not be byte
+/// equal). RFC 7489 permits relaxed alignment, so requiring exact equality (the
+/// old behavior) produced false negatives for legitimate senders that sign with
+/// a subdomain (e.g. From `example.com`, header.d `mail.example.com`).
 fn check_dkim_alignment(from_domain: &str, dkim_domain: &str) -> bool {
-    from_domain.to_lowercase() == dkim_domain.to_lowercase()
+    organizational_domain(from_domain) == organizational_domain(dkim_domain)
 }
 
-/// Verify transport authentication (DMARC/DKIM/SPF) from RFC 5322 email
-/// Accepts either raw RFC 5322 bytes or a parsed mailparse::ParsedMail struct
+/// Verify transport authentication (DMARC/DKIM) of an RFC 5322 email's visible
+/// `From:` domain, by reading the `Authentication-Results` header added by the
+/// user's own receiving provider.
+///
+/// `trusted_authserv_org_domains` is the set of organizational domains whose
+/// authserv-id we trust (see [`trusted_authserv_org_domains`]). Only an A-R
+/// header stamped by one of these is honored; a sender-injected A-R is ignored.
+/// Pass an empty slice to trust no header (fails closed).
+///
+/// SPF is deliberately *not* a positive signal here: it authenticates the
+/// envelope `MAIL FROM` (Return-Path), not the visible `From:` header, so an
+/// SPF-only pass does not establish From-authentication.
+///
+/// Accepts either raw RFC 5322 bytes or a parsed `mailparse::ParsedMail`.
 pub fn verify_transport_authentication(
     raw_bytes: Option<&[u8]>,
-    parsed_email: Option<&mailparse::ParsedMail>
+    parsed_email: Option<&mailparse::ParsedMail>,
+    trusted_authserv_org_domains: &[String],
 ) -> Result<TransportAuthVerdict> {
     // Parse email if not already parsed - need to handle lifetime by parsing into owned value
     let parsed_owned: Option<mailparse::ParsedMail> = if parsed_email.is_some() {
@@ -3920,22 +4034,25 @@ pub fn verify_transport_authentication(
         }
     };
     
-    // Find the last Authentication-Results header (trusted final MTA)
-    let auth_results_header = match get_last_authentication_results_header(email) {
+    // Select the top-most Authentication-Results header stamped by a trusted
+    // authserv-id (our own receiving provider). A sender-injected A-R sits below
+    // the provider's and is ignored; if no trusted header exists we do not fall
+    // back to an untrusted one (issue #101).
+    let auth_results_header = match select_trusted_authentication_results(email, trusted_authserv_org_domains) {
         Some(header) => header,
         None => {
             return Ok(TransportAuthVerdict {
                 transport_verified: false,
                 method: TransportAuthMethod::None,
-                reason: "No Authentication-Results header found".to_string(),
+                reason: "No Authentication-Results header from a trusted authserv-id was found".to_string(),
             });
         }
     };
-    
+
     // Parse Authentication-Results header
     let auth_results = parse_authentication_results(&auth_results_header);
-    
-    // Evaluate in priority order: DMARC > DKIM > SPF
+
+    // Evaluate in priority order: DMARC > DKIM. SPF is not From-authentication.
     
     // 1. Check DMARC
     if let Some(ref dmarc_result) = auth_results.dmarc {
@@ -3988,28 +4105,16 @@ pub fn verify_transport_authentication(
         }
     }
     
-    // 3. Check SPF
-    if let Some(ref spf_result) = auth_results.spf {
-        if spf_result == "pass" {
-            return Ok(TransportAuthVerdict {
-                transport_verified: true,
-                method: TransportAuthMethod::None, // SPF is not a separate method in our enum, use "none"
-                reason: format!("SPF verification passed for domain {}", from_domain),
-            });
-        } else if spf_result == "fail" {
-            return Ok(TransportAuthVerdict {
-                transport_verified: false,
-                method: TransportAuthMethod::None,
-                reason: format!("SPF verification failed for domain {}", from_domain),
-            });
-        }
-    }
-    
-    // No authentication method passed
+    // SPF is intentionally NOT treated as From-authentication: it validates the
+    // envelope MAIL FROM (Return-Path), which can differ from the visible From:
+    // header, so an SPF-only pass must not set transport_verified. It remains
+    // available in `auth_results.spf` for diagnostics only.
+
+    // No From-authenticating method passed (DMARC/aligned-DKIM)
     Ok(TransportAuthVerdict {
         transport_verified: false,
         method: TransportAuthMethod::None,
-        reason: format!("No authentication method passed. DMARC: {:?}, DKIM: {:?}, SPF: {:?}", 
+        reason: format!("No From-authenticating method passed. DMARC: {:?}, DKIM: {:?}, SPF (envelope-only, not counted): {:?}",
             auth_results.dmarc, auth_results.dkim, auth_results.spf),
     })
 }
@@ -5178,6 +5283,129 @@ nitela\n\
         assert_eq!(manifest.attachments.as_ref().unwrap()[0].id, "a1");
         assert_eq!(manifest.attachments.as_ref().unwrap()[0].orig_filename, "test.pdf");
     }
+
+    // ---- Transport authentication (issue #101) ----
+
+    /// Gmail's trusted authserv-id org-domains: the IMAP/mailbox domain plus
+    /// Google's receiving-MTA org domain (`mx.google.com` -> `google.com`).
+    fn gmail_trusted() -> Vec<String> {
+        super::trusted_authserv_org_domains("gmail.com", "imap.gmail.com")
+    }
+
+    fn verify_transport(raw: &str, trusted: &[String]) -> bool {
+        super::verify_transport_authentication(Some(raw.as_bytes()), None, trusted)
+            .unwrap()
+            .transport_verified
+    }
+
+    #[test]
+    fn test_organizational_domain() {
+        assert_eq!(super::organizational_domain("mx.google.com"), "google.com");
+        assert_eq!(super::organizational_domain("imap.gmail.com"), "gmail.com");
+        assert_eq!(super::organizational_domain("example.com"), "example.com");
+        assert_eq!(super::organizational_domain("a.b.c.example.com"), "example.com");
+        assert_eq!(super::organizational_domain("mail.example.co.uk"), "example.co.uk");
+        assert_eq!(super::organizational_domain("EXAMPLE.COM"), "example.com");
+    }
+
+    #[test]
+    fn test_trusted_authserv_covers_gmail_mx() {
+        let trusted = gmail_trusted();
+        // Google's receiving MTA stamps mx.google.com, whose org domain must be
+        // trusted even though the mailbox domain is gmail.com.
+        assert!(trusted.contains(&"google.com".to_string()));
+        assert!(trusted.contains(&"gmail.com".to_string()));
+    }
+
+    #[test]
+    fn test_exploit_forged_bottom_ar_is_ignored() {
+        // The documented exploit: provider's real A-R is prepended at the TOP and
+        // does not authenticate the spoofed From; the attacker's forged A-R sits
+        // at the bottom. The old `.pop()` selected the bottom (forged) one.
+        let raw = "Authentication-Results: mx.google.com; dmarc=fail header.from=victim.com; dkim=none; spf=fail\n\
+                   Authentication-Results: anything.invalid; dmarc=pass header.from=victim.com\n\
+                   From: attacker <evil@victim.com>\n\
+                   Subject: spoof\n\
+                   \n\
+                   body\n";
+        assert!(!verify_transport(raw, &gmail_trusted()),
+            "forged bottom Authentication-Results must not authenticate the From");
+    }
+
+    #[test]
+    fn test_provider_added_no_ar_rejects_forged_only() {
+        // Provider added no A-R at all; only the sender's forged header exists.
+        // Selecting "first" is not enough — the authserv-id gate must reject it.
+        let raw = "Authentication-Results: anything.invalid; dmarc=pass header.from=victim.com\n\
+                   From: attacker <evil@victim.com>\n\
+                   \n\
+                   body\n";
+        assert!(!verify_transport(raw, &gmail_trusted()),
+            "an A-R from an untrusted authserv-id must never authenticate");
+    }
+
+    #[test]
+    fn test_dmarc_pass_from_trusted_authserv_verifies() {
+        let raw = "Authentication-Results: mx.google.com; dmarc=pass header.from=example.com; dkim=pass header.d=example.com; spf=pass\n\
+                   From: alice <alice@example.com>\n\
+                   \n\
+                   body\n";
+        assert!(verify_transport(raw, &gmail_trusted()));
+    }
+
+    #[test]
+    fn test_spf_only_is_not_from_authentication() {
+        // SPF authenticates the envelope MAIL FROM, not the visible From:.
+        let raw = "Authentication-Results: mx.google.com; spf=pass smtp.mailfrom=bounce.example.com; dkim=none; dmarc=none\n\
+                   From: alice <alice@example.com>\n\
+                   \n\
+                   body\n";
+        assert!(!verify_transport(raw, &gmail_trusted()),
+            "SPF-only pass must not set transport_verified");
+    }
+
+    #[test]
+    fn test_dkim_relaxed_alignment_with_subdomain() {
+        // From example.com signed by header.d=mail.example.com: relaxed alignment
+        // (shared org domain) should pass where exact equality would fail.
+        let raw = "Authentication-Results: mx.google.com; dkim=pass header.d=mail.example.com; dmarc=none; spf=none\n\
+                   From: alice <alice@example.com>\n\
+                   \n\
+                   body\n";
+        assert!(verify_transport(raw, &gmail_trusted()));
+    }
+
+    #[test]
+    fn test_dkim_unaligned_does_not_verify() {
+        let raw = "Authentication-Results: mx.google.com; dkim=pass header.d=mailer.com; dmarc=none; spf=none\n\
+                   From: alice <alice@example.com>\n\
+                   \n\
+                   body\n";
+        assert!(!verify_transport(raw, &gmail_trusted()),
+            "DKIM signed by an unrelated domain is not aligned with the From");
+    }
+
+    #[test]
+    fn test_select_first_trusted_skips_untrusted_top() {
+        // A relay above the provider may add its own (untrusted) A-R; selection
+        // must skip it and use the provider's trusted header below.
+        let raw = "Authentication-Results: relay.untrusted.example; dmarc=fail header.from=example.com\n\
+                   Authentication-Results: mx.google.com; dmarc=pass header.from=example.com\n\
+                   From: alice <alice@example.com>\n\
+                   \n\
+                   body\n";
+        assert!(verify_transport(raw, &gmail_trusted()));
+    }
+
+    #[test]
+    fn test_no_trusted_authserv_configured_fails_closed() {
+        let raw = "Authentication-Results: mx.google.com; dmarc=pass header.from=example.com\n\
+                   From: alice <alice@example.com>\n\
+                   \n\
+                   body\n";
+        assert!(!verify_transport(raw, &[]),
+            "with no trusted authserv-id, no header is honored (fail closed)");
+    }
 }
 
 
@@ -5495,8 +5723,10 @@ async fn sync_nostr_emails_to_db_inner(config: &EmailConfig, folders_arg: Option
         // Bound the per-spam-folder search to the same default load window the
         // scan uses (spam folders are small, so this rarely binds).
         let rescue_window = lookup_initial_count(db, active_pubkey);
+        let rescue_email_domain = extract_domain_from_email_address(&config.email_address).unwrap_or_default();
+        let rescue_trusted = trusted_authserv_org_domains(&rescue_email_domain, &config.imap_host);
         let moved = guarded_session_op(&mut session, &target, |s| {
-            rescue_nostr_emails_from_spam(s, &rescue_target, /* unseen_only = */ true, rescue_window)
+            rescue_nostr_emails_from_spam(s, &rescue_target, /* unseen_only = */ true, rescue_window, &rescue_trusted)
         })?.unwrap_or(0);
         if moved > 0 {
             println!("[RUST] sync_nostr_emails_to_db: spam rescue moved {} message(s) to '{}'", moved, rescue_target);
@@ -6171,7 +6401,9 @@ fn parse_nostr_email_from_imap_body_inner(
     let message_id = extract_message_id_from_headers(&raw_headers).unwrap_or_else(|| Uuid::new_v4().to_string());
 
     let transport_auth_verified = if verify_transport {
-        let verdict = verify_transport_authentication(Some(raw_body), Some(&email))
+        let email_domain = extract_domain_from_email_address(&config.email_address).unwrap_or_default();
+        let trusted = trusted_authserv_org_domains(&email_domain, &config.imap_host);
+        let verdict = verify_transport_authentication(Some(raw_body), Some(&email), &trusted)
             .unwrap_or_else(|e| TransportAuthVerdict {
                 transport_verified: false,
                 method: TransportAuthMethod::None,
@@ -7123,7 +7355,7 @@ fn extend_with_spam_folders(
 /// the inbox, stranding it where the user can't see it. Mail that fails SPF/DKIM
 /// is therefore deliberately left in spam — only authenticated nostr mail that
 /// the provider misfiled gets rescued.
-fn should_rescue_message(raw_body: &[u8]) -> bool {
+fn should_rescue_message(raw_body: &[u8], trusted_authserv: &[String]) -> bool {
     let text = String::from_utf8_lossy(raw_body);
     let has_nostr_marker = text.contains("X-Nostr-Pubkey:")
         || text.contains("X-Nostr-Sig:")
@@ -7135,7 +7367,7 @@ fn should_rescue_message(raw_body: &[u8]) -> bool {
         debug_log!("[RUST] rescue: should_rescue_message=false (no nostr marker)");
         return false;
     }
-    match verify_transport_authentication(Some(raw_body), None) {
+    match verify_transport_authentication(Some(raw_body), None, trusted_authserv) {
         Ok(verdict) => {
             if !verdict.transport_verified {
                 debug_log!("[RUST] rescue: should_rescue_message=false (has marker, transport auth NOT verified)");
@@ -7190,6 +7422,7 @@ fn rescue_nostr_emails_from_spam(
     target_folder: &str,
     unseen_only: bool,
     window: usize,
+    trusted_authserv: &[String],
 ) -> usize {
     let spam_folders = list_spam_folders(session);
     debug_log!("[RUST] rescue: spam folders found = {:?}, target = '{}', unseen_only = {}", spam_folders, target_folder, unseen_only);
@@ -7201,7 +7434,7 @@ fn rescue_nostr_emails_from_spam(
 
     let mut moved_total = 0usize;
     for folder in spam_folders {
-        moved_total += move_nostr_from_folder(session, &folder, target_folder, unseen_only, window);
+        moved_total += move_nostr_from_folder(session, &folder, target_folder, unseen_only, window, trusted_authserv);
     }
     moved_total
 }
@@ -7222,6 +7455,7 @@ fn move_nostr_from_folder(
     target_folder: &str,
     unseen_only: bool,
     window: usize,
+    trusted_authserv: &[String],
 ) -> usize {
     if folder.eq_ignore_ascii_case(target_folder) {
         return 0;
@@ -7298,7 +7532,7 @@ fn move_nostr_from_folder(
         };
         for msg in messages.iter() {
             if let (Some(uid), Some(body)) = (msg.uid, msg.body()) {
-                if should_rescue_message(body) {
+                if should_rescue_message(body, trusted_authserv) {
                     to_move.push(uid);
                 } else {
                     debug_log!("[RUST] move_nostr_from_folder: uid {} in '{}' not eligible (missing nostr marker or transport auth failed)", uid, folder);
@@ -7332,8 +7566,10 @@ fn move_nostr_from_folder(
 /// afterwards so the moved messages land in the local DB.
 pub async fn rescue_spam_now(config: &EmailConfig, target_folder: &str, window: usize) -> anyhow::Result<usize> {
     let target = ImapTarget::from_config(config);
+    let email_domain = extract_domain_from_email_address(&config.email_address).unwrap_or_default();
+    let trusted = trusted_authserv_org_domains(&email_domain, &config.imap_host);
     let moved = imap_pool::with_session(&target, |session| {
-        Ok(rescue_nostr_emails_from_spam(session, target_folder, /* unseen_only = */ false, window))
+        Ok(rescue_nostr_emails_from_spam(session, target_folder, /* unseen_only = */ false, window, &trusted))
     })?;
     Ok(moved)
 }


### PR DESCRIPTION
Closes #101.

`verify_transport_authentication` trusted the plaintext `Authentication-Results` header it selected with `.pop()` — the **bottom-most, sender-injectable** header. A sender could forge `dmarc=pass` for a spoofed `From:` and set `transport_verified = true`.

## Security fixes (must-fix)

1. **Select the first (top-most) A-R header**, stamped by the closest hop (the user's own receiving provider), not the last. Relays prepend trace headers, so a sender-injected A-R sits at the bottom — exactly what `.pop()` selected.
2. **Gate on `authserv-id`.** An A-R header is honored only when its *organizational* domain matches the user's provider, derived from the email/IMAP host with a known-provider map (so Gmail's `mx.google.com` is trusted even though the mailbox is `gmail.com`). **Fails closed** for unknown authserv-ids: a sender-forged A-R is rejected even when it's the only one present (defends the "provider added no A-R" case, where selecting "first" alone is insufficient).
3. **SPF ≠ From-authentication.** Dropped the `spf=pass → verified` branch; SPF authenticates the envelope `MAIL FROM`, not the visible `From:`. Kept for diagnostics only.

## Correctness (should-fix)

4. **Relaxed DMARC alignment.** DKIM alignment now compares organizational domains (RFC 7489 relaxed), so a legitimate subdomain signature (`From: example.com` / `header.d: mail.example.com`) is no longer a false negative.

The derived trusted-authserv set is threaded through both call sites — the inbox filter and the spam-rescue path (`should_rescue_message` → `move_nostr_from_folder` → `rescue_nostr_emails_from_spam`).

## SECURITY.md (new)

Adds the doc requested in the issue: threat model (malicious/compromised provider + header-injection adversary), the npub-rooted trust model (self-asserted addresses; resolve `trusted npub → email`, never `email → key`), the three trust states (`verified` / `signed-but-unverified` / `unsigned`), what transport-auth does and does not prove, and the planned SecureJoin-style email-ownership binding (with the request+response-pair caveat).

## Tests

10 new unit tests cover the exploit (forged bottom header ignored), the authserv-id gate (forged-only rejected), SPF-only, DMARC pass, relaxed/unaligned DKIM, header-selection skip, and fail-closed behavior.

- `cargo test --lib`: 208 passed, 0 failed
- `cargo test --test email_integration`: 21 passed
- No new compiler warnings

## Out of scope

The **optional** "real cryptographic DKIM verification in Rust" item is left for a follow-up.

https://claude.ai/code/session_01PyRdoum6RhwJnVyQnVrEJ3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyRdoum6RhwJnVyQnVrEJ3)_