### PR TITLE
Feature test checklist for landing staging → master (incl. draft rendering fix)

### DIFF
--- a/FEATURE_TEST_CHECKLIST.md
+++ b/FEATURE_TEST_CHECKLIST.md
@@ -1,0 +1,135 @@
+# Feature Test Checklist — Landing to `master`
+
+Tracking checklist for the features and fixes currently queued to land on
+`master` (from `staging`). Each item lists the user-visible behavior we are
+promising and the test that guards it. An item is **ready to land** when its
+box is checked: the code is on `staging` **and** a feature test covers the
+behavior so it can't silently regress.
+
+## How to run
+
+```bash
+# Backend integration tests (what CI runs on every PR to master/staging)
+cd tauri-app/backend && cargo test --test email_integration
+
+# Backend unit tests
+cd tauri-app/backend && cargo test --lib
+```
+
+CI: `.github/workflows/test.yml` runs `cargo test --test email_integration`
+on every push/PR to `main`, `master`, and `staging`.
+
+Legend: `[x]` code landed **and** covered by a feature test · `[ ]` code
+landed but **test still owed** before this can be considered safe to land.
+
+---
+
+## 🖋️ Draft rendering fix _(focus of this PR)_
+
+Drafts are authored by the current user and are **unsigned until sent**, so the
+inbound-protection settings (`hide_unsigned_messages` / `require_signature`)
+must never hide them — mirroring the sent-mail render path. The draft preview
+must also decode both glossia clear-signed bodies and NIP-44 encrypted bodies.
+
+Code: `email-service.js` `renderDrafts()` / `renderDraftItem()`
+(commit `5c8edce`, "Show self-authored drafts regardless of
+`hide_unsigned_messages`").
+
+- [ ] Self-authored draft renders even when `hide_unsigned_messages` /
+      `require_signature` is on (must not be filtered as "unverified")
+- [ ] NIP-44 encrypted draft body decrypts to a preview for the author
+- [ ] Glossia clear-signed draft body decodes to plaintext preview
+- [ ] Undecryptable draft is only hidden when `hide_undecryptable_emails` is on
+- [ ] Draft attachment count badge renders without blocking the list
+
+> **Owed:** a backend feature test in `email_integration.rs` exercising the
+> draft preview path (encrypted + signed bodies) — there is currently **no**
+> `draft` test in the integration suite.
+
+---
+
+## 🔏 Signing & verification
+
+Covered today by `email_integration.rs`.
+
+- [x] Header-signature roundtrip (`defaults_header_sig_roundtrip`)
+- [x] Full roundtrip with inline signature (`defaults_full_roundtrip_with_inline_sig`)
+- [x] Tampered body invalidates signature (`tampered_body_invalidates_signature`)
+- [x] Clear-signed plaintext verifies via header (`clearsigned_plaintext_verifies_via_header`)
+- [x] Inline-vs-header precedence reporting
+      (`inline_valid_header_broken_reports_body`,
+      `inline_broken_header_valid_reports_header`)
+- [x] Broken pubkey fails verification (`broken_pubkey_fails_verification`)
+- [x] `decode_sig_and_pubkey` honors schema canonical-first order
+      (branch `claude/sig-decoder-schema-order`, merged)
+
+## 🔐 Encryption (NIP-04 / NIP-44) & replies
+
+- [x] NIP-04 legacy decrypt (`nip04_legacy_decrypt`)
+- [x] NIP-04 falls back to `X-Nostr-Sig` header when no inline signature
+      (`nip04_header_sig_fallback_unlocks_decrypt`)
+- [x] Glossia latin body roundtrip (`glossia_body_latin_roundtrip`)
+- [x] Signed plaintext reply preserves nested signature
+      (`signed_plaintext_reply_preserves_nested_signature`)
+- [x] NIP-44 reply preserves nested encrypted armor
+      (`nip44_reply_preserves_nested_encrypted_armor`)
+- [x] NIP-44 three-level reply chain (`nip44_three_level_reply_chain`)
+- [x] Reply threading headers + encoded quote (`reply_threading_headers_and_encoded_quote`)
+
+## 📎 Attachments
+
+- [x] Manifest attachment compose, inline-sig verifies
+      (`manifest_attachment_compose_inline_sig_verifies`)
+- [x] Manifest attachment default js-format, inline-sig verifies
+      (`manifest_attachment_default_jsformat_inline_sig_verifies`)
+- [x] Attachments render inline in thread/conversation cards
+      (branch `claude/attachment-decrypt-fix`, merged)
+- [ ] Inbox attachment download for self-authored mail (manual; no automated test)
+
+## 📬 Sent / inbox decryption
+
+- [x] Sent mail decrypts via recipient header without a DM
+      (`sent_mail_decrypts_via_recipient_header_without_dm`)
+- [x] Sent mail undecryptable without any counterparty hint
+      (`sent_mail_undecryptable_without_any_counterparty_hint`)
+- [x] Multipart HTML + text (`multipart_html_and_text`)
+- [x] Non-ASCII subject roundtrip (`non_ascii_subject_roundtrip`)
+- [x] Quoted-printable body roundtrip (`quoted_printable_body_roundtrip`)
+
+## 🛡️ Transport authentication _(in flight — PR #103)_
+
+Hardening of `verify_transport_authentication` (forgeable `dmarc=pass`
+verdict). Targets `staging` and must land before/with this PR.
+
+- [ ] Forged bottom-most `Authentication-Results` header is ignored
+      (top-most, provider-stamped header is selected)
+- [ ] `authserv-id` gate fails closed for unknown authserv-ids
+- [ ] SPF-only does **not** mark a message From-authenticated
+- [ ] Relaxed DMARC alignment on organizational domain (subdomain DKIM passes)
+
+> Tests live on PR #103's branch (`claude/eloquent-volta-t3c4cj`); confirm
+> they are green and merged into `staging` before this lands.
+
+## 🔄 IMAP sync, folders & spam _(manual / no automated coverage yet)_
+
+- [ ] Count-based history sync (`sync_initial_count` / `sync_max_scan`)
+- [ ] Backward UID pagination / infinite scroll on inbox + sent
+- [ ] `gap_fill` examines each UID once and watermarks it (no full rescan)
+- [ ] IDLE push delivers new mail on the active account
+- [ ] Spam/junk/bulk folders kept out of the main inbox
+- [ ] Spam rescue gated on transport auth, uses `\Seen` as intent
+- [ ] `\Seen` read-state syncs in both directions
+
+## 💬 Direct messages _(manual / no automated coverage yet)_
+
+- [ ] NIP-17 DMs deduplicated by rumor id (legacy duplicates collapse)
+- [ ] Conversation pagination with lighter contact-list previews
+
+## 👥 Group / multi-recipient _(spec only — future, not landing now)_
+
+Spec landed (To/Cc roles, group encryption, CONSENT block — PRs #97/#99/#100);
+implementation and tests are future work, tracked here so they aren't lost.
+
+- [ ] Multi-recipient (group) encryption: one content key wrapped per recipient
+- [ ] To/Cc role semantics
+- [ ] CONSENT block disambiguates signing from replying

--- a/docs/nostr-mail-spec.md
+++ b/docs/nostr-mail-spec.md
@@ -1,6 +1,6 @@
 # Nostr-Mail Protocol Specification
 
-**Version:** 0.3.0-draft
+**Version:** 0.4.0-draft
 **Date:** 2026-06-13
 
 ## 1. Overview
@@ -21,9 +21,11 @@ All Nostr-Mail content is enclosed in ASCII armor blocks using `-----` delimiter
 | `BEGIN NOSTR SEAL` | Identity declaration | Sender's Nostr public key (unsigned messages only) |
 | `BEGIN NOSTR HYBRID ENCRYPTED BODY` | Multi-recipient encrypted content | AES-256-GCM ciphertext under a per-message Content Encryption Key (CEK) |
 | `BEGIN NOSTR RECIPIENTS` | Recipient key-wrap + roles | Per-recipient NIP-44-wrapped CEK, pubkey, and role |
+| `BEGIN NOSTR CONTRACT` | Explicit consent marker | A signatory's binding consent to a specific agreement (document hash + signer pubkey); see Section 11.3 |
 | `END NOSTR MESSAGE` | Closing tag | Terminates the outermost block |
 | `END NOSTR SEAL` | Closing tag | Terminates standalone seal blocks |
 | `END NOSTR RECIPIENTS` | Closing tag | Terminates a standalone recipients block |
+| `END NOSTR CONTRACT` | Closing tag | Terminates a standalone contract block |
 
 The encryption type is embedded directly in the BEGIN tag (e.g., `BEGIN NOSTR NIP-44 ENCRYPTED BODY`), keeping the format self-describing without metadata lines.
 
@@ -280,15 +282,15 @@ The Schnorr signature over `SHA-256(ciphertext_bytes)` serves as the authenticat
 
 NIP-44 messages are exempt from this requirement because NIP-44 uses ChaCha20 (no padding) with HMAC-SHA256 authentication built in.
 
-### 4.2 Signature Coverage of the Recipients Block
+### 4.2 Signature Coverage of the Recipients & Contract Blocks
 
-For multi-recipient messages (Section 3.6), the signature MUST cover the RECIPIENTS block in addition to the body, so that the membership list and per-recipient roles cannot be altered without invalidating the signature. The per-level signing contribution becomes:
+For multi-recipient messages (Section 3.6), the signature MUST cover the RECIPIENTS block — and, when present, the CONTRACT block (Section 11.3) — in addition to the body, so that the membership list, per-recipient roles, and any declared consent cannot be altered without invalidating the signature. The per-level signing contribution becomes:
 
 ```
-level(L) = decode(body_L) || canonical(recipients_L)
+level(L) = decode(body_L) || canonical(recipients_L) || canonical(contract_L)
 ```
 
-where `decode(body_L)` is the level's decoded body bytes (as in Section 4) and `canonical(recipients_L)` is the **canonicalized recipients block**: the lines between `BEGIN NOSTR RECIPIENTS` and the following delimiter, each stripped of trailing whitespace and any `> ` quote prefix, joined with `\n`, with no trailing newline. If a level has no RECIPIENTS block, `canonical(recipients_L)` is the empty string and this reduces to the Section 4 model.
+where `decode(body_L)` is the level's decoded body bytes (as in Section 4); `canonical(recipients_L)` is the **canonicalized recipients block**: the lines between `BEGIN NOSTR RECIPIENTS` and the following delimiter, each stripped of trailing whitespace and any `> ` quote prefix, joined with `\n`, with no trailing newline; and `canonical(contract_L)` is the **canonicalized contract block**, formed by the identical rule over the lines between `BEGIN NOSTR CONTRACT` and the following delimiter. The blocks are concatenated in the fixed order **body, then recipients, then contract** (Section 11.3.1). If a level has no RECIPIENTS block, `canonical(recipients_L)` is the empty string; if it has no CONTRACT block, `canonical(contract_L)` is the empty string. A level with neither reduces to the Section 4 model.
 
 The signing target for a level (and its nested levels) is then:
 
@@ -296,7 +298,7 @@ The signing target for a level (and its nested levels) is then:
 SHA-256( level(L) || level(L-1) || … || level(1) )
 ```
 
-This preserves the flat-concatenation, chain-of-custody property of Section 3.5: tampering with any level's body **or** its recipient/role set invalidates that level's signature and every signature above it.
+This preserves the flat-concatenation, chain-of-custody property of Section 3.5: tampering with any level's body, its recipient/role set, **or its declared consent** invalidates that level's signature and every signature above it.
 
 ## 5. Content Encoding (Glossia)
 
@@ -406,6 +408,67 @@ Since email clients strip `<style>` tags and external stylesheets, all styling M
 - **Signature div**: `border-left: 2px solid #ccc; padding-left: 1em; color: #888; font-style: italic; overflow-wrap: break-word;`
 - **Signature heading**: `margin: 0 0 0.5em; color: #666; font-size: 0.9em;`
 - **HR separator**: `border: none; border-top: 1px solid #ccc; margin: 1.5em 0;`
+
+#### 6.2.6 Agreement & Consent Rendering
+
+When a thread is an agreement — any level carries a CONTRACT block (Section 11.3), or the `X-Nostr-Agreement` header is set — the HTML SHOULD make the **reply-vs-consent distinction visible**, so a reader can tell a binding signature apart from an ordinary comment at a glance. These are rendering aids only: a Nostr-Mail client MUST recompute completion from the verified armor (Section 11.5), never from the rendered HTML.
+
+1. **Status banner.** At the top of the outermost `<div>`, render `M of N signatories signed` plus the short document hash `H` (Section 11.3.1). `M` and `N` come from verified CONTRACT blocks intersected with the declared signatory set, never from the header.
+2. **Consent section.** A level whose SIGNATURE is accompanied by a CONTRACT block renders its signature section as a **"✓ Signed by @Name — consents to document H"** panel, visually distinct (green accent) from a plain signature.
+3. **Plain reply / comment.** A level with a SIGNATURE but **no** CONTRACT block renders the normal muted §6.2.4 signature section, labeled with the author's role (e.g. `viewer · comment`). It MUST NOT show a consent badge.
+4. **Don't rely on colour alone.** Use the literal `✓ Signed` / `comment` text and the role token alongside any colour, so the distinction survives in clients that strip styling and for accessibility. Show the short `H` inline and the full `H` on hover/`title`, so two different documents cannot look identical at a glance.
+
+The following renders an agreement that @Alice originated and signed, @Bob counter-signed, and @Carol (a `viewer`) replied to with a comment. Newest content is outermost, per Section 6.2.3:
+
+```html
+<div>
+  <!-- Status banner -->
+  <div style="border: 1px solid #cfe8cf; border-left: 4px solid #4caf50;
+              padding: 0.5em 0.75em; color: #2e7d32; font-size: 0.9em; margin: 0 0 1em;">
+    ✓ Agreement complete — 2 of 2 signatories signed
+    <div style="color: #666; font-size: 0.85em;" title="{full H}">Document H: a1b2c3…9f</div>
+  </div>
+
+  <!-- L3: Carol's new comment (outermost = newest) -->
+  <div>Looks good to me — no changes needed on my end.</div>
+
+  <blockquote style="border-left: 2px solid #ccc; margin: 1em 0; padding: 0 1em;">
+    <!-- L2: Bob -->
+    <div>I agree to the terms as written.</div>
+
+    <blockquote style="border-left: 2px solid #ccc; margin: 1em 0; padding: 0 1em;">
+      <!-- L1: Alice's original terms -->
+      <div>This Mutual NDA is entered into as of 2026-06-13 between …</div>
+
+      <!-- Alice's CONTRACT + SIGNATURE → consent panel -->
+      <hr style="border: none; border-top: 1px solid #ccc; margin: 1.5em 0;">
+      <h4 style="margin: 0 0 0.5em; color: #2e7d32; font-size: 0.9em;">✓ Signed by @Alice</h4>
+      <div style="color: #2e7d32; font-size: 0.85em;" title="{full H}">consents to document a1b2c3…9f</div>
+      <div style="border-left: 2px solid #4caf50; padding-left: 1em; color: #888;
+                  font-style: italic; overflow-wrap: break-word;">{Alice encoded sig + pubkey}</div>
+    </blockquote>
+
+    <!-- Bob's CONTRACT + SIGNATURE → consent panel -->
+    <hr style="border: none; border-top: 1px solid #ccc; margin: 1.5em 0;">
+    <h4 style="margin: 0 0 0.5em; color: #2e7d32; font-size: 0.9em;">✓ Signed by @Bob</h4>
+    <div style="color: #2e7d32; font-size: 0.85em;" title="{full H}">consents to document a1b2c3…9f</div>
+    <div style="border-left: 2px solid #4caf50; padding-left: 1em; color: #888;
+                font-style: italic; overflow-wrap: break-word;">{Bob encoded sig + pubkey}</div>
+  </blockquote>
+
+  <!-- Carol's SIGNATURE, NO CONTRACT → plain comment (muted, not green) -->
+  <hr style="border: none; border-top: 1px solid #ccc; margin: 1.5em 0;">
+  <h4 style="margin: 0 0 0.5em; color: #666; font-size: 0.9em;">@Carol · viewer · comment</h4>
+  <div style="border-left: 2px solid #ccc; padding-left: 1em; color: #888;
+              font-style: italic; overflow-wrap: break-word;">{Carol encoded sig + pubkey}</div>
+</div>
+```
+
+Recommended additional inline styles:
+
+- **Status banner**: `border: 1px solid #cfe8cf; border-left: 4px solid #4caf50; padding: 0.5em 0.75em; color: #2e7d32; font-size: 0.9em;` (use a neutral/amber accent — e.g. `#e0a800` — while an agreement is still `M of N` with `M < N`).
+- **Consent heading**: `margin: 0 0 0.5em; color: #2e7d32; font-size: 0.9em;`
+- **Consent signature div**: same as the §6.2.5 signature div but with a green left border: `border-left: 2px solid #4caf50;`
 
 ### 6.3 Transport Recipients (To / Cc)
 
@@ -578,30 +641,71 @@ An agreement is initiated as a signed multi-recipient message:
 - **Body**: the agreement cover text / terms, in a signed `HYBRID ENCRYPTED BODY`.
 - **Attachment(s)**: the contract document(s), encrypted under the same CEK (existing hybrid-attachment path).
 - **RECIPIENTS**: a `signer` stanza for each required signatory, a `viewer` stanza for each viewer, and the `self` stanza.
-- **SIGNATURE**: the originator's signature, covering body + recipients (Section 4.2), which fixes the set of required signatories and the exact document bytes.
+- **CONTRACT** (optional): if the originator is themselves a required signatory, they include their own CONTRACT block (Section 11.3) declaring consent. The originator's `self` stanza handles only decryption access and is never counted as a consent (Section 10.3) — an originator who signs MUST do so via a CONTRACT block.
+- **SIGNATURE**: the originator's signature, covering body + recipients + any contract (Section 4.2), which fixes the set of required signatories and the exact document bytes.
+
+The originating message's body + RECIPIENTS define the **document hash** `H` that every consent in the thread refers to (Section 11.3.1).
 
 Clients MAY include an `X-Nostr-Agreement` MIME header (boolean/identifier) to let IMAP filtering surface agreement threads without decrypting bodies. The authoritative agreement state always comes from the signed armor blocks, not the header.
 
-### 11.3 Signing Round
+### 11.3 Consent (CONTRACT) Block
 
-A signatory signs by **replying** to the agreement thread (Section 3.5 / 3.6.1):
+Because every reply in a thread carries a SIGNATURE (it is how chain-of-custody works, Section 3.5.0), the mere presence of a signatory's signature over the document cannot, by itself, mean "I agree" — a signatory might be replying to negotiate, ask a question, or object. To make consent an **explicit, intentional act** rather than a side effect of replying, a signatory declares consent with a dedicated CONTRACT block. This is the armor-grammar analogue of a purpose-built signing action: a comment carries no CONTRACT block; a signature does.
 
-- The reply nests the prior message unchanged and adds the signatory's SIGNATURE, which — per Section 4.2 / 3.5.0 — covers `level(reply) || level(prior) || …`, i.e. the signatory's own content plus the full nested history including the original document bytes.
-- A signatory's reply therefore cryptographically binds **their identity to the exact agreement and to every signature already in the thread**, giving an ordered, tamper-evident chain of custody.
+A CONTRACT block contains exactly two fields, one per line:
+
+```
+----- BEGIN NOSTR CONTRACT -----
+agreement <H>
+signer    <pubkey>
+```
+
+| Field | Encoding | Meaning |
+|-------|----------|---------|
+| `agreement` | hex (64 chars) | The document hash `H` being consented to (Section 11.3.1). |
+| `signer` | hex (64 chars) or npub | The consenting party's pubkey. MUST equal the pubkey in this level's SIGNATURE block. |
+
+The CONTRACT block does **not** carry its own signature — the level's existing SIGNATURE provides the binding. Because that signature covers `level(reply) || … || level(1)` (Sections 4.2, 3.5.0) and `level(L)` now includes the CONTRACT block, the consent is bound to (a) the consenting identity, (b) the exact document `H`, and (c) the full nested history, and it cannot be stripped or altered without invalidating that signature and every signature above it. (A future version MAY define an optional self-contained variant carrying its own signature over `H`, for consents that must be verifiable in isolation from the thread; out of scope for v0.4.)
+
+Decoders MUST tolerate additional unknown lines in a CONTRACT block (forward compatibility) and MUST ignore blank lines and `> ` quote prefixes.
+
+#### 11.3.1 Document Hash `H`
+
+```
+H = SHA-256( decode(body_1) || canonical(recipients_1) )
+```
+
+`H` is computed over the **originating** level's (level 1) body and RECIPIENTS block only — it deliberately **excludes all CONTRACT blocks** (including the originator's own), so that `H` is fixed for the life of the agreement no matter how many consents accumulate, and so that the originator's level-1 CONTRACT referencing `H` is not self-referential. Note this is distinct from `level(1)` (Section 4.2), which *does* include level 1's CONTRACT block: `H` identifies the document, `level(L)` is what a level's signature covers.
+
+#### 11.3.2 Ordering
+
+Within a level, the CONTRACT block is **content**, not a trailer: it is the last block of the level's content group, in the fixed order **body → RECIPIENTS → CONTRACT**, and appears before any nested (inner) level and before the trailing SIGNATURE stack. Each level has **at most one** CONTRACT block (a level has a single author). As an agreement accumulates signatures, each consenting reply contributes its own CONTRACT block at its own level — they are never merged into one growing block, since nesting the prior message unchanged forbids mutating an inner level. The CONTRACT block at a given nesting depth is bound by the SIGNATURE at the same depth (the same body↔signature depth-pairing used throughout Section 3.5).
+
+### 11.4 Signing Round
+
+A signatory signs by **replying** to the agreement thread (Section 3.5 / 3.6.1) and including a CONTRACT block in their reply:
+
+- The reply nests the prior message unchanged, adds a CONTRACT block declaring consent to `H`, and adds the signatory's SIGNATURE, which — per Section 4.2 / 3.5.0 — covers `level(reply) || level(prior) || …`, i.e. the signatory's own content (including their CONTRACT) plus the full nested history including the original document bytes.
+- A signatory's consenting reply therefore cryptographically binds **their identity and intent to the exact agreement and to every signature already in the thread**, giving an ordered, tamper-evident chain of custody. Signing order is recoverable from nesting depth (innermost = first signer).
+- A reply **without** a CONTRACT block is a comment: authenticated and part of the chain of custody, but **not** a consent, and never counted toward completion (Section 11.5). This is how a signatory negotiates or a `viewer` comments without being mistaken for having signed.
 - Reply-all preserves the `signer`/`viewer` roles from the prior level so the membership is carried forward (subject to the access rules of Section 10.8).
 
-### 11.4 Completion & Status
+### 11.5 Completion & Status
 
-An agreement is **complete** when, for every `signer` pubkey declared in the originating message's RECIPIENTS block, the thread contains a valid SIGNATURE from that pubkey over a level that includes the original document bytes. Clients:
+An agreement is **complete** when, for every required signatory, the thread contains a valid CONTRACT block referencing the agreement's `H`, bound by a verified SIGNATURE from that signatory's pubkey. The required signatory set is the set of `signer` stanzas in the originating message's RECIPIENTS block, **plus** the originator if the originating message itself carries a CONTRACT block (Section 11.2). Clients:
 
-- SHOULD compute "M of N signed" by intersecting the declared signatory set with the set of verified signer pubkeys present in the thread.
-- MAY use the `X-Nostr-Sig` / `X-Nostr-Pubkey` headers (Section 6.1) for a fast, decrypt-free progress estimate, but MUST confirm completion against verified in-body signatures.
-- SHOULD NOT count `viewer` or `self` pubkeys toward completion.
+- SHOULD compute "M of N signed" by intersecting the required signatory set with the set of pubkeys that have a **verified CONTRACT block over `H`** in the thread.
+- MUST key completion off the presence of a verified CONTRACT block, **not** off the mere presence of a signature from a signatory — a signed comment (no CONTRACT) does not count.
+- MUST deduplicate by pubkey: a signatory who appears in multiple levels (e.g. commented, then signed) counts at most once.
+- MAY use the `X-Nostr-Sig` / `X-Nostr-Pubkey` / `X-Nostr-Agreement` headers (Section 6.1) for a fast, decrypt-free progress estimate, but MUST confirm completion against verified in-body CONTRACT blocks.
+- SHOULD NOT count `viewer` or `self` pubkeys toward completion. A `viewer` who nonetheless emits a valid CONTRACT block is not a required signatory and MUST NOT change the `N`, though clients MAY surface the extra consent informationally.
 
-### 11.5 Verification
+### 11.6 Verification
 
-A completed agreement is verifiable offline and without any nostr-mail or SIGit server: a verifier walks the thread, and for each level checks the SIGNATURE against `SHA-256(level(L) || … || level(1))` (Section 4.2) using the pubkey in the SIGNATURE block. If every required signatory's signature verifies over a level covering the original document bytes, the agreement is valid and attributable to those Nostr identities. Tampering with the document, the recipient/role set, or any prior signature invalidates the affected signature and every signature above it.
+A completed agreement is verifiable offline and without any nostr-mail or SIGit server: a verifier walks the thread and, for each level, checks the SIGNATURE against `SHA-256(level(L) || … || level(1))` (Section 4.2) using the pubkey in the SIGNATURE block, then collects the CONTRACT blocks. If, for every required signatory, a CONTRACT block over the agreement's `H` is bound by a verified signature from that signatory's pubkey, the agreement is valid and attributable to those Nostr identities. Tampering with the document, the recipient/role set, any declared consent, or any prior signature invalidates the affected signature and every signature above it.
 
 ## 12. Versioning
 
 This specification may be extended with additional block types in future versions. Decoders SHOULD ignore unrecognized block types rather than failing. Unknown `role` tokens in a RECIPIENTS block (Section 10.2) MUST be treated as recipients for decryption while being ignored for workflow accounting, so that future roles do not break older clients.
+
+The CONTRACT block (Section 11.3) is likewise backward compatible: a client that predates it ignores the unknown block and simply sees an ordinary signed reply, so message decryption and signature verification are unaffected — only the agreement-completion view (which such a client does not compute) is unavailable. Agreement-aware clients MUST tolerate unknown trailing lines within a CONTRACT block so that future consent fields do not break older clients.

--- a/docs/nostr-mail-spec.md
+++ b/docs/nostr-mail-spec.md
@@ -21,11 +21,11 @@ All Nostr-Mail content is enclosed in ASCII armor blocks using `-----` delimiter
 | `BEGIN NOSTR SEAL` | Identity declaration | Sender's Nostr public key (unsigned messages only) |
 | `BEGIN NOSTR HYBRID ENCRYPTED BODY` | Multi-recipient encrypted content | AES-256-GCM ciphertext under a per-message Content Encryption Key (CEK) |
 | `BEGIN NOSTR RECIPIENTS` | Recipient key-wrap + roles | Per-recipient NIP-44-wrapped CEK, pubkey, and role |
-| `BEGIN NOSTR CONTRACT` | Explicit consent marker | A signatory's binding consent to a specific agreement (document hash + signer pubkey); see Section 11.3 |
+| `BEGIN NOSTR CONSENT` | Explicit consent marker | A signatory's binding consent to a specific agreement (document hash + signer pubkey); see Section 11.3 |
 | `END NOSTR MESSAGE` | Closing tag | Terminates the outermost block |
 | `END NOSTR SEAL` | Closing tag | Terminates standalone seal blocks |
 | `END NOSTR RECIPIENTS` | Closing tag | Terminates a standalone recipients block |
-| `END NOSTR CONTRACT` | Closing tag | Terminates a standalone contract block |
+| `END NOSTR CONSENT` | Closing tag | Terminates a standalone consent block |
 
 The encryption type is embedded directly in the BEGIN tag (e.g., `BEGIN NOSTR NIP-44 ENCRYPTED BODY`), keeping the format self-describing without metadata lines.
 
@@ -282,15 +282,15 @@ The Schnorr signature over `SHA-256(ciphertext_bytes)` serves as the authenticat
 
 NIP-44 messages are exempt from this requirement because NIP-44 uses ChaCha20 (no padding) with HMAC-SHA256 authentication built in.
 
-### 4.2 Signature Coverage of the Recipients & Contract Blocks
+### 4.2 Signature Coverage of the Recipients & Consent Blocks
 
-For multi-recipient messages (Section 3.6), the signature MUST cover the RECIPIENTS block — and, when present, the CONTRACT block (Section 11.3) — in addition to the body, so that the membership list, per-recipient roles, and any declared consent cannot be altered without invalidating the signature. The per-level signing contribution becomes:
+For multi-recipient messages (Section 3.6), the signature MUST cover the RECIPIENTS block — and, when present, the CONSENT block (Section 11.3) — in addition to the body, so that the membership list, per-recipient roles, and any declared consent cannot be altered without invalidating the signature. The per-level signing contribution becomes:
 
 ```
-level(L) = decode(body_L) || canonical(recipients_L) || canonical(contract_L)
+level(L) = decode(body_L) || canonical(recipients_L) || canonical(consent_L)
 ```
 
-where `decode(body_L)` is the level's decoded body bytes (as in Section 4); `canonical(recipients_L)` is the **canonicalized recipients block**: the lines between `BEGIN NOSTR RECIPIENTS` and the following delimiter, each stripped of trailing whitespace and any `> ` quote prefix, joined with `\n`, with no trailing newline; and `canonical(contract_L)` is the **canonicalized contract block**, formed by the identical rule over the lines between `BEGIN NOSTR CONTRACT` and the following delimiter. The blocks are concatenated in the fixed order **body, then recipients, then contract** (Section 11.3.1). If a level has no RECIPIENTS block, `canonical(recipients_L)` is the empty string; if it has no CONTRACT block, `canonical(contract_L)` is the empty string. A level with neither reduces to the Section 4 model.
+where `decode(body_L)` is the level's decoded body bytes (as in Section 4); `canonical(recipients_L)` is the **canonicalized recipients block**: the lines between `BEGIN NOSTR RECIPIENTS` and the following delimiter, each stripped of trailing whitespace and any `> ` quote prefix, joined with `\n`, with no trailing newline; and `canonical(consent_L)` is the **canonicalized consent block**, formed by the identical rule over the lines between `BEGIN NOSTR CONSENT` and the following delimiter. The blocks are concatenated in the fixed order **body, then recipients, then consent** (Section 11.3.1). If a level has no RECIPIENTS block, `canonical(recipients_L)` is the empty string; if it has no CONSENT block, `canonical(consent_L)` is the empty string. A level with neither reduces to the Section 4 model.
 
 The signing target for a level (and its nested levels) is then:
 
@@ -411,11 +411,11 @@ Since email clients strip `<style>` tags and external stylesheets, all styling M
 
 #### 6.2.6 Agreement & Consent Rendering
 
-When a thread is an agreement — any level carries a CONTRACT block (Section 11.3), or the `X-Nostr-Agreement` header is set — the HTML SHOULD make the **reply-vs-consent distinction visible**, so a reader can tell a binding signature apart from an ordinary comment at a glance. These are rendering aids only: a Nostr-Mail client MUST recompute completion from the verified armor (Section 11.5), never from the rendered HTML.
+When a thread is an agreement — any level carries a CONSENT block (Section 11.3), or the `X-Nostr-Agreement` header is set — the HTML SHOULD make the **reply-vs-consent distinction visible**, so a reader can tell a binding signature apart from an ordinary comment at a glance. These are rendering aids only: a Nostr-Mail client MUST recompute completion from the verified armor (Section 11.5), never from the rendered HTML.
 
-1. **Status banner.** At the top of the outermost `<div>`, render `M of N signatories signed` plus the short document hash `H` (Section 11.3.1). `M` and `N` come from verified CONTRACT blocks intersected with the declared signatory set, never from the header.
-2. **Consent section.** A level whose SIGNATURE is accompanied by a CONTRACT block renders its signature section as a **"✓ Signed by @Name — consents to document H"** panel, visually distinct (green accent) from a plain signature.
-3. **Plain reply / comment.** A level with a SIGNATURE but **no** CONTRACT block renders the normal muted §6.2.4 signature section, labeled with the author's role (e.g. `viewer · comment`). It MUST NOT show a consent badge.
+1. **Status banner.** At the top of the outermost `<div>`, render `M of N signatories signed` plus the short document hash `H` (Section 11.3.1). `M` and `N` come from verified CONSENT blocks intersected with the declared signatory set, never from the header.
+2. **Consent section.** A level whose SIGNATURE is accompanied by a CONSENT block renders its signature section as a **"✓ Signed by @Name — consents to document H"** panel, visually distinct (green accent) from a plain signature.
+3. **Plain reply / comment.** A level with a SIGNATURE but **no** CONSENT block renders the normal muted §6.2.4 signature section, labeled with the author's role (e.g. `viewer · comment`). It MUST NOT show a consent badge.
 4. **Don't rely on colour alone.** Use the literal `✓ Signed` / `comment` text and the role token alongside any colour, so the distinction survives in clients that strip styling and for accessibility. Show the short `H` inline and the full `H` on hover/`title`, so two different documents cannot look identical at a glance.
 
 The following renders an agreement that @Alice originated and signed, @Bob counter-signed, and @Carol (a `viewer`) replied to with a comment. Newest content is outermost, per Section 6.2.3:
@@ -440,7 +440,7 @@ The following renders an agreement that @Alice originated and signed, @Bob count
       <!-- L1: Alice's original terms -->
       <div>This Mutual NDA is entered into as of 2026-06-13 between …</div>
 
-      <!-- Alice's CONTRACT + SIGNATURE → consent panel -->
+      <!-- Alice's CONSENT + SIGNATURE → consent panel -->
       <hr style="border: none; border-top: 1px solid #ccc; margin: 1.5em 0;">
       <h4 style="margin: 0 0 0.5em; color: #2e7d32; font-size: 0.9em;">✓ Signed by @Alice</h4>
       <div style="color: #2e7d32; font-size: 0.85em;" title="{full H}">consents to document a1b2c3…9f</div>
@@ -448,7 +448,7 @@ The following renders an agreement that @Alice originated and signed, @Bob count
                   font-style: italic; overflow-wrap: break-word;">{Alice encoded sig + pubkey}</div>
     </blockquote>
 
-    <!-- Bob's CONTRACT + SIGNATURE → consent panel -->
+    <!-- Bob's CONSENT + SIGNATURE → consent panel -->
     <hr style="border: none; border-top: 1px solid #ccc; margin: 1.5em 0;">
     <h4 style="margin: 0 0 0.5em; color: #2e7d32; font-size: 0.9em;">✓ Signed by @Bob</h4>
     <div style="color: #2e7d32; font-size: 0.85em;" title="{full H}">consents to document a1b2c3…9f</div>
@@ -456,7 +456,7 @@ The following renders an agreement that @Alice originated and signed, @Bob count
                 font-style: italic; overflow-wrap: break-word;">{Bob encoded sig + pubkey}</div>
   </blockquote>
 
-  <!-- Carol's SIGNATURE, NO CONTRACT → plain comment (muted, not green) -->
+  <!-- Carol's SIGNATURE, NO CONSENT → plain comment (muted, not green) -->
   <hr style="border: none; border-top: 1px solid #ccc; margin: 1.5em 0;">
   <h4 style="margin: 0 0 0.5em; color: #666; font-size: 0.9em;">@Carol · viewer · comment</h4>
   <div style="border-left: 2px solid #ccc; padding-left: 1em; color: #888;
@@ -618,7 +618,9 @@ Because each level is sealed under its own CEK wrapped only to that level's list
 
 ### 10.9 Privacy Considerations
 
-The RECIPIENTS block lists each participant's pubkey in the (cleartext) `text/plain` body, so relays/mail servers that see the message learn the participant set. This is no worse than the `To:`/`Cc:` headers, which already expose the email addresses, but it is strictly less private than NIP-59 gift wrap, which hides recipients behind an ephemeral key. A future version MAY define a metadata-private mode that omits pubkey labels and requires readers to trial-decrypt each stanza (as the `age` format does); this is out of scope for v0.3.
+The RECIPIENTS block lists each participant's pubkey in the (cleartext) `text/plain` body, so relays/mail servers that see the message learn the participant set. This is no worse than the `To:`/`Cc:` headers, which already expose the email addresses, but it is strictly less private than NIP-59 gift wrap, which hides recipients behind an ephemeral key. A future version MAY define a metadata-private mode that omits pubkey labels and requires readers to trial-decrypt each stanza (as the `age` format does); this is out of scope for v0.4.
+
+A planned future direction is a **Nostr-only agreement transport** that folds in SIGit's privacy model (Section 11.7): instead of carrying the agreement in the email body, the message body and document(s) would be sealed and NIP-59 gift-wrapped to each counterparty (optionally with large files on Blossom), hiding the participant set behind ephemeral keys. The consent/chain-of-custody semantics defined here (the document hash `H`, per-signatory consent, and signature chaining) are transport-independent and would carry over unchanged; only the envelope and recipient-addressing would differ. This is out of scope for v0.4 and noted here so the consent model is not specialized to the cleartext email envelope.
 
 ## 11. Recipient Roles & Agreement Workflow
 
@@ -634,28 +636,28 @@ This section defines how multi-recipient messages support DocuSign-style agreeme
 
 The role is a **workflow** attribute, not an access attribute — every role can read the agreement. A client uses the role only to decide whether it expects a signature reply from that participant and to compute completion status.
 
-### 11.2 Agreement (Contract) Message
+### 11.2 Agreement Message
 
 An agreement is initiated as a signed multi-recipient message:
 
 - **Body**: the agreement cover text / terms, in a signed `HYBRID ENCRYPTED BODY`.
 - **Attachment(s)**: the contract document(s), encrypted under the same CEK (existing hybrid-attachment path).
 - **RECIPIENTS**: a `signer` stanza for each required signatory, a `viewer` stanza for each viewer, and the `self` stanza.
-- **CONTRACT** (optional): if the originator is themselves a required signatory, they include their own CONTRACT block (Section 11.3) declaring consent. The originator's `self` stanza handles only decryption access and is never counted as a consent (Section 10.3) — an originator who signs MUST do so via a CONTRACT block.
-- **SIGNATURE**: the originator's signature, covering body + recipients + any contract (Section 4.2), which fixes the set of required signatories and the exact document bytes.
+- **CONSENT** (optional): if the originator is themselves a required signatory, they include their own CONSENT block (Section 11.3) declaring consent. The originator's `self` stanza handles only decryption access and is never counted as a consent (Section 10.3) — an originator who signs MUST do so via a CONSENT block.
+- **SIGNATURE**: the originator's signature, covering body + recipients + any consent (Section 4.2), which fixes the set of required signatories and the exact document bytes.
 
 The originating message's body + RECIPIENTS define the **document hash** `H` that every consent in the thread refers to (Section 11.3.1).
 
 Clients MAY include an `X-Nostr-Agreement` MIME header (boolean/identifier) to let IMAP filtering surface agreement threads without decrypting bodies. The authoritative agreement state always comes from the signed armor blocks, not the header.
 
-### 11.3 Consent (CONTRACT) Block
+### 11.3 Consent Block
 
-Because every reply in a thread carries a SIGNATURE (it is how chain-of-custody works, Section 3.5.0), the mere presence of a signatory's signature over the document cannot, by itself, mean "I agree" — a signatory might be replying to negotiate, ask a question, or object. To make consent an **explicit, intentional act** rather than a side effect of replying, a signatory declares consent with a dedicated CONTRACT block. This is the armor-grammar analogue of a purpose-built signing action: a comment carries no CONTRACT block; a signature does.
+Because every reply in a thread carries a SIGNATURE (it is how chain-of-custody works, Section 3.5.0), the mere presence of a signatory's signature over the document cannot, by itself, mean "I agree" — a signatory might be replying to negotiate, ask a question, or object. To make consent an **explicit, intentional act** rather than a side effect of replying, a signatory declares consent with a dedicated CONSENT block. This is the armor-grammar analogue of a purpose-built signing action: a comment carries no CONSENT block; a signature does.
 
-A CONTRACT block contains exactly two fields, one per line:
+A CONSENT block contains exactly two fields, one per line:
 
 ```
------ BEGIN NOSTR CONTRACT -----
+----- BEGIN NOSTR CONSENT -----
 agreement <H>
 signer    <pubkey>
 ```
@@ -665,9 +667,9 @@ signer    <pubkey>
 | `agreement` | hex (64 chars) | The document hash `H` being consented to (Section 11.3.1). |
 | `signer` | hex (64 chars) or npub | The consenting party's pubkey. MUST equal the pubkey in this level's SIGNATURE block. |
 
-The CONTRACT block does **not** carry its own signature — the level's existing SIGNATURE provides the binding. Because that signature covers `level(reply) || … || level(1)` (Sections 4.2, 3.5.0) and `level(L)` now includes the CONTRACT block, the consent is bound to (a) the consenting identity, (b) the exact document `H`, and (c) the full nested history, and it cannot be stripped or altered without invalidating that signature and every signature above it. (A future version MAY define an optional self-contained variant carrying its own signature over `H`, for consents that must be verifiable in isolation from the thread; out of scope for v0.4.)
+The CONSENT block does **not** carry its own signature — the level's existing SIGNATURE provides the binding. Because that signature covers `level(reply) || … || level(1)` (Sections 4.2, 3.5.0) and `level(L)` now includes the CONSENT block, the consent is bound to (a) the consenting identity, (b) the exact document `H`, and (c) the full nested history, and it cannot be stripped or altered without invalidating that signature and every signature above it. (A future version MAY define an optional self-contained variant carrying its own signature over `H`, for consents that must be verifiable in isolation from the thread; out of scope for v0.4.)
 
-Decoders MUST tolerate additional unknown lines in a CONTRACT block (forward compatibility) and MUST ignore blank lines and `> ` quote prefixes.
+Decoders MUST tolerate additional unknown lines in a CONSENT block (forward compatibility) and MUST ignore blank lines and `> ` quote prefixes.
 
 #### 11.3.1 Document Hash `H`
 
@@ -675,37 +677,53 @@ Decoders MUST tolerate additional unknown lines in a CONTRACT block (forward com
 H = SHA-256( decode(body_1) || canonical(recipients_1) )
 ```
 
-`H` is computed over the **originating** level's (level 1) body and RECIPIENTS block only — it deliberately **excludes all CONTRACT blocks** (including the originator's own), so that `H` is fixed for the life of the agreement no matter how many consents accumulate, and so that the originator's level-1 CONTRACT referencing `H` is not self-referential. Note this is distinct from `level(1)` (Section 4.2), which *does* include level 1's CONTRACT block: `H` identifies the document, `level(L)` is what a level's signature covers.
+`H` is computed over the **originating** level's (level 1) body and RECIPIENTS block only — it deliberately **excludes all CONSENT blocks** (including the originator's own), so that `H` is fixed for the life of the agreement no matter how many consents accumulate, and so that the originator's level-1 CONSENT referencing `H` is not self-referential. Note this is distinct from `level(1)` (Section 4.2), which *does* include level 1's CONSENT block: `H` identifies the document, `level(L)` is what a level's signature covers.
 
 #### 11.3.2 Ordering
 
-Within a level, the CONTRACT block is **content**, not a trailer: it is the last block of the level's content group, in the fixed order **body → RECIPIENTS → CONTRACT**, and appears before any nested (inner) level and before the trailing SIGNATURE stack. Each level has **at most one** CONTRACT block (a level has a single author). As an agreement accumulates signatures, each consenting reply contributes its own CONTRACT block at its own level — they are never merged into one growing block, since nesting the prior message unchanged forbids mutating an inner level. The CONTRACT block at a given nesting depth is bound by the SIGNATURE at the same depth (the same body↔signature depth-pairing used throughout Section 3.5).
+Within a level, the CONSENT block is **content**, not a trailer: it is the last block of the level's content group, in the fixed order **body → RECIPIENTS → CONSENT**, and appears before any nested (inner) level and before the trailing SIGNATURE stack. Each level has **at most one** CONSENT block (a level has a single author). As an agreement accumulates signatures, each consenting reply contributes its own CONSENT block at its own level — they are never merged into one growing block, since nesting the prior message unchanged forbids mutating an inner level. The CONSENT block at a given nesting depth is bound by the SIGNATURE at the same depth (the same body↔signature depth-pairing used throughout Section 3.5).
 
 ### 11.4 Signing Round
 
-A signatory signs by **replying** to the agreement thread (Section 3.5 / 3.6.1) and including a CONTRACT block in their reply:
+A signatory signs by **replying** to the agreement thread (Section 3.5 / 3.6.1) and including a CONSENT block in their reply:
 
-- The reply nests the prior message unchanged, adds a CONTRACT block declaring consent to `H`, and adds the signatory's SIGNATURE, which — per Section 4.2 / 3.5.0 — covers `level(reply) || level(prior) || …`, i.e. the signatory's own content (including their CONTRACT) plus the full nested history including the original document bytes.
+- The reply nests the prior message unchanged, adds a CONSENT block declaring consent to `H`, and adds the signatory's SIGNATURE, which — per Section 4.2 / 3.5.0 — covers `level(reply) || level(prior) || …`, i.e. the signatory's own content (including their CONSENT) plus the full nested history including the original document bytes.
 - A signatory's consenting reply therefore cryptographically binds **their identity and intent to the exact agreement and to every signature already in the thread**, giving an ordered, tamper-evident chain of custody. Signing order is recoverable from nesting depth (innermost = first signer).
-- A reply **without** a CONTRACT block is a comment: authenticated and part of the chain of custody, but **not** a consent, and never counted toward completion (Section 11.5). This is how a signatory negotiates or a `viewer` comments without being mistaken for having signed.
+- A reply **without** a CONSENT block is a comment: authenticated and part of the chain of custody, but **not** a consent, and never counted toward completion (Section 11.5). This is how a signatory negotiates or a `viewer` comments without being mistaken for having signed.
 - Reply-all preserves the `signer`/`viewer` roles from the prior level so the membership is carried forward (subject to the access rules of Section 10.8).
 
 ### 11.5 Completion & Status
 
-An agreement is **complete** when, for every required signatory, the thread contains a valid CONTRACT block referencing the agreement's `H`, bound by a verified SIGNATURE from that signatory's pubkey. The required signatory set is the set of `signer` stanzas in the originating message's RECIPIENTS block, **plus** the originator if the originating message itself carries a CONTRACT block (Section 11.2). Clients:
+An agreement is **complete** when, for every required signatory, the thread contains a valid CONSENT block referencing the agreement's `H`, bound by a verified SIGNATURE from that signatory's pubkey. The required signatory set is the set of `signer` stanzas in the originating message's RECIPIENTS block, **plus** the originator if the originating message itself carries a CONSENT block (Section 11.2). Clients:
 
-- SHOULD compute "M of N signed" by intersecting the required signatory set with the set of pubkeys that have a **verified CONTRACT block over `H`** in the thread.
-- MUST key completion off the presence of a verified CONTRACT block, **not** off the mere presence of a signature from a signatory — a signed comment (no CONTRACT) does not count.
+- SHOULD compute "M of N signed" by intersecting the required signatory set with the set of pubkeys that have a **verified CONSENT block over `H`** in the thread.
+- MUST key completion off the presence of a verified CONSENT block, **not** off the mere presence of a signature from a signatory — a signed comment (no CONSENT) does not count.
 - MUST deduplicate by pubkey: a signatory who appears in multiple levels (e.g. commented, then signed) counts at most once.
-- MAY use the `X-Nostr-Sig` / `X-Nostr-Pubkey` / `X-Nostr-Agreement` headers (Section 6.1) for a fast, decrypt-free progress estimate, but MUST confirm completion against verified in-body CONTRACT blocks.
-- SHOULD NOT count `viewer` or `self` pubkeys toward completion. A `viewer` who nonetheless emits a valid CONTRACT block is not a required signatory and MUST NOT change the `N`, though clients MAY surface the extra consent informationally.
+- MAY use the `X-Nostr-Sig` / `X-Nostr-Pubkey` / `X-Nostr-Agreement` headers (Section 6.1) for a fast, decrypt-free progress estimate, but MUST confirm completion against verified in-body CONSENT blocks.
+- SHOULD NOT count `viewer` or `self` pubkeys toward completion. A `viewer` who nonetheless emits a valid CONSENT block is not a required signatory and MUST NOT change the `N`, though clients MAY surface the extra consent informationally.
 
 ### 11.6 Verification
 
-A completed agreement is verifiable offline and without any nostr-mail or SIGit server: a verifier walks the thread and, for each level, checks the SIGNATURE against `SHA-256(level(L) || … || level(1))` (Section 4.2) using the pubkey in the SIGNATURE block, then collects the CONTRACT blocks. If, for every required signatory, a CONTRACT block over the agreement's `H` is bound by a verified signature from that signatory's pubkey, the agreement is valid and attributable to those Nostr identities. Tampering with the document, the recipient/role set, any declared consent, or any prior signature invalidates the affected signature and every signature above it.
+A completed agreement is verifiable offline and without any nostr-mail or SIGit server: a verifier walks the thread and, for each level, checks the SIGNATURE against `SHA-256(level(L) || … || level(1))` (Section 4.2) using the pubkey in the SIGNATURE block, then collects the CONSENT blocks. If, for every required signatory, a CONSENT block over the agreement's `H` is bound by a verified signature from that signatory's pubkey, the agreement is valid and attributable to those Nostr identities. Tampering with the document, the recipient/role set, any declared consent, or any prior signature invalidates the affected signature and every signature above it.
+
+### 11.7 Relation to SIGit
+
+This agreement model is conceptually aligned with [SIGit](https://sigit.io)'s document-signing design, re-expressed for an **email-native, self-contained** transport rather than SIGit's Nostr-relay + Blossom + account-server split. The core concepts map directly:
+
+| SIGit | nostr-mail (this spec) |
+|-------|------------------------|
+| "Agreement" (documents + counterparties + metadata) | the agreement thread (Section 11) |
+| `signers` / `viewers` arrays; Creator | `signer` / `viewer` roles (Section 11.1); originator + `self` stanza |
+| `keys: { npub: ENCRYPTD }` — decryption key NIP-44-wrapped per counterparty | RECIPIENTS block — CEK NIP-44-wrapped per recipient (Section 10) |
+| `meta` hash that Sign events commit to | document hash `H` (Section 11.3.1) |
+| `prevSig` chain + `docSignatures` map | nested per-level SIGNATURE chain-of-custody (Sections 3.5, 4.2) |
+| Sign event (Kind 938) added to `docSignatures` | the CONSENT block bound by the level's signature (Section 11.3) |
+| Offline-verifiable from the encrypted zip | offline-verifiable from the email thread (Section 11.6) |
+
+The deliberate difference is transport and privacy. SIGit hides the participant set by gift-wrapping (NIP-59) metadata to ephemeral keys and storing encrypted files on Blossom; nostr-mail keeps the whole agreement in one email thread, which is more self-contained and offline-verifiable but exposes the participant set in the cleartext RECIPIENTS block (Section 10.9). A future **Nostr-only agreement transport** is planned that folds in SIGit's gift-wrap/Blossom approach for stronger metadata privacy; because the consent semantics here (`H`, per-signatory CONSENT, signature chaining) are transport-independent, that mode is expected to reuse this section's model with a different envelope. SIGit's own event-kind numbering is **not** adopted; nostr-mail consent lives in armor blocks, not relay-published Nostr events.
 
 ## 12. Versioning
 
 This specification may be extended with additional block types in future versions. Decoders SHOULD ignore unrecognized block types rather than failing. Unknown `role` tokens in a RECIPIENTS block (Section 10.2) MUST be treated as recipients for decryption while being ignored for workflow accounting, so that future roles do not break older clients.
 
-The CONTRACT block (Section 11.3) is likewise backward compatible: a client that predates it ignores the unknown block and simply sees an ordinary signed reply, so message decryption and signature verification are unaffected — only the agreement-completion view (which such a client does not compute) is unavailable. Agreement-aware clients MUST tolerate unknown trailing lines within a CONTRACT block so that future consent fields do not break older clients.
+The CONSENT block (Section 11.3) is likewise backward compatible: a client that predates it ignores the unknown block and simply sees an ordinary signed reply, so message decryption and signature verification are unaffected — only the agreement-completion view (which such a client does not compute) is unavailable. Agreement-aware clients MUST tolerate unknown trailing lines within a CONSENT block so that future consent fields do not break older clients.

--- a/docs/nostr-mail-spec.md
+++ b/docs/nostr-mail-spec.md
@@ -1,7 +1,7 @@
 # Nostr-Mail Protocol Specification
 
-**Version:** 0.2.0-draft
-**Date:** 2026-03-26
+**Version:** 0.3.0-draft
+**Date:** 2026-06-13
 
 ## 1. Overview
 
@@ -19,8 +19,11 @@ All Nostr-Mail content is enclosed in ASCII armor blocks using `-----` delimiter
 | `BEGIN NOSTR SIGNED BODY` | Signed plaintext | Plaintext body content |
 | `BEGIN NOSTR SIGNATURE` | Proof of authorship + identity | Schnorr signature (64 bytes) followed by sender's pubkey (32 bytes) |
 | `BEGIN NOSTR SEAL` | Identity declaration | Sender's Nostr public key (unsigned messages only) |
+| `BEGIN NOSTR HYBRID ENCRYPTED BODY` | Multi-recipient encrypted content | AES-256-GCM ciphertext under a per-message Content Encryption Key (CEK) |
+| `BEGIN NOSTR RECIPIENTS` | Recipient key-wrap + roles | Per-recipient NIP-44-wrapped CEK, pubkey, and role |
 | `END NOSTR MESSAGE` | Closing tag | Terminates the outermost block |
 | `END NOSTR SEAL` | Closing tag | Terminates standalone seal blocks |
+| `END NOSTR RECIPIENTS` | Closing tag | Terminates a standalone recipients block |
 
 The encryption type is embedded directly in the BEGIN tag (e.g., `BEGIN NOSTR NIP-44 ENCRYPTED BODY`), keeping the format self-describing without metadata lines.
 
@@ -193,6 +196,60 @@ For reply chains, nesting increases with each level. Signatures close in innermo
 
 Decoders MUST also accept armor block delimiters preceded by `> ` quote prefixes, since email clients may add quote prefixes when forwarding or replying. Glossia decoders naturally ignore quote prefixes as non-payload words.
 
+### 3.6 Multi-Recipient (Group-Encrypted)
+
+When a message has more than one cryptographic recipient — for example multiple `To:` signatories and/or `Cc:` viewers — the body cannot be encrypted with a single pairwise NIP-44 shared secret, because each recipient derives a different secret. Instead the body is encrypted **once** under a random Content Encryption Key (CEK), and the CEK is wrapped to each recipient with NIP-44. This is the same hybrid construction already used for attachments (AES-256 for payload, NIP-44 for the key), generalized to N recipients. The envelope mechanics are normative in Section 10.
+
+```
+----- BEGIN NOSTR HYBRID ENCRYPTED BODY -----
+<AES-256-GCM ciphertext under CEK, base64 or glossia-encoded>
+----- BEGIN NOSTR RECIPIENTS -----
+signer <pubkey-1> <NIP-44-wrapped CEK>
+signer <pubkey-2> <NIP-44-wrapped CEK>
+viewer <pubkey-3> <NIP-44-wrapped CEK>
+self   <sender-pubkey> <NIP-44-wrapped CEK>
+----- BEGIN NOSTR SIGNATURE -----
+@ProfileName
+<signature: glossia-encoded or hex (64 bytes)>
+<pubkey: glossia-encoded, hex, or npub>
+----- END NOSTR MESSAGE -----
+```
+
+Each RECIPIENTS entry is a single line of three space-separated tokens: `<role> <pubkey> <wrapped-cek>` (see Section 10.2). The sender's own `self` stanza makes the Sent copy decryptable on any device, mirroring the "wrap twice" behavior of NIP-17 DMs.
+
+A multi-recipient message SHOULD be signed; the SIGNATURE then covers both the body and the recipients block (Section 4.2), making the membership and role set tamper-evident. An unsigned multi-recipient message MAY instead carry a SEAL block to supply the sender's pubkey for CEK unwrapping, but in that case the role set is unauthenticated and MUST NOT be relied upon to designate required signatories.
+
+#### 3.6.1 Multi-Recipient Reply
+
+Each encrypted level in a reply chain has its own independent CEK, and therefore its own RECIPIENTS block. The recipients block is **not** inherited from an enclosing or enclosed level. This both is cryptographically required (a single block cannot hand out different per-level CEKs) and records the recipient/role set as it stood at each point in the thread.
+
+```
+----- BEGIN NOSTR HYBRID ENCRYPTED BODY -----
+<reply ciphertext under CEK_reply>
+----- BEGIN NOSTR RECIPIENTS -----
+signer <pubkey-1> <CEK_reply wrapped to pubkey-1>
+signer <pubkey-2> <CEK_reply wrapped to pubkey-2>
+self   <reply-author-pubkey> <CEK_reply wrapped to self>
+----- BEGIN NOSTR HYBRID ENCRYPTED BODY -----
+<original ciphertext under CEK_orig>
+----- BEGIN NOSTR RECIPIENTS -----
+signer <pubkey-1> <CEK_orig wrapped to pubkey-1>
+signer <pubkey-2> <CEK_orig wrapped to pubkey-2>
+self   <original-author-pubkey> <CEK_orig wrapped to self>
+----- BEGIN NOSTR SIGNATURE -----
+@OriginalAuthor
+<original signature (64 bytes)>              ← signs: decode(original) || recipients(original)
+<original author pubkey (32 bytes)>
+----- END NOSTR MESSAGE -----
+----- BEGIN NOSTR SIGNATURE -----
+@ReplyAuthor
+<reply signature (64 bytes)>                 ← signs: level(reply) || level(original)
+<reply author pubkey (32 bytes)>
+----- END NOSTR MESSAGE -----
+```
+
+Single-recipient messages are unaffected and continue to use the pairwise `BEGIN NOSTR NIP-44 ENCRYPTED BODY` format with no RECIPIENTS block (Section 10.5).
+
 ## 4. Composable Signing Model
 
 Signing is user-controlled for NIP-44 messages and can be applied at any stage to the current body bytes. **For NIP-04 messages, signing is mandatory** — encoders MUST produce a SIGNATURE block, and decoders MUST reject NIP-04 messages without one (see Section 4.1).
@@ -222,6 +279,24 @@ The Schnorr signature over `SHA-256(ciphertext_bytes)` serves as the authenticat
 **Decode-time requirement**: Decoders MUST verify the signature **before** attempting NIP-04 decryption. If the signature is missing or invalid, the decoder MUST reject the message without decrypting. This verify-then-decrypt ordering is critical — if decryption errors (including padding errors) are surfaced before signature verification, the padding oracle window remains open.
 
 NIP-44 messages are exempt from this requirement because NIP-44 uses ChaCha20 (no padding) with HMAC-SHA256 authentication built in.
+
+### 4.2 Signature Coverage of the Recipients Block
+
+For multi-recipient messages (Section 3.6), the signature MUST cover the RECIPIENTS block in addition to the body, so that the membership list and per-recipient roles cannot be altered without invalidating the signature. The per-level signing contribution becomes:
+
+```
+level(L) = decode(body_L) || canonical(recipients_L)
+```
+
+where `decode(body_L)` is the level's decoded body bytes (as in Section 4) and `canonical(recipients_L)` is the **canonicalized recipients block**: the lines between `BEGIN NOSTR RECIPIENTS` and the following delimiter, each stripped of trailing whitespace and any `> ` quote prefix, joined with `\n`, with no trailing newline. If a level has no RECIPIENTS block, `canonical(recipients_L)` is the empty string and this reduces to the Section 4 model.
+
+The signing target for a level (and its nested levels) is then:
+
+```
+SHA-256( level(L) || level(L-1) || … || level(1) )
+```
+
+This preserves the flat-concatenation, chain-of-custody property of Section 3.5: tampering with any level's body **or** its recipient/role set invalidates that level's signature and every signature above it.
 
 ## 5. Content Encoding (Glossia)
 
@@ -253,6 +328,7 @@ The following custom MIME headers are included for backwards compatibility and f
 |--------|-------|---------|
 | `X-Nostr-Pubkey` | hex or npub (bech32) pubkey | Sender identification |
 | `X-Nostr-Sig` | hex-encoded signature | Message authentication |
+| `X-Nostr-Agreement` | identifier (optional) | Marks an agreement/signing thread for fast IMAP filtering (Section 11.2); non-authoritative |
 
 Decoders MUST accept both hex-encoded and npub (bech32-encoded, `npub1...`) formats for `X-Nostr-Pubkey`. Encoders MAY produce either format.
 
@@ -331,6 +407,21 @@ Since email clients strip `<style>` tags and external stylesheets, all styling M
 - **Signature heading**: `margin: 0 0 0.5em; color: #666; font-size: 0.9em;`
 - **HR separator**: `border: none; border-top: 1px solid #ccc; margin: 1.5em 0;`
 
+### 6.3 Transport Recipients (To / Cc)
+
+The email `To:` and `Cc:` headers carry the transport recipients. For multi-recipient messages, nostr-mail assigns a default cryptographic role from the header a recipient appears in:
+
+| Header | Default role | Meaning |
+|--------|--------------|---------|
+| `To:` | `signer` | Participant expected to sign (a signatory) |
+| `Cc:` | `viewer` | Participant granted read access but not expected to sign |
+
+Both `To:` and `Cc:` recipients receive a NIP-44-wrapped CEK and can decrypt the body — the distinction is one of **role, not access** (a viewer can read the agreement, just isn't asked to sign it). Encoders MUST include a wrapped-CEK stanza in the RECIPIENTS block for every `To:` and `Cc:` recipient (plus a `self` stanza for the sender).
+
+Because email headers are spoofable and may be rewritten on forward (Section 7), the authoritative role for each recipient is the `role` token inside the signed RECIPIENTS block, **not** the header. The headers are a transport convenience and a mirror for non-Nostr-Mail clients. Where the two disagree, decoders MUST trust the signed RECIPIENTS block.
+
+`Bcc:` recipients, if supported, MUST NOT appear in the RECIPIENTS block of the copy sent to other recipients (doing so would disclose the blind recipient); each Bcc recipient instead receives a separately addressed copy.
+
 ## 7. Identity Model
 
 | Layer | Source | Trust Level |
@@ -347,10 +438,14 @@ Since email clients strip `<style>` tags and external stylesheets, all styling M
 4. **Detect** content encoding: base64 (no spaces) vs Glossia (word patterns)
 5. **Decode** content: base64 decode or Glossia transcode -> bytes
 6. **Unpack** NIP-04 if applicable (bitpacked binary -> `base64?iv=base64`)
-7. **Verify** signatures against `SHA-256(decoded_body_bytes)` using the pubkey from the SIGNATURE block
+7. **Verify** signatures against the per-level signing target using the pubkey from the SIGNATURE block
+   - Single-recipient / plaintext: `SHA-256(decoded_body_bytes)` (Section 4)
+   - Multi-recipient (RECIPIENTS block present): include the canonicalized recipients block per Section 4.2
    - For NIP-04: signature MUST be present and MUST verify. If the signature is missing or invalid, the decoder MUST reject the message **without proceeding to step 8** (see Section 4.1)
-   - For NIP-44: signature verification is recommended but not required (NIP-44 provides its own authentication via HMAC)
-8. **Decrypt** if encrypted, using recipient's private key and sender's pubkey
+   - For NIP-44 / hybrid: signature verification is recommended but not required (NIP-44 and AES-256-GCM provide their own authentication via HMAC / GCM tag)
+8. **Decrypt** if encrypted:
+   - **Pairwise** (`NIP-04`/`NIP-44 ENCRYPTED BODY`, no RECIPIENTS): use the recipient's private key and the sender's pubkey
+   - **Multi-recipient** (`HYBRID ENCRYPTED BODY` + RECIPIENTS): locate the stanza whose pubkey matches the reader's own pubkey, NIP-44-unwrap the CEK using the reader's private key and the sender's pubkey, then AES-256-GCM-decrypt the body with the CEK. If no stanza matches the reader's pubkey, the reader is not a recipient of that level and cannot decrypt it (this is expected for levels predating the reader's addition to the thread — see Section 10.8)
 
 ## 9. Spam Rescue & Folder Handling
 
@@ -386,6 +481,127 @@ There is currently **no dedicated "mark as spam" UI.** A message can only reach 
 - Route it through the same `move_message_to_folder` → spam-folder path so it sets `\Seen`; the per-sync rescue (§9.2) will then automatically respect it as a "leave it" signal with no further changes.
 - Reconsider the on-enable catch-up (§9.3): with a real spam-filing action, the catch-up's `unseen_only = false` would *undo* a deliberate spam-filing. At that point the catch-up should likely honor `\Seen` (keep `unseen_only = true`) so it only sweeps provider-misclassified mail, not user-filed spam.
 
-## 10. Versioning
+## 10. Multi-Recipient Encryption (Group Encryption)
 
-This specification may be extended with additional block types in future versions. Decoders SHOULD ignore unrecognized block types rather than failing.
+NIP-44 is pairwise: a ciphertext encrypted with the shared secret of `(senderPriv, recipientPub)` can only be opened by that one recipient (and the sender). To deliver one message to N recipients, nostr-mail uses **envelope encryption** — the same hybrid construction already used for attachments (random AES-256 key for the payload, NIP-44 to wrap the key), generalized from one recipient to many.
+
+### 10.1 Envelope Scheme
+
+```
+1. Generate a random 256-bit Content Encryption Key (CEK).
+2. Encrypt the body ONCE with AES-256-GCM under the CEK            → one HYBRID ENCRYPTED BODY
+   (attachments are encrypted under the same CEK, as today).
+3. For each pubkey P in { To ∪ Cc ∪ sender-self }:
+       wrapped[P] = NIP44_encrypt(CEK, senderPriv, P)             → one RECIPIENTS stanza per P
+4. Emit: [HYBRID ENCRYPTED BODY] + [RECIPIENTS block] + optional [SIGNATURE]
+```
+
+To read the message, a recipient locates the stanza addressed to their own pubkey, NIP-44-unwraps the CEK with their private key and the sender's pubkey, then AES-256-GCM-decrypts the body. The body ciphertext is produced once regardless of recipient count; only the 32-byte CEK is wrapped per recipient.
+
+The sender's pubkey (needed to unwrap the CEK) is taken from the SIGNATURE block, the SEAL block, or the `X-Nostr-Pubkey` header — a multi-recipient message MUST therefore carry one of these.
+
+### 10.2 RECIPIENTS Block Format
+
+The RECIPIENTS block contains one entry per line. Each entry is exactly three space-separated tokens:
+
+```
+<role> <pubkey> <wrapped-cek>
+```
+
+| Field | Encoding | Notes |
+|-------|----------|-------|
+| `role` | `signer` \| `viewer` \| `self` (lowercase token) | See Section 11.1. Unknown roles MUST be ignored for workflow purposes but still treated as recipients for decryption. |
+| `pubkey` | hex (64 chars) or npub (bech32, `npub1…`) | The recipient's Nostr public key. Glossia is **not** used here, to keep entries single-token and line-parseable. |
+| `wrapped-cek` | base64 (NIP-44 payload) | `NIP44_encrypt(CEK)` to `pubkey`. Glossia is not used here. |
+
+Rules:
+
+- Entries SHOULD be ordered deterministically: `To:` recipients in header order, then `Cc:` recipients in header order, then the `self` stanza last. Deterministic ordering keeps the signed canonical form stable across encoders.
+- Display names are intentionally **omitted**; clients resolve names from the Nostr social registry / profile cache by pubkey.
+- Decoders MUST tolerate additional trailing tokens on a line (forward compatibility) and MUST ignore blank lines and `> ` quote prefixes.
+
+### 10.3 Roles
+
+`signer` and `viewer` are the workflow roles (Section 11). `self` is the sender's own wrap, present so the Sent copy is decryptable on any of the sender's devices — it is neither a signatory nor a viewer and MUST be excluded from signatory-completion accounting.
+
+### 10.4 Self-Stanza
+
+Every multi-recipient message MUST include a `self` stanza wrapping the CEK to the sender's own pubkey (`NIP44_encrypt(CEK, senderPriv, senderPub)`). This mirrors the "wrap twice — once to the recipient, once to yourself" behavior of NIP-17 DMs and is what makes sent agreements readable after a fresh install or on a second device.
+
+### 10.5 Single-Recipient Gating & Backward Compatibility
+
+The envelope format is used **only** when a message has more than one cryptographic recipient (i.e. more than one of `To ∪ Cc`, excluding `self`). A message to a single recipient continues to use the pairwise `BEGIN NOSTR NIP-44 ENCRYPTED BODY` format with no RECIPIENTS block, so existing decoders are unaffected.
+
+- Encoders MUST emit the pairwise format for single-recipient messages and the hybrid format for multi-recipient messages.
+- Decoders MUST select the decryption path by block type: `HYBRID ENCRYPTED BODY` ⇒ envelope path (Section 8 step 8, multi-recipient); `NIP-44`/`NIP-04 ENCRYPTED BODY` ⇒ pairwise path.
+- NIP-04 MUST NOT be used as the body cipher for multi-recipient messages (the body cipher is always AES-256-GCM under the CEK, which is authenticated; see Section 4.1 for why unauthenticated CBC is disallowed).
+
+### 10.6 Signature Coverage
+
+When signed, the signature covers the body **and** the canonicalized RECIPIENTS block, per Section 4.2. This authenticates the membership list and each recipient's role, which is required for the agreement workflow (a `viewer` must not be silently re-labeled a `signer`, nor a signatory removed, without breaking the signature).
+
+### 10.7 Replies: Per-Level Recipients
+
+Each encrypted level in a reply chain is encrypted independently and therefore has its **own CEK and its own RECIPIENTS block** (Section 3.6.1). The recipients block is never inherited across levels — it cannot be, since one block cannot distribute multiple per-level CEKs. The common case (reply-all to the same parties) simply repeats the same membership at each level; the per-recipient overhead is one ~100-byte stanza per recipient per level, which is negligible against the body and preserves the property that every level is independently decryptable and verifiable.
+
+### 10.8 Access-Control Consequences
+
+Because each level is sealed under its own CEK wrapped only to that level's listed recipients:
+
+- A reader can decrypt a level **iff** they hold a stanza in that level's RECIPIENTS block.
+- Adding a participant at reply *k* grants them access to level *k* **and forward only**. They cannot read levels `< k`, because the replier does not hold the earlier CEKs and so cannot re-wrap them. This is a deliberate, desirable property: a party added late cannot be silently back-doored into earlier private deliberations.
+- To intentionally share history with a newly added participant, the replier (who *can* decrypt the levels they received) MAY re-wrap each historical CEK to the new pubkey and add the corresponding stanzas — this MUST be an explicit "include history" action, never automatic.
+- Encoders MUST NOT re-encrypt nested historical bodies under a new CEK, as that would discard the original per-level ciphertext and its independent signature, breaking chain-of-custody verification.
+
+### 10.9 Privacy Considerations
+
+The RECIPIENTS block lists each participant's pubkey in the (cleartext) `text/plain` body, so relays/mail servers that see the message learn the participant set. This is no worse than the `To:`/`Cc:` headers, which already expose the email addresses, but it is strictly less private than NIP-59 gift wrap, which hides recipients behind an ephemeral key. A future version MAY define a metadata-private mode that omits pubkey labels and requires readers to trial-decrypt each stanza (as the `age` format does); this is out of scope for v0.3.
+
+## 11. Recipient Roles & Agreement Workflow
+
+This section defines how multi-recipient messages support DocuSign-style agreements: a document distributed to signatories and viewers, signed in rounds, and independently verifiable from the resulting email thread.
+
+### 11.1 Signatory vs Viewer Semantics
+
+| Role | Can decrypt | Expected to sign | Default header |
+|------|-------------|------------------|----------------|
+| `signer` | Yes | Yes | `To:` |
+| `viewer` | Yes | No | `Cc:` |
+| `self` | Yes (sender) | n/a | — |
+
+The role is a **workflow** attribute, not an access attribute — every role can read the agreement. A client uses the role only to decide whether it expects a signature reply from that participant and to compute completion status.
+
+### 11.2 Agreement (Contract) Message
+
+An agreement is initiated as a signed multi-recipient message:
+
+- **Body**: the agreement cover text / terms, in a signed `HYBRID ENCRYPTED BODY`.
+- **Attachment(s)**: the contract document(s), encrypted under the same CEK (existing hybrid-attachment path).
+- **RECIPIENTS**: a `signer` stanza for each required signatory, a `viewer` stanza for each viewer, and the `self` stanza.
+- **SIGNATURE**: the originator's signature, covering body + recipients (Section 4.2), which fixes the set of required signatories and the exact document bytes.
+
+Clients MAY include an `X-Nostr-Agreement` MIME header (boolean/identifier) to let IMAP filtering surface agreement threads without decrypting bodies. The authoritative agreement state always comes from the signed armor blocks, not the header.
+
+### 11.3 Signing Round
+
+A signatory signs by **replying** to the agreement thread (Section 3.5 / 3.6.1):
+
+- The reply nests the prior message unchanged and adds the signatory's SIGNATURE, which — per Section 4.2 / 3.5.0 — covers `level(reply) || level(prior) || …`, i.e. the signatory's own content plus the full nested history including the original document bytes.
+- A signatory's reply therefore cryptographically binds **their identity to the exact agreement and to every signature already in the thread**, giving an ordered, tamper-evident chain of custody.
+- Reply-all preserves the `signer`/`viewer` roles from the prior level so the membership is carried forward (subject to the access rules of Section 10.8).
+
+### 11.4 Completion & Status
+
+An agreement is **complete** when, for every `signer` pubkey declared in the originating message's RECIPIENTS block, the thread contains a valid SIGNATURE from that pubkey over a level that includes the original document bytes. Clients:
+
+- SHOULD compute "M of N signed" by intersecting the declared signatory set with the set of verified signer pubkeys present in the thread.
+- MAY use the `X-Nostr-Sig` / `X-Nostr-Pubkey` headers (Section 6.1) for a fast, decrypt-free progress estimate, but MUST confirm completion against verified in-body signatures.
+- SHOULD NOT count `viewer` or `self` pubkeys toward completion.
+
+### 11.5 Verification
+
+A completed agreement is verifiable offline and without any nostr-mail or SIGit server: a verifier walks the thread, and for each level checks the SIGNATURE against `SHA-256(level(L) || … || level(1))` (Section 4.2) using the pubkey in the SIGNATURE block. If every required signatory's signature verifies over a level covering the original document bytes, the agreement is valid and attributable to those Nostr identities. Tampering with the document, the recipient/role set, or any prior signature invalidates the affected signature and every signature above it.
+
+## 12. Versioning
+
+This specification may be extended with additional block types in future versions. Decoders SHOULD ignore unrecognized block types rather than failing. Unknown `role` tokens in a RECIPIENTS block (Section 10.2) MUST be treated as recipients for decryption while being ignored for workflow accounting, so that future roles do not break older clients.

--- a/tauri-app/frontend/js/email-service.js
+++ b/tauri-app/frontend/js/email-service.js
@@ -9515,18 +9515,13 @@ ${attachmentsHtml}
             // Always re-render all drafts (simpler approach)
             draftsList.innerHTML = '';
 
-            // Check if we should hide unverified messages
             const settings = appState.getSettings();
-            const hideUnverified = settings && settings.hide_unsigned_messages === true;
 
-            // Process drafts in parallel with timeout protection
+            // Drafts are authored by the current user and are not signed until they
+            // are sent — the hide_unsigned_messages setting protects against
+            // unverified inbound senders and does not apply here. Always show your
+            // own drafts (mirrors the sent-mail rendering path).
             const draftPromises = drafts
-                .filter(draft => {
-                    if (hideUnverified && draft.signature_valid !== true) {
-                        return false;
-                    }
-                    return true;
-                })
                 .map(async (draft) => {
                     try {
                         const timeoutPromise = new Promise((_, reject) =>
@@ -9555,8 +9550,6 @@ ${attachmentsHtml}
                 const hideUndecryptable = settings && settings.hide_undecryptable_emails === true;
                 if (hideUndecryptable && drafts.length > 0) {
                     draftsList.innerHTML = '<div class="text-center text-muted">No decryptable drafts found. All drafts are encrypted for a different keypair.</div>';
-                } else if (hideUnverified && drafts.length > 0) {
-                    draftsList.innerHTML = '<div class="text-center text-muted">No verified drafts found. All drafts have missing or invalid signatures.</div>';
                 } else {
                     draftsList.innerHTML = '<div class="text-center text-muted">No drafts found</div>';
                 }


### PR DESCRIPTION
Adds `FEATURE_TEST_CHECKLIST.md` — a tracking checklist of the features and fixes currently queued to land on `master` (the `staging` delta), each tied to the feature test that guards it, or flagged as **test-owed** when the code has landed but no test covers it yet.

Because this PR is based on `staging`, the diff also carries the queued work itself (`master` → `staging`, 7 commits: the draft rendering fix and the To/Cc / group-encryption / CONSENT spec). The checklist is the lens for reviewing what lands.

## Draft rendering fix (focus)

Drafts are authored by the current user and are **unsigned until sent**, so the inbound-protection settings (`hide_unsigned_messages` / `require_signature`) must never hide them — mirroring the sent-mail render path. The preview must also decode both glossia clear-signed and NIP-44 encrypted bodies.

- Code: `email-service.js` `renderDrafts()` / `renderDraftItem()` (commit `5c8edce`).
- **Owed:** there is currently **no** `draft` test in `email_integration.rs`; the checklist tracks adding one for the encrypted + signed preview paths.

## What the checklist covers

- 🖋️ **Draft rendering** — show self-authored drafts regardless of `hide_unsigned_messages`; decode NIP-44/glossia bodies _(test owed)_
- 🔏 **Signing & verification** — header/inline sig precedence, tamper detection, schema-order decode _(covered)_
- 🔐 **Encryption & replies** — NIP-04 fallback, NIP-44 nested reply chains, glossia roundtrip _(covered)_
- 📎 **Attachments** — manifest compose + inline-sig verify _(covered)_; inbox download for self-authored mail _(manual)_
- 📬 **Sent/inbox decryption** — recipient-header decrypt, multipart, encodings _(covered)_
- 🛡️ **Transport authentication** — forgeable `dmarc=pass` hardening _(in flight, PR #103)_
- 🔄 **IMAP sync / folders / spam** and 💬 **DMs** — _(manual, no automated coverage yet)_
- 👥 **Group / multi-recipient** — spec only, future work, tracked so it isn't lost

Legend in the doc: `[x]` = code landed **and** covered by a feature test; `[ ]` = landed but test still owed before it's safe to land.

## Test commands

```bash
cd tauri-app/backend && cargo test --test email_integration   # what CI runs
cd tauri-app/backend && cargo test --lib
```

https://claude.ai/code/session_01G8qsd2rk22GHN3RNspKTAD

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8qsd2rk22GHN3RNspKTAD)_